### PR TITLE
save_csv does not report proper latency distribution

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1198,23 +1198,19 @@ bool run_stats::save_csv(const char *filename)
 
 
     double total_count_float = 0;
-    int i=0;
     fprintf(f, "\n" "Full-Test GET Latency\n");
     fprintf(f, "Latency (<= msec),Percent\n");
     for ( latency_map_itr it = m_get_latency_map.begin() ; it != m_get_latency_map.end() ; it++ ) {
         total_count_float += it->second;
-        fprintf(f, "%u,%.2f\n", i, total_count_float / total_get_ops * 100);
-        i++;
+        fprintf(f, "%8.3f,%.2f\n", it->first, total_count_float / total_get_ops * 100);
     }
     total_count_float = 0;
-    i=0;
     fprintf(f, "\n" "Full-Test SET Latency\n");
     fprintf(f, "Latency (<= msec),Percent\n");
 
     for ( latency_map_itr it = m_set_latency_map.begin(); it != m_set_latency_map.end() ; it++ ) {
         total_count_float += it->second;
-        fprintf(f, "%u,%.2f\n", i, total_count_float / total_set_ops * 100);
-        i++;
+        fprintf(f, "%8.3f,%.2f\n", it->first, total_count_float / total_set_ops * 100);
     }
 
     fclose(f);

--- a/client.cpp
+++ b/client.cpp
@@ -1212,7 +1212,7 @@ bool run_stats::save_csv(const char *filename)
 
     for ( latency_map_itr it = m_set_latency_map.begin(); it != m_set_latency_map.end() ; it++ ) {
         total_count_float += it->second;
-        fprintf(f, "%u,%.2f\n", i, total_count_float / total_get_ops * 100);
+        fprintf(f, "%u,%.2f\n", i, total_count_float / total_set_ops * 100);
         i++;
     }
 

--- a/client.cpp
+++ b/client.cpp
@@ -1206,6 +1206,7 @@ bool run_stats::save_csv(const char *filename)
         fprintf(f, "%u,%.2f\n", i, total_count_float / total_get_ops * 100);
         i++;
     }
+    total_count_float = 0;
     i=0;
     fprintf(f, "\n" "Full-Test SET Latency\n");
     fprintf(f, "Latency (<= msec),Percent\n");


### PR DESCRIPTION
when running memtier_benchmark along with --client-stats the printed latency distributions are not actual latencies. Moreover, SET ops percentage are false ( greater than 100% and calculated using total_get_ops). 