### PR TITLE
Prevents the program from entering endless loop

### DIFF
--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -438,7 +438,7 @@ void shard_connection::process_response(void)
     }
 
     if (m_config->reconnect_interval > 0 && responses_handled) {
-        if ((m_conns_manager->get_reqs_processed() % m_config->reconnect_interval) == 0) {
+        if ((m_config->requests != m_conns_manager->get_reqs_processed()) && ((m_conns_manager->get_reqs_processed() % m_config->reconnect_interval) == 0)) {
             assert(m_pipeline->size() == 0);
             benchmark_debug_log("reconnecting, m_reqs_processed = %u\n", m_conns_manager->get_reqs_processed());
 


### PR DESCRIPTION
See https://github.com/RedisLabs/memtier_benchmark/issues/135

The fix is simple enough, we just abort if we detect this particular
setting.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>