### PR TITLE
add support for JSON output

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+* Version 1.2.9 
+    * Add JSON output support: add thin json handling class that could be overridden for extensive uses
+    * Add --json-out-file: Name of JSON output file, if not set, will not print to json
+    * Refactor some code duplications in the prints sections
+    * Change license to 2017
+
 * Version 1.2.8
     * Optimization of gettimeofday() and latency calculations
     * WAIT command support

--- a/JSON_handler.cpp
+++ b/JSON_handler.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
+ *
+ * This file is part of memtier_benchmark.
+ *
+ * memtier_benchmark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * memtier_benchmark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with memtier_benchmark.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "JSON_handler.h"
+
+
+/**
+ * C'tor
+ * -----
+ * Opens the file named jsonfilename and sets the first nesting as NESTED_GENERAL
+ * In case of failure to create the file, will state the error perror
+ */
+json_handler::json_handler(const char * jsonfilename) : m_json_file(NULL)
+{
+    // Try to open a file and add the first level
+    m_json_file = fopen(jsonfilename, "w");
+    if (!m_json_file) {
+        perror(jsonfilename);
+    }                  
+    // opening the JSON
+    fprintf(stderr, "Json file %s created...\n", jsonfilename);
+    fprintf(m_json_file,"{"); 
+    m_nest_closer_types.push_back(NESTED_GENERAL);
+    beutify();    
+}
+
+/**
+ * D'tor
+ * -----
+ * Closes all the nesting and the file pointer.
+ */
+json_handler::~json_handler()
+{
+    if (m_json_file){
+        // close nesting...
+        while (close_nesting());
+        fclose(m_json_file);
+        fprintf(stderr, "Json file closed.\n");
+    }
+}
+
+/** 
+ * Write singel object named objectname to the JSON with values stated in ...
+ * based on the format defined
+ * basically uses fprintf with the same parameters.
+ */
+void json_handler::write_obj(const char * objectname, const char * format, ...)
+{
+    fprintf(m_json_file, "\"%s\": ", objectname);
+    va_list argptr;
+    va_start(argptr, format);
+    vfprintf(m_json_file, format, argptr);
+    va_end(argptr);
+    beutify();
+    fprintf(m_json_file, ",");
+}
+
+/** 
+ * Starts a nesting with a title as defined in objectname
+ * in case objectname == NULL it will not add the title and just start nesting
+ * The type defines the kind of charecters that will be used
+ */
+void json_handler::open_nesting(const char * objectname,eJSON_NESTED_TYPE type /*= NESTED_GENERAL*/)
+{
+    const char * nestStart = (type == NESTED_GENERAL) ? "{" : "[";
+    if (objectname != NULL){
+        fprintf(m_json_file, "\"%s\":", objectname);
+    }
+    fprintf(m_json_file, "%s", nestStart);
+    // Adding the type to the nesting closer list to be able to close it properly
+    m_nest_closer_types.push_back(type);
+    beutify(false);
+}
+
+/** 
+ * Ends the nesting
+ * Closes the nesting based on the nesting list 
+ * Returns = the nested levels left after the closing
+ */
+int json_handler::close_nesting()
+{
+    int nest_level = m_nest_closer_types.size();
+    if (nest_level > 0)
+    {
+        eJSON_NESTED_TYPE type = m_nest_closer_types.back();
+        m_nest_closer_types.pop_back();
+        // as we assume that the last value is always a ',' or '\n' we need to remove it first
+        fseek(m_json_file, -1, SEEK_CUR);
+        const char * nestEnd = (type == NESTED_GENERAL) ? "}" : "]";
+        fprintf(m_json_file, "%s", nestEnd);
+        beutify();
+        if (nest_level > 1)
+        {
+            fprintf(m_json_file, ",");
+        }
+    }
+    return m_nest_closer_types.size();
+}
+
+/** 
+ * Add tabls and new line (if only_tabs==true will only add tabs)
+ */
+void json_handler::beutify(bool only_tabs)
+{
+    if (only_tabs == false)
+    {
+        fprintf(m_json_file, "\n");
+    }
+    int nest_level = m_nest_closer_types.size();
+    for(;nest_level>0;nest_level--)
+    {
+        fprintf(m_json_file, "\t");
+    }
+    
+}

