### PR TITLE
circleci integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+  version: 2.1
+  jobs:
+    build:
+      machine: true
+      steps:
+        - checkout
+
+        - run: docker build -t memtier_benchmark .
+        - run: docker run --rm memtier_benchmark --help || echo "memtier_benchmark --help returns status 2 so we ignore it"
+
+        # We save the docker image as tarball.
+        - run: docker save memtier_benchmark | gzip > memtier_benchmark_docker_image.tar.gz
+        - store_artifacts:
+            path: memtier_benchmark_docker_image.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ config.log
 config.status
 libtool
 stamp-h1
+.idea


### PR DESCRIPTION
Adding a circle-ci integration for this repo.
For now it just builds in docker and runs `--help`.
Since `--help` returns status 2 (which I think is a bug), we ignore the return status.

Also adding  intellij files to git ignore.