### PR TITLE
fix sequential key pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,20 @@ On recent Ubuntu versions, simply install all prerequisites as follows:
 
 ### Cluster mode
 
+#### Connections:
+
+When using the cluster-mode option, each client open connections as the number of nodes, so when
+using large number of threads and clients, user need to verify that he's not limited
+by max number of file discriptors.
+
+#### Using sequential key pattern:
+
 In case where there is some asymmetry between the redis nodes, and user set
-the number of total requests with sequential key pattern options, it might be
-gaps in the generated keys.
+the --requests option, it might be gaps in the generated keys.
+
+Also, the ratio and the key generator is per client (and not connection),
+which mean that setting the ratio to 1:1 not guarantee 100% hits, since
+the keys spreads to different connections/shards.
 
 
 ### Building and installing

--- a/README.md
+++ b/README.md
@@ -76,20 +76,20 @@ On recent Ubuntu versions, simply install all prerequisites as follows:
 
 ### Cluster mode
 
-#### Connections:
+#### Connections
 
-When using the cluster-mode option, each client open connections as the number of nodes, so when
-using large number of threads and clients, user need to verify that he's not limited
-by max number of file discriptors.
+When using the cluster-mode option, each client opens one connection for each node.
+So, when using a large number of threads and clients, the user must verify that he is not
+limited by the maximum number of file descriptors.
 
-#### Using sequential key pattern:
+#### Using sequential key pattern
 
-In case where there is some asymmetry between the redis nodes, and user set
-the --requests option, it might be gaps in the generated keys.
+When there is an asymmetry between the Redis nodes and user set
+the --requests option, there may be gaps in the generated keys.
 
-Also, the ratio and the key generator is per client (and not connection),
-which mean that setting the ratio to 1:1 not guarantee 100% hits, since
-the keys spreads to different connections/shards.
+Also, the ratio and the key generator is per client (and not connection).
+In this case, setting the ratio to 1:1 does not guarantee 100% hits because
+the keys spread to different connections/nodes.
 
 
 ### Building and installing

--- a/client.cpp
+++ b/client.cpp
@@ -99,7 +99,7 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
     else if (config->distinct_client_seed)
         m_obj_gen->set_random_seed(config->next_client_idx);
 
-    if (config->key_pattern[0]=='P') {
+    if (config->key_pattern[key_pattern_set]=='P') {
         unsigned long long range = (config->key_maximum - config->key_minimum)/(config->clients*config->threads) + 1;
         unsigned long long min = config->key_minimum + range*config->next_client_idx;
         unsigned long long max = min+range;

--- a/client.h
+++ b/client.h
@@ -276,11 +276,16 @@ public:
     // Utility function to get the object iterator type based on the config
     inline int obj_iter_type(benchmark_config *cfg, unsigned char index)
     {
-        if (cfg->key_pattern[index] == 'R')
+        if (cfg->key_pattern[index] == 'R') {
             return OBJECT_GENERATOR_KEY_RANDOM;
-        else if (cfg->key_pattern[index] == 'G')
+        } else if (cfg->key_pattern[index] == 'G') {
             return OBJECT_GENERATOR_KEY_GAUSSIAN;
-        return OBJECT_GENERATOR_KEY_SET_ITER;
+        } else {
+            if (index == key_pattern_set)
+                return OBJECT_GENERATOR_KEY_SET_ITER;
+            else
+                return OBJECT_GENERATOR_KEY_GET_ITER;
+        }
     }
 };
 

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -595,9 +595,15 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                     break;
                 case o_key_pattern:
                     cfg->key_pattern = optarg;
-                    if (strlen(cfg->key_pattern) != 3 || cfg->key_pattern[1] != ':' ||
-                        (cfg->key_pattern[0] != 'R' && cfg->key_pattern[0] != 'S' && cfg->key_pattern[0] != 'G' && cfg->key_pattern[0] != 'P') ||
-                        (cfg->key_pattern[2] != 'R' && cfg->key_pattern[2] != 'S' && cfg->key_pattern[2] != 'G' && cfg->key_pattern[2] != 'P')) {
+                    if (strlen(cfg->key_pattern) != 3 || cfg->key_pattern[key_pattern_delimiter] != ':' ||
+                        (cfg->key_pattern[key_pattern_set] != 'R' &&
+                         cfg->key_pattern[key_pattern_set] != 'S' &&
+                         cfg->key_pattern[key_pattern_set] != 'G' &&
+                         cfg->key_pattern[key_pattern_set] != 'P') ||
+                        (cfg->key_pattern[key_pattern_get] != 'R' &&
+                         cfg->key_pattern[key_pattern_get] != 'S' &&
+                         cfg->key_pattern[key_pattern_get] != 'G' &&
+                         cfg->key_pattern[key_pattern_get] != 'P')) {
                             fprintf(stderr, "error: key-pattern must be in the format of [S/R/G]:[S/R/G].\n");
                             return -1;
                     }
@@ -1130,7 +1136,7 @@ int main(int argc, char *argv[])
         obj_gen->set_key_range(cfg.key_minimum, cfg.key_maximum);
     }
     if (cfg.key_stddev>0 || cfg.key_median>0) {
-        if (cfg.key_pattern[0]!='G' && cfg.key_pattern[2]!='G') {
+        if (cfg.key_pattern[key_pattern_set]!='G' && cfg.key_pattern[key_pattern_get]!='G') {
             fprintf(stderr, "error: key-stddev and key-median are only allowed together with key-pattern set to G.\n");
             usage();
         }   

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -31,6 +31,12 @@
 #define benchmark_error_log(...) \
     benchmark_log(LOGLEVEL_ERROR, __VA_ARGS__)
 
+enum key_pattern_index {
+    key_pattern_set       = 0,
+    key_pattern_delimiter = 1,
+    key_pattern_get       = 2
+};
+
 struct benchmark_config {
     const char *server;
     unsigned short port;


### PR DESCRIPTION
fix obj_iter_type() to return the appropriate
iterator for the set/get command, when using sequential pattern