--- a/JSON_handler.h
+++ b/JSON_handler.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
+ *
+ * This file is part of memtier_benchmark.
+ *
+ * memtier_benchmark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * memtier_benchmark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with memtier_benchmark.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _JSON_HANDLER_H
+#define _JSON_HANDLER_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <list>
+
+// enum for holding type of nesting
+typedef enum{
+    NESTED_GENERAL, // {}
+    NESTED_ARRAY    // []
+}eJSON_NESTED_TYPE;
+
+/** represents an JSON handler, At this phase, only writes to JSON. */ 
+class json_handler {
+protected:
+    FILE * m_json_file; 
+    // This list is used later for closing the nesting
+    std::list<eJSON_NESTED_TYPE>    m_nest_closer_types;
+    void beutify(bool only_tabs = false);
+public:
+    json_handler(const char * jsonfilename);
+    ~json_handler();
+    
+    // Write a single object to JSON
+    void write_obj(const char * objectname, const char * format, ...);
+
+    // Starts nesting, the type is used for deciding which charecter to be used for opening and closing 
+    // the nesting ('{}','[]')
+    void open_nesting(const char * objectname,eJSON_NESTED_TYPE type = NESTED_GENERAL);
+    
+    // returns the nested level left after closing
+    int close_nesting();
+};
+
+#endif /* _JSON_HANDLER_H */

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 # Makefile for memtier_benchmark
-# Copyright (C) 2011-2016 Redis Labs Ltd.
+# Copyright (C) 2011-2017 Redis Labs Ltd.
 
 # This file is part of memtier_benchmark.
 
@@ -25,6 +25,7 @@ memtier_benchmark_CPPFLAGS = $(LIBEVENT_CFLAGS)
 memtier_benchmark_SOURCES = \
 	memtier_benchmark.cpp memtier_benchmark.h \
 	client.cpp client.h \
+	JSON_handler.cpp JSON_handler.h \
 	protocol.cpp protocol.h \
 	obj_gen.cpp obj_gen.h \
 	item.cpp item.h \

--- a/client.h
+++ b/client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *
@@ -32,6 +32,7 @@
 #include <event2/buffer.h>
 
 #include "protocol.h"
+#include "JSON_handler.h"
 
 class client;               // forward decl
 class client_group;         // forward decl
@@ -121,7 +122,7 @@ public:
     void merge(const run_stats& other, int iteration);
     bool save_csv(const char *filename);
     void debug_dump(void);
-    void print(FILE *file, bool histogram);
+    void print(FILE *file, bool histogram, const char* header = NULL, json_handler* jsonhandler = NULL);
     
     unsigned int get_duration(void);
     unsigned long int get_duration_usec(void);

--- a/config_types.cpp
+++ b/config_types.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/config_types.h
+++ b/config_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl configure.ac for memtier_benchmark
-dnl Copyright (C) 2011-2016 Redis Labs Ltd.
+dnl Copyright (C) 2011-2017 Redis Labs Ltd.
 
 dnl This file is part of memtier_benchmark.
 

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/file_io.h
+++ b/file_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/item.cpp
+++ b/item.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/item.h
+++ b/item.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *
@@ -36,8 +36,10 @@
 #include <stdexcept>
 
 #include "client.h"
+#include "JSON_handler.h"
 #include "obj_gen.h"
 #include "memtier_benchmark.h"
+
 
 static int log_level = 0;
 void benchmark_log_file_line(int level, const char *filename, unsigned int line, const char *fmt, ...)
@@ -112,13 +114,14 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
         "no-expiry = %s\n"
         "wait-ratio = %u:%u\n"
         "num-slaves = %u-%u\n"
-        "wait-timeout = %u-%u\n",
+        "wait-timeout = %u-%u\n"
+        "json-out-file = %s\n",
         cfg->server,
         cfg->port,
         cfg->unix_socket,
         cfg->protocol,
         cfg->out_file,
-        cfg->client_stats,
+        cfg->client_stats,	
         cfg->run_count,
         cfg->debug,
         cfg->requests,
@@ -151,7 +154,57 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
         cfg->no_expiry ? "yes" : "no",
         cfg->wait_ratio.a, cfg->wait_ratio.b,
         cfg->num_slaves.min, cfg->num_slaves.max,
