### PR TITLE
Fix segfault when passing -S | --unix-socket (#49)

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -196,7 +196,7 @@ int client::connect(void)
     assert(sc != NULL);
 
     // get address information
-    if (m_config->server_addr->get_connect_info(&addr) != 0) {
+    if (m_config->server_addr && m_config->server_addr->get_connect_info(&addr) != 0) {
         benchmark_error_log("connect: resolve error: %s\n", m_config->server_addr->get_last_error());
         return -1;
     }


### PR DESCRIPTION
Don't try to dereference when server_addr is NULL.

Signed-off-by: Reto Achermann <rachermann@vmware.com>