### PR TITLE
fix unix socket connection

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -274,6 +274,9 @@ static bool verify_cluster_option(struct benchmark_config *cfg) {
     } else if (cfg->protocol && strcmp(cfg->protocol, "redis")) {
         fprintf(stderr, "error: cluster mode supported only in redis protocol.\n");
         return false;
+    } else if (cfg->unix_socket) {
+        fprintf(stderr, "error: cluster mode dose not support unix-socket option.\n");
+        return false;
     }
 
     return true;

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -104,7 +104,8 @@ verify_request::~verify_request(void)
 
 shard_connection::shard_connection(unsigned int id, connections_manager* conns_man, benchmark_config* config,
                                    struct event_base* event_base, abstract_protocol* abs_protocol) :
-        m_sockfd(-1), m_unix_sockaddr(NULL), m_event(NULL), m_pending_resp(0), m_connected(false),
+        m_sockfd(-1), m_address(NULL), m_port(NULL), m_unix_sockaddr(NULL),
+        m_event(NULL), m_pending_resp(0), m_connected(false),
         m_authentication(auth_done), m_db_selection(select_done), m_cluster_slots(slots_done) {
     m_id = id;
     m_conns_manager = conns_man;


### PR DESCRIPTION
1. reslove address only when using server/port option and not unix-socket
2. disable runing cluster-mode with unix-socket, since even when using
unix-socket option in redis-server, the CLUSTER SLOTS command
return the local address and default port (6379) and not the unix domain socket.