-        cfg->wait_timeout.min, cfg->wait_timeout.max);
+        cfg->wait_timeout.min, cfg->wait_timeout.max,
+        cfg->json_out_file);
+}
+
+static void config_print_to_json(json_handler * jsonhandler, struct benchmark_config *cfg)
+{
+    char tmpbuf[512];
+    
+    jsonhandler->open_nesting("configuration");  
+	
+    jsonhandler->write_obj("server"            ,"\"%s\"",      	cfg->server);
+    jsonhandler->write_obj("port"              ,"%u",          	cfg->port);
+    jsonhandler->write_obj("unix socket"       ,"\"%s\"",      	cfg->unix_socket);
+    jsonhandler->write_obj("protocol"          ,"\"%s\"",      	cfg->protocol);
+    jsonhandler->write_obj("out_file"          ,"\"%s\"",      	cfg->out_file);
+    jsonhandler->write_obj("client_stats"      ,"\"%s\"",      	cfg->client_stats);
+    jsonhandler->write_obj("run_count"         ,"%u",          	cfg->run_count);
+    jsonhandler->write_obj("debug"             ,"%u",          	cfg->debug);
+    jsonhandler->write_obj("requests"          ,"%u",          	cfg->requests);
+    jsonhandler->write_obj("clients"           ,"%u",          	cfg->clients);
+    jsonhandler->write_obj("threads"           ,"%u",          	cfg->threads);
+    jsonhandler->write_obj("test_time"         ,"%u",          	cfg->test_time);
+    jsonhandler->write_obj("ratio"             ,"\"%u:%u\"",   	cfg->ratio.a, cfg->ratio.b);
+    jsonhandler->write_obj("pipeline"          ,"%u",          	cfg->pipeline);
+    jsonhandler->write_obj("data_size"         ,"%u",          	cfg->data_size);
+    jsonhandler->write_obj("data_offset"       ,"%u",          	cfg->data_offset);
+    jsonhandler->write_obj("random_data"       ,"\"%s\"",      	cfg->random_data ? "true" : "false");
+    jsonhandler->write_obj("data_size_range"   ,"\"%u:%u\"",	cfg->data_size_range.min, cfg->data_size_range.max);
+    jsonhandler->write_obj("data_size_list"    ,"\"%s\"",   	cfg->data_size_list.print(tmpbuf, sizeof(tmpbuf)-1));
+    jsonhandler->write_obj("data_size_pattern" ,"\"%s\"", 		cfg->data_size_pattern);
+    jsonhandler->write_obj("expiry_range"      ,"\"%u:%u\"",   	cfg->expiry_range.min, cfg->expiry_range.max);
+    jsonhandler->write_obj("data_import"       ,"\"%s\"",       cfg->data_import);
+    jsonhandler->write_obj("data_verify"       ,"\"%s\"",       cfg->data_verify ? "true" : "false");
+    jsonhandler->write_obj("verify_only"       ,"\"%s\"",       cfg->verify_only ? "true" : "false");
+    jsonhandler->write_obj("generate_keys"     ,"\"%s\"",     	cfg->generate_keys ? "true" : "false");
+    jsonhandler->write_obj("key_prefix"        ,"\"%s\"",       cfg->key_prefix);
+    jsonhandler->write_obj("key_minimum"       ,"%11u",        	cfg->key_minimum);
+    jsonhandler->write_obj("key_maximum"       ,"%11u",        	cfg->key_maximum);
+    jsonhandler->write_obj("key_pattern"       ,"\"%s\"",       cfg->key_pattern);
+    jsonhandler->write_obj("key_stddev"        ,"%f",           cfg->key_stddev);
+    jsonhandler->write_obj("key_median"        ,"%f",           cfg->key_median);
+    jsonhandler->write_obj("reconnect_interval","%u",    		cfg->reconnect_interval);
+    jsonhandler->write_obj("multi_key_get"     ,"%u",         	cfg->multi_key_get);
+    jsonhandler->write_obj("authenticate"      ,"\"%s\"",      	cfg->authenticate ? cfg->authenticate : "");
+    jsonhandler->write_obj("select-db"         ,"%d",           cfg->select_db);
+    jsonhandler->write_obj("no-expiry"         ,"\"%s\"",       cfg->no_expiry ? "true" : "false");
+    jsonhandler->write_obj("wait-ratio"        ,"\"%u:%u\"",    cfg->wait_ratio.a, cfg->wait_ratio.b);
+    jsonhandler->write_obj("num-slaves"        ,"\"%u:%u\"",    cfg->num_slaves.min, cfg->num_slaves.max);
+    jsonhandler->write_obj("wait-timeout"      ,"\"%u-%u\"",   	cfg->wait_timeout.min, cfg->wait_timeout.max);
+
+	jsonhandler->close_nesting();
 }
 
 static void config_init_defaults(struct benchmark_config *cfg)
