### PR TITLE
Fix missing closing of JSON nesting for results printing

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1593,6 +1593,10 @@ void run_stats::print(FILE *out, bool histogram, const char * header/*=NULL*/,  
         }
         if (jsonhandler != NULL){ jsonhandler->close_nesting();}
     }
+    // This close_nesting closes either:
+    //      jsonhandler->open_nesting(header); or
+    //      jsonhandler->open_nesting("UNKNOWN STATS");
+    //      From the top (beginning of function). 
     if (jsonhandler != NULL){ jsonhandler->close_nesting();}
 }
 

--- a/client.cpp
+++ b/client.cpp
@@ -1593,5 +1593,6 @@ void run_stats::print(FILE *out, bool histogram, const char * header/*=NULL*/,  
         }
         if (jsonhandler != NULL){ jsonhandler->close_nesting();}
     }
+    if (jsonhandler != NULL){ jsonhandler->close_nesting();}
 }
 


### PR DESCRIPTION
Added if (jsonhandler != NULL){ jsonhandler->close_nesting();} for making sure that Best, Worst and Average results will be brothers in the JSON