### PR TITLE
fix full-test iterations

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -117,7 +117,8 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
 
 client::client(client_group* group) :
         m_event_base(NULL), m_initialized(false), m_end_set(false), m_config(NULL),
-        m_obj_gen(NULL), m_reqs_processed(0), m_set_ratio_count(0), m_get_ratio_count(0),
+        m_obj_gen(NULL), m_reqs_processed(0), m_reqs_generated(0),
+        m_set_ratio_count(0), m_get_ratio_count(0),
         m_tot_set_ops(0), m_tot_wait_ops(0)
 {
     m_event_base = group->get_event_base();
@@ -133,8 +134,9 @@ client::client(client_group* group) :
 client::client(struct event_base *event_base, benchmark_config *config,
                abstract_protocol *protocol, object_generator *obj_gen) :
         m_event_base(NULL), m_initialized(false), m_end_set(false), m_config(NULL),
-        m_obj_gen(NULL), m_reqs_processed(0), m_set_ratio_count(0), m_get_ratio_count(0),
-        m_tot_set_ops(0), m_tot_wait_ops(0)
+        m_obj_gen(NULL), m_reqs_processed(0), m_reqs_generated(0),
+        m_set_ratio_count(0), m_get_ratio_count(0),
+        m_tot_set_ops(0), m_tot_wait_ops(0), m_keylist(NULL)
 {
     m_event_base = event_base;
 


### PR DESCRIPTION
when using -x (full-test iterations) option, the next
iterations of test after the first one, can run with out sending
any requests, due to uninitialize parameter in client class.