@@ -240,7 +293,8 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_no_expiry,
         o_wait_ratio,
         o_num_slaves,
-        o_wait_timeout
+        o_wait_timeout, 
+        o_json_out_file
     };
     
     static struct option long_options[] = {
@@ -287,6 +341,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         { "wait-ratio",                 1, 0, o_wait_ratio },
         { "num-slaves",                 1, 0, o_num_slaves },
         { "wait-timeout",               1, 0, o_wait_timeout },
+        { "json-out-file",              1, 0, o_json_out_file },
         { "help",                       0, 0, 'h' },
         { "version",                    0, 0, 'v' },
         { NULL,                         0, 0, 0 }
@@ -305,7 +360,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                 case 'v':
                     puts(PACKAGE_STRING);
                 // FIXME!!
-                    puts("Copyright (C) 2011-2016 Redis Labs Ltd.");
+                    puts("Copyright (C) 2011-2017 Redis Labs Ltd.");
                     puts("This is free software.  You may redistribute copies of it under the terms of");
                     puts("the GNU General Public License <http://www.gnu.org/licenses/gpl.html>.");
                     puts("There is NO WARRANTY, to the extent permitted by law.");
@@ -577,6 +632,9 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                         return -1;
                     }
                     break;
+                case o_json_out_file:
+                    cfg->json_out_file = optarg;
+                    break;
             default:
                     return -1;
                     break;
@@ -601,6 +659,7 @@ void usage() {
             "  -D, --debug                    Print debug output\n"
             "      --client-stats=FILE        Produce per-client stats file\n"
             "      --out-file=FILE            Name of output file (default: stdout)\n"
+            "      --json-out-file=FILE       Name of JSON output file, if not set, will not print to json\n"
             "      --show-config              Print detailed configuration before running\n"
             "      --hide-histogram           Don't print detailed latency histogram\n"
             "      --help                     Display this help\n"
@@ -883,6 +942,14 @@ int main(int argc, char *argv[])
         config_print(stdout, &cfg);
         fprintf(stderr, "===================================================\n");
     }
