### PR TITLE
fix memory usage when not use json-out-file option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
+    - name: update pip
+      run: /opt/hostedtoolcache/Python/3.6.12/x64/bin/python -m pip install --upgrade pip
     - name: Install Python dependencies
       run: pip install -r tests/test_requirements.txt
-
     - name: Cache Redis
       id: cache-redis
       uses: actions/cache@v1

--- a/run_stats_types.h
+++ b/run_stats_types.h
@@ -82,8 +82,11 @@ public:
     unsigned int m_moved;
     unsigned int m_ask;
     unsigned long long int m_total_latency;
-    safe_hdr_histogram latency_histogram;
-    one_sec_cmd_stats();
+    safe_hdr_histogram *latency_histogram;
+    one_sec_cmd_stats(bool has_latency_histogram = 1);
+    one_sec_cmd_stats(const one_sec_cmd_stats& other);
+    one_sec_cmd_stats& operator=(const one_sec_cmd_stats& other);
+    ~one_sec_cmd_stats() { delete latency_histogram; }
     void reset();
     void merge(const one_sec_cmd_stats& other);
     void update_op(unsigned int bytes, unsigned int latency);
@@ -97,7 +100,7 @@ class one_second_stats; // forward declaration
 class ar_one_sec_cmd_stats {
 public:
     ar_one_sec_cmd_stats() {;}
-    void setup(size_t n_arbitrary_commands);
+    void setup(size_t n_arbitrary_commands, bool has_latency_histogram = 1);
     void reset();
     void merge(const ar_one_sec_cmd_stats& other);
     unsigned long int ops();
@@ -121,8 +124,8 @@ public:
     one_sec_cmd_stats m_get_cmd;
     one_sec_cmd_stats m_wait_cmd;
     ar_one_sec_cmd_stats m_ar_commands;
-    one_second_stats(unsigned int second);
-    void setup_arbitrary_commands(size_t n_arbitrary_commands);
+    one_second_stats(unsigned int second, bool has_latency_histogram = 1);
+    void setup_arbitrary_commands(size_t n_arbitrary_commands, bool has_latency_histogram = 1);
     void reset(unsigned int second);
     void merge(const one_second_stats& other);
 };

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,4 +1,4 @@
-redis>=3.0.0
+redis>=2.10.6
 git+https://github.com/Grokzen/redis-py-cluster.git@master
 git+https://github.com/RedisLabsModules/RLTest.git@master
 git+https://github.com/RedisLabs/mbdirector.git@master

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,4 +1,4 @@
-redis>=2.10.6
+redis>=3.0.0
 git+https://github.com/Grokzen/redis-py-cluster.git@master
 git+https://github.com/RedisLabsModules/RLTest.git@master
 git+https://github.com/RedisLabs/mbdirector.git@master


### PR DESCRIPTION
I ran memtier_benchmark with the following options;
```
memtier_benchmark -s 127.0.0.1 -p 6379 -t 48 -c 72 --command="mget __key__ __key__  __key__" --command-ratio=1 --command-key-pattern=G  -d 100 -n 2000 --hide-histogram
```
memtier_benchmark use a lot of memory about 500MB/s.

that the cause of this is latency_histogram in one_second_stats.
however I think it only used when set json-out-file option.

this pr change to not alloc and collect latency histogram if don't use json-out-file option 