### PR TITLE
fix issue #158, gaussian key-pattern on MAC OS

### DIFF
--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -82,7 +82,7 @@ unsigned long long random_generator::get_random()
 
     rn = jrand48(m_data_blob);
     llrn |= rn & 0xffffffff; // reset the sign extension bits of negative numbers
-    llrn &= 0x8000000000000000; // avoid any trouble from sign mismatch and negative numbers
+    llrn &= 0x7FFFFFFFFFFFFFFF; // avoid any trouble from sign mismatch and negative numbers
 #else
     #error no random function
 #endif


### PR DESCRIPTION
in case we are using jrand48 and generate a random number, all the bits
(except for the last bit) are reset, instead of resetting only the last bit.