### PR TITLE
Update memtier_benchmark.cpp

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -575,7 +575,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                     if (strlen(cfg->key_pattern) != 3 || cfg->key_pattern[1] != ':' ||
                         (cfg->key_pattern[0] != 'R' && cfg->key_pattern[0] != 'S' && cfg->key_pattern[0] != 'G' && cfg->key_pattern[0] != 'P') ||
                         (cfg->key_pattern[2] != 'R' && cfg->key_pattern[2] != 'S' && cfg->key_pattern[2] != 'G' && cfg->key_pattern[2] != 'P')) {
-                            fprintf(stderr, "error: key-pattern must be in the format of [S/R/G]:[S/R/G].\n");
+                            fprintf(stderr, "error: key-pattern must be in the format of [S/R/G/P]:[S/R/G/P].\n");
                             return -1;
                     }
                     break;

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1141,12 +1141,12 @@ int main(int argc, char *argv[])
                "%-9u %s\n",
                cfg.threads, cfg.clients, 
                cfg.requests > 0 ? cfg.requests : cfg.test_time,
-               cfg.requests > 0 ? "Requests per thread"  : "Seconds");
+               cfg.requests > 0 ? "Requests per client"  : "Seconds");
         if (jsonhandler != NULL){
             jsonhandler->open_nesting("run information");
             jsonhandler->write_obj("Threads","%u",cfg.threads);
             jsonhandler->write_obj("Connections per thread","%u",cfg.clients);
-            jsonhandler->write_obj(cfg.requests > 0 ? "Requests per thread"  : "Seconds","%u",
+            jsonhandler->write_obj(cfg.requests > 0 ? "Requests per client"  : "Seconds","%u",
                                    cfg.requests > 0 ? cfg.requests : cfg.test_time);
             jsonhandler->close_nesting();
         }


### PR DESCRIPTION
Inconsistent labeling of 'requests' field.  Docs, behavior & code indicate that 'requests' is per client, not per thread.