### PR TITLE
fix parallel key-pattern

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* Version 1.2.14
+    * Keep keys to be in key-range when using run-count with parallel key-patten
+    * Fix keys overlap when using parallel key-patten
+
 * Version 1.2.13
     * Support "MOVED" in cluster mode
 

--- a/client.cpp
+++ b/client.cpp
@@ -100,12 +100,17 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
         m_obj_gen->set_random_seed(config->next_client_idx);
 
     if (config->key_pattern[key_pattern_set]=='P') {
-        unsigned long long range = (config->key_maximum - config->key_minimum)/(config->clients*config->threads) + 1;
-        unsigned long long min = config->key_minimum + range*config->next_client_idx;
-        unsigned long long max = min+range;
+        unsigned long long total_num_of_clients = config->clients*config->threads;
+        unsigned long long client_index = config->next_client_idx % total_num_of_clients;
 
-        if(config->next_client_idx==(int)(config->clients*config->threads)-1)
+        unsigned long long range = (config->key_maximum - config->key_minimum)/total_num_of_clients + 1;
+        unsigned long long min = config->key_minimum + (range * client_index);
+        unsigned long long max = min + range - 1;
+
+        if (client_index == (total_num_of_clients - 1)) {
             max = config->key_maximum; //the last clients takes the leftover
+        }
+
         m_obj_gen->set_key_range(min, max);
     }
     config->next_client_idx++;

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ dnl You should have received a copy of the GNU General Public License
 dnl along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 AC_PREREQ(2.59)
-AC_INIT(memtier_benchmark,1.2.13,yossigo@gmail.com)
+AC_INIT(memtier_benchmark,1.2.14,yossigo@gmail.com)
 AC_CONFIG_SRCDIR([memtier_benchmark.cpp])
 AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE


### PR DESCRIPTION
1. when using parallel key-pattern each client get a subset of the key-range.
if the user also chooses the run-count option, the subset of each client exceeded
the configured key-range.
fix this bug and keep the subset of keys for each client to be in
range for each run.

2. fix the overlapping of the ranges when using parallel key-pattern.