### PR TITLE
Fix dropouts due to vector resize during long benchmarks

### DIFF
--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -282,7 +282,7 @@ void run_stats::save_csv_one_sec(FILE *f,
     total_get_ops = 0;
     total_set_ops = 0;
     total_wait_ops = 0;
-    for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
 
         fprintf(f, "%u,%lu,%u.%06u,%lu,%lu,%u.%06u,%lu,%u,%u,%lu,%u.%06u\n",
@@ -308,7 +308,7 @@ void run_stats::save_csv_one_sec(FILE *f,
 std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_get() {
     std::vector<one_sec_cmd_stats> result;
     result.reserve(m_stats.size());
-    for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
             result.push_back(i->m_get_cmd);    
     }
@@ -318,7 +318,7 @@ std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_get() {
 std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_set() {
     std::vector<one_sec_cmd_stats> result;
     result.reserve(m_stats.size());
-    for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
             result.push_back(i->m_set_cmd);    
     }
@@ -328,7 +328,7 @@ std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_set() {
 std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_wait() {
     std::vector<one_sec_cmd_stats> result;
     result.reserve(m_stats.size());
-    for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
             result.push_back(i->m_wait_cmd);
     }
@@ -338,9 +338,9 @@ std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_wait() {
 std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_totals() {
     std::vector<one_sec_cmd_stats> result;
     result.reserve(m_stats.size());
-    for (size_t i = 0; i < m_stats.size(); i++)
+    for (std::list<one_second_stats>::iterator i = m_stats.begin(); i != m_stats.end(); ++i)
     {
-        one_second_stats current_second_stats = m_stats.at(i);
+        one_second_stats current_second_stats = *i;
         one_sec_cmd_stats total_stat = one_sec_cmd_stats(current_second_stats.m_get_cmd);
         total_stat.merge(current_second_stats.m_set_cmd);
         total_stat.merge(current_second_stats.m_wait_cmd);
@@ -357,7 +357,7 @@ std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_totals() {
 std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_arbitrary_command( unsigned int pos ){
     std::vector<one_sec_cmd_stats> result;
     result.reserve(m_stats.size());
-    for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
             result.push_back(i->m_ar_commands.at(pos));
     }
@@ -367,7 +367,7 @@ std::vector<one_sec_cmd_stats> run_stats::get_one_sec_cmd_stats_arbitrary_comman
 std::vector<unsigned int> run_stats::get_one_sec_cmd_stats_timestamp() {
     std::vector<unsigned int> result;
     result.reserve(m_stats.size());
-    for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
             result.push_back(i->m_second);    
     }
@@ -379,7 +379,7 @@ void run_stats::save_csv_one_sec_cluster(FILE *f) {
     fprintf(f, "\nPer-Second Benchmark Cluster Data\n");
     fprintf(f, "Second,SET Moved,SET Ask,GET Moved,GET Ask\n");
 
-    for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
 
         fprintf(f, "%u,%u,%u,%u,%u\n",
@@ -453,7 +453,7 @@ void run_stats::save_csv_arbitrary_commands_one_sec(FILE *f,
     fprintf(f, "\n");
 
     // print data
-    for (std::vector<one_second_stats>::iterator stat = m_stats.begin();
+    for (std::list<one_second_stats>::iterator stat = m_stats.begin();
          stat != m_stats.end(); stat++) {
 
         fprintf(f, "%u,", stat->m_second);
@@ -644,7 +644,7 @@ void run_stats::debug_dump(void)
                         m_start_time.tv_sec, m_start_time.tv_usec,
                         m_end_time.tv_sec, m_end_time.tv_usec);
 
-    for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
 
         benchmark_debug_log("  %u: get latency=%u.%ums, set latency=%u.%ums, wait latency=%u.%ums"
@@ -711,12 +711,12 @@ void run_stats::merge(const run_stats& other, int iteration)
 
     // aggregate the one_second_stats vectors. this is not efficient
     // but it's not really important (small numbers, not realtime)
-    for (std::vector<one_second_stats>::const_iterator other_i = other.m_stats.begin();
+    for (std::list<one_second_stats>::const_iterator other_i = other.m_stats.begin();
          other_i != other.m_stats.end(); other_i++) {
 
         // find ours
         bool merged = false;
-        for (std::vector<one_second_stats>::iterator i = m_stats.begin();
+        for (std::list<one_second_stats>::iterator i = m_stats.begin();
              i != m_stats.end(); i++) {
             if (i->m_second == other_i->m_second) {
                 i->merge(*other_i);
@@ -732,7 +732,7 @@ void run_stats::merge(const run_stats& other, int iteration)
     }
 
     if (new_stats) {
-        sort(m_stats.begin(), m_stats.end(), one_second_stats_predicate);
+        m_stats.sort(one_second_stats_predicate);
     }
 
     // aggregate totals
@@ -755,7 +755,7 @@ void run_stats::summarize(totals& result) const
     one_second_stats totals(0);
     totals.setup_arbitrary_commands(m_cur_stats.m_ar_commands.size());
 
-    for (std::vector<one_second_stats>::const_iterator i = m_stats.begin();
+    for (std::list<one_second_stats>::const_iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
         totals.merge(*i);
     }

--- a/run_stats.h
+++ b/run_stats.h
@@ -96,7 +96,7 @@ protected:
 
     totals m_totals;
 
-    std::vector<one_second_stats> m_stats;
+    std::list<one_second_stats> m_stats;
 
     // current second stats ( appended to m_stats and reset every second )
     one_second_stats m_cur_stats;


### PR DESCRIPTION
The current implementation collects stats in a std::vector. As the vector grows it needs to be resized, during long runs this resize can take significant amounts of time and appear to the user as though the server is not responding.  This is both inacurate and confusing to users using the tool.

The chart below clearly demonstrates the problem during a long run against redis.  You can see big dropouts around 208, 520, 2080, 4056 seconds, profiler shows this time is spent in memmove during a vector resize.
![image](https://user-images.githubusercontent.com/3894786/127722076-b134bbfb-2d07-46fb-bc00-dfff191322b0.png)

### The Fix

During the benchmark its critical that updating stats takes a constant time.  Otherwise the benchmark results will be skewed.  Because of this a std::vector with its O(n) insert is not the correct datastructure.  The fix changes the code to a std::list which can guarantee O(1) inserts resulting in a more accurate benchmark.

![image](https://user-images.githubusercontent.com/3894786/127722182-8ef3d175-0dff-4c57-9d04-d5aa1904c951.png)

The run with the fix achieved 159022 sets/s, while the original code produced 158304 sets/s

memtier command:
-t 50 -c 8 -n 2000000 -d 256 --key-minimum=1 --key-maximum=800000000 --ratio 1:0 --key-pattern=P:P --hide-histogram --json-out-file=redis.json
