### PR TITLE
Dockerfile: Get source files from local build context instead of downloading from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y \
     build-essential autoconf automake libpcre3-dev libevent-dev \
-    pkg-config zlib1g-dev libssl-dev git libboost-all-dev cmake flex
-RUN git clone https://github.com/RedisLabs/memtier_benchmark.git
+    pkg-config zlib1g-dev libssl-dev libboost-all-dev cmake flex
+COPY . /memtier_benchmark
 WORKDIR /memtier_benchmark
 RUN autoreconf -ivf && ./configure && make && make install
 


### PR DESCRIPTION
Checking the Dockerfile, I've realized that the build is done using source code _downloaded_ from Github. Most of the Docker workflow advantages come from building the artifact from local Docker build context, especially the source code.
I've changed this, so now it makes more sense to have a Docker Compose manifest for local development (#88), since it will build from local source, too. Thus, anybody can start hacking right away without having to install anything else besides Docker and Docker Compose. Now it makes more sense, IMO.