### PR TITLE
Fix memory leaks involving hdr_histogram.

### DIFF
--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -117,21 +117,6 @@ run_stats::run_stats(benchmark_config *config) :
 {
     memset(&m_start_time, 0, sizeof(m_start_time));
     memset(&m_end_time, 0, sizeof(m_end_time));
-    hdr_init(
-            LATENCY_HDR_MIN_VALUE,          // Minimum value
-            LATENCY_HDR_MAX_VALUE,          // Maximum value
-            LATENCY_HDR_SIGDIGTS,           // Number of significant figures
-            &m_get_latency_histogram);      // Pointer to initialise
-    hdr_init(
-            LATENCY_HDR_MIN_VALUE,          // Minimum value
-            LATENCY_HDR_MAX_VALUE,          // Maximum value
-            LATENCY_HDR_SIGDIGTS,           // Number of significant figures
-            &m_set_latency_histogram);      // Pointer to initialise
-    hdr_init(
-            LATENCY_HDR_MIN_VALUE,          // Minimum value
-            LATENCY_HDR_MAX_VALUE,          // Maximum value
-            LATENCY_HDR_SIGDIGTS,           // Number of significant figures
-            &m_wait_latency_histogram);     // Pointer to initialise
 
     if (config->arbitrary_commands->is_defined()) {
         setup_arbitrary_commands(config->arbitrary_commands->size());
@@ -142,13 +127,6 @@ void run_stats::setup_arbitrary_commands(size_t n_arbitrary_commands) {
     m_totals.setup_arbitrary_commands(n_arbitrary_commands);
     m_cur_stats.setup_arbitrary_commands(n_arbitrary_commands);
     m_ar_commands_latency_histograms.resize(n_arbitrary_commands);
-    for (unsigned int i=0; i<n_arbitrary_commands; i++) {
-        hdr_init(
-            LATENCY_HDR_MIN_VALUE,                 // Minimum value
-            LATENCY_HDR_MAX_VALUE,                 // Maximum value
-            LATENCY_HDR_SIGDIGTS,                  // Number of significant figures
-            &m_ar_commands_latency_histograms[i]); // Pointer to initialise
-    }
 }
 
 void run_stats::set_start_time(struct timeval* start_time)
@@ -1023,15 +1001,10 @@ void run_stats::print_avg_latency_column(output_table &table) {
     table_el el;
     table_column column(15);
 
-    struct hdr_histogram* m_totals_latency_histogram;
-	hdr_init(
-			LATENCY_HDR_MIN_VALUE,          // Minimum value
-			LATENCY_HDR_MAX_VALUE,          // Maximum value
-			LATENCY_HDR_SIGDIGTS,           // Number of significant figures
-			&m_totals_latency_histogram);      // Pointer to initialise
-	hdr_add(m_totals_latency_histogram,m_set_latency_histogram);
-	hdr_add(m_totals_latency_histogram,m_get_latency_histogram);
-	hdr_add(m_totals_latency_histogram,m_wait_latency_histogram);
+    safe_hdr_histogram m_totals_latency_histogram;
+    hdr_add(m_totals_latency_histogram,m_set_latency_histogram);
+    hdr_add(m_totals_latency_histogram,m_get_latency_histogram);
+    hdr_add(m_totals_latency_histogram,m_wait_latency_histogram);
 
     column.elements.push_back(*el.init_str("%15s ", "Avg. Latency"));
     column.elements.push_back(*el.init_str("%s", "----------------"));
@@ -1070,12 +1043,7 @@ void run_stats::print_quantile_latency_column(output_table &table, double quanti
     table_el el;
     table_column column(15);
 
-    struct hdr_histogram* m_totals_latency_histogram;
-    hdr_init(
-            LATENCY_HDR_MIN_VALUE,          // Minimum value
-            LATENCY_HDR_MAX_VALUE,          // Maximum value
-            LATENCY_HDR_SIGDIGTS,           // Number of significant figures
-            &m_totals_latency_histogram);      // Pointer to initialise
+    safe_hdr_histogram m_totals_latency_histogram;
     hdr_add(m_totals_latency_histogram,m_set_latency_histogram);
     hdr_add(m_totals_latency_histogram,m_get_latency_histogram);
     hdr_add(m_totals_latency_histogram,m_wait_latency_histogram);

--- a/run_stats.h
+++ b/run_stats.h
@@ -101,10 +101,10 @@ protected:
     // current second stats ( appended to m_stats and reset every second )
     one_second_stats m_cur_stats;
 
-    struct hdr_histogram* m_get_latency_histogram;
-    struct hdr_histogram* m_set_latency_histogram;
-    struct hdr_histogram* m_wait_latency_histogram;
-    std::vector<struct hdr_histogram*> m_ar_commands_latency_histograms;
+    safe_hdr_histogram m_get_latency_histogram;
+    safe_hdr_histogram m_set_latency_histogram;
+    safe_hdr_histogram m_wait_latency_histogram;
+    std::vector<safe_hdr_histogram> m_ar_commands_latency_histograms;
 
     void roll_cur_stats(struct timeval* ts);
 

--- a/run_stats_types.cpp
+++ b/run_stats_types.cpp
@@ -26,36 +26,16 @@
 
 
 
-one_sec_cmd_stats::one_sec_cmd_stats() {
-    m_bytes = 0;
-    m_ops = 0;
-    m_hits = 0;
-    m_misses = 0;
-    m_moved = 0;
-    m_ask = 0;
-    m_total_latency = 0;
-    hdr_init(
-    LATENCY_HDR_MIN_VALUE,          // Minimum value
-    LATENCY_HDR_MAX_VALUE,          // Maximum value
-    LATENCY_HDR_SIGDIGTS,           // Number of significant figures
-    &latency_histogram);            // Pointer to initialise
+one_sec_cmd_stats::one_sec_cmd_stats() :
+    m_bytes(0),
+    m_ops(0),
+    m_hits(0),
+    m_misses(0),
+    m_moved(0),
+    m_ask(0),
+    m_total_latency(0) {
 }
 
-one_sec_cmd_stats::one_sec_cmd_stats(const one_sec_cmd_stats& b1){
-    m_bytes = b1.m_bytes;
-    m_ops = b1.m_ops;
-    m_hits = b1.m_hits;
-    m_misses = b1.m_misses;
-    m_moved = b1.m_moved;
-    m_ask = b1.m_ask;
-    m_total_latency = b1.m_total_latency;
-    hdr_init(
-    LATENCY_HDR_MIN_VALUE,          // Minimum value
-    LATENCY_HDR_SEC_MAX_VALUE,          // Maximum value
-    LATENCY_HDR_SEC_SIGDIGTS,           // Number of significant figures
-    &latency_histogram);            // Pointer to initialise
-    hdr_add(latency_histogram, b1.latency_histogram);
-}
 
 void one_sec_cmd_stats::reset() {
     m_bytes = 0;
@@ -269,11 +249,6 @@ totals::totals() :
         m_latency(0),
         m_bytes(0),
         m_ops(0) {
-    hdr_init(
-    LATENCY_HDR_MIN_VALUE,          // Minimum value
-    LATENCY_HDR_MAX_VALUE,          // Maximum value
-    LATENCY_HDR_SIGDIGTS,           // Number of significant figures
-    &latency_histogram);            // Pointer to initialise
 }
 
 void totals::setup_arbitrary_commands(size_t n_arbitrary_commands) {


### PR DESCRIPTION
Handle all allocation, deallocation and copying of hdr_histogram
automatically using a safe_hdr_histogram wrapper class.

This also saves the need for explicit initialization and custom
constructors.
