### PR TITLE
Fixed core when tls is enabled but not used

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1579,11 +1579,13 @@ int main(int argc, char *argv[])
     }
 
 #ifdef USE_TLS
-    if (cfg.openssl_ctx) {
-        SSL_CTX_free(cfg.openssl_ctx);
-        cfg.openssl_ctx = NULL;
-    }
+    if(cfg.tls) {
+        if (cfg.openssl_ctx) {
+            SSL_CTX_free(cfg.openssl_ctx);
+            cfg.openssl_ctx = NULL;
+        }
 
-    cleanup_openssl();
+        cleanup_openssl();
+    }
 #endif
 }


### PR DESCRIPTION
init_openssl function is called only when tls is used:
`
#ifdef USE_TLS

    // Initialize OpenSSL only if we're really going to use it.

    if (cfg.tls) {
        init_openssl();
`
Corresponding cleanup_openssl function is called whether or not tls is used hence we got a core:

`


Thread 1 "memtier_benchma" received signal SIGSEGV, Segmentation fault.
__GI___pthread_mutex_destroy (mutex=0x0) at pthread_mutex_destroy.c:30
30      pthread_mutex_destroy.c: Nie ma takiego pliku ani katalogu.
(gdb) where
#0  __GI___pthread_mutex_destroy (mutex=0x0) at pthread_mutex_destroy.c:30
#1  0x000055555555a1bd in cleanup_openssl_threads () at memtier_benchmark.cpp:1185
#2  cleanup_openssl () at memtier_benchmark.cpp:1204
#3  main (argc=<optimized out>, argv=<optimized out>) at memtier_benchmark.cpp:1587
`

This pull request fixes access to unitialized mutex and related coredump.
