### PR TITLE
Fix: missing config.h includes in some files.

### DIFF
--- a/JSON_handler.cpp
+++ b/JSON_handler.cpp
@@ -16,6 +16,10 @@
  * along with memtier_benchmark.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/run_stats_types.cpp
+++ b/run_stats_types.cpp
@@ -16,6 +16,10 @@
  * along with memtier_benchmark.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdio.h>
 
 #include "run_stats_types.h"


### PR DESCRIPTION
Leads to compile issues on some platforms (e.g. FreeBSD), see #119.