+    //
+    // JSON file initiation
+    json_handler *jsonhandler = NULL;
+    if (cfg.json_out_file != NULL){
+        jsonhandler = new json_handler((const char *)cfg.json_out_file);
+        // We allways print the configuration to the JSON file      
+        config_print_to_json(jsonhandler,&cfg);
+    }
 
     struct rlimit rlim;
     if (getrlimit(RLIMIT_NOFILE, &rlim) != 0) {
@@ -1037,7 +1104,7 @@ int main(int argc, char *argv[])
         if (cfg.key_pattern[0]!='G' && cfg.key_pattern[2]!='G') {
             fprintf(stderr, "error: key-stddev and key-median are only allowed together with key-pattern set to G.\n");
             usage();
-        }
+        }   
         if (cfg.key_median!=0 && (cfg.key_median<cfg.key_minimum || cfg.key_median>cfg.key_maximum)) {
             fprintf(stderr, "error: key-median must be between key-minimum and key-maximum.\n");
             usage();
@@ -1050,7 +1117,6 @@ int main(int argc, char *argv[])
     FILE *outfile;
     if (cfg.out_file != NULL) {
         fprintf(stderr, "Writing results to %s...\n", cfg.out_file);
-        
         outfile = fopen(cfg.out_file, "w");
         if (!outfile) {
             perror(cfg.out_file);
@@ -1066,11 +1132,10 @@ int main(int argc, char *argv[])
                 sleep(1);   // let connections settle
             
             run_stats stats = run_benchmark(run_id, &cfg, obj_gen);
-
             all_stats.push_back(stats);
         }
-        
-        // Print some run information
+        //
+        // Print some run information        
         fprintf(outfile,
                "%-9u Threads\n"
                "%-9u Connections per thread\n"
@@ -1078,6 +1143,14 @@ int main(int argc, char *argv[])
                cfg.threads, cfg.clients, 
                cfg.requests > 0 ? cfg.requests : cfg.test_time,
                cfg.requests > 0 ? "Requests per thread"  : "Seconds");
+        if (jsonhandler != NULL){
+            jsonhandler->open_nesting("run information");
+            jsonhandler->write_obj("Threads","%u",cfg.threads);
+            jsonhandler->write_obj("Connections per thread","%u",cfg.clients);
+            jsonhandler->write_obj(cfg.requests > 0 ? "Requests per thread"  : "Seconds","%u",
+                                   cfg.requests > 0 ? cfg.requests : cfg.test_time);
+            jsonhandler->close_nesting();
+        }
 
         // If more than 1 run was used, compute best, worst and average
         if (cfg.run_count > 1) {
@@ -1098,26 +1171,18 @@ int main(int argc, char *argv[])
                 }
             }
 
-
-            fprintf(outfile, "\n\n"
-                             "BEST RUN RESULTS\n"
-                             "========================================================================\n");        
-            best->print(outfile, !cfg.hide_histogram);
-
-            fprintf(outfile, "\n\n"
-                             "WORST RUN RESULTS\n"
-                             "========================================================================\n");        
-            worst->print(outfile, !cfg.hide_histogram);
-
-            fprintf(outfile, "\n\n"
-                             "AGGREGATED AVERAGE RESULTS (%u runs)\n"
-                             "========================================================================\n", cfg.run_count);
-
+            // Best results:
+            best->print(outfile, !cfg.hide_histogram, "BEST RUN RESULTS", jsonhandler);
+            // worst results:
+            worst->print(outfile, !cfg.hide_histogram, "WORST RUN RESULTS", jsonhandler);
+            // average results:
             run_stats average;
             average.aggregate_average(all_stats);
-            average.print(outfile, !cfg.hide_histogram);
+            char average_header[50];
+            sprintf(average_header,"AGGREGATED AVERAGE RESULTS (%u runs)", cfg.run_count);
+            average.print(outfile, !cfg.hide_histogram, average_header, jsonhandler);
         } else {
-            all_stats.begin()->print(outfile, !cfg.hide_histogram);
+            all_stats.begin()->print(outfile, !cfg.hide_histogram, "ALL STATS", jsonhandler);
         }
     }
 
@@ -1138,6 +1203,13 @@ int main(int argc, char *argv[])
                         "%-10llu keys failed.\n",
                         client->get_verified_keys(),
                         client->get_errors());
+        
+        if (jsonhandler != NULL){
+            jsonhandler->open_nesting("client verifications results");
+            jsonhandler->write_obj("keys verified successfuly", "%-10llu",  client->get_verified_keys());
+            jsonhandler->write_obj("keys failed", "%-10llu",  client->get_errors());
+            jsonhandler->close_nesting();
+        }
 
         // Clean up...
         delete client;
@@ -1147,6 +1219,11 @@ int main(int argc, char *argv[])
 
     if (outfile != stdout) {
         fclose(outfile);
+    }
+
+    if (jsonhandler != NULL) {
+        // closing the JSON
+        delete jsonhandler;
     }
 
     delete obj_gen;

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *
@@ -79,6 +79,8 @@ struct benchmark_config {
     config_ratio wait_ratio;
     config_range num_slaves;
     config_range wait_timeout;
+    // JSON additions
+    const char *json_out_file;
 };
 
 

--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/obj_gen.h
+++ b/obj_gen.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *

--- a/protocol.h
+++ b/protocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2016 Redis Labs Ltd.
+ * Copyright (C) 2011-2017 Redis Labs Ltd.
  *
  * This file is part of memtier_benchmark.
  *


### PR DESCRIPTION
* Add JSON output support: add thin json handling class that could be
overridden for extensive uses
* Add --json-out-file: Name of JSON output file, if not set, will not
print to json
* Refactor some code duplications in the prints sections
* Change license to 2017