### PR TITLE
add pkg-config dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Then proceed to follow the build instructions below.
 On recent Ubuntu versions, simply install all prerequisites as follows:
 
 ```
-# apt-get install build-essential autoconf automake libpcre3-dev libevent-dev
+# apt-get install build-essential autoconf automake libpcre3-dev libevent-dev pkg-config
 ```
 
 


### PR DESCRIPTION
Otherwise, `./configure` fails when the PKG_CHECK_MODULES macro is referenced.
