### PR TITLE
Initial support for keys following zipfian

### DIFF
--- a/client.h
+++ b/client.h
@@ -124,6 +124,8 @@ public:
             return OBJECT_GENERATOR_KEY_RANDOM;
         } else if (cfg->key_pattern[index] == 'G') {
             return OBJECT_GENERATOR_KEY_GAUSSIAN;
+        } else if (cfg->key_pattern[index] == 'Z') {
+            return OBJECT_GENERATOR_KEY_ZIPFIAN;
         } else {
             if (index == key_pattern_set)
                 return OBJECT_GENERATOR_KEY_SET_ITER;
@@ -137,6 +139,8 @@ public:
             return OBJECT_GENERATOR_KEY_RANDOM;
         } else if (cmd->key_pattern == 'G') {
             return OBJECT_GENERATOR_KEY_GAUSSIAN;
+        } else if (cmd->key_pattern == 'Z') {
+            return OBJECT_GENERATOR_KEY_ZIPFIAN;
         } else {
             return index;
         }

--- a/memtier_benchmark.1
+++ b/memtier_benchmark.1
@@ -184,6 +184,7 @@ Key ID maximum value (default: 10000000)
 \fB\-\-key\-pattern\fR=\fI\,PATTERN\/\fR
 Set:Get pattern (default: R:R)
 G for Gaussian distribution.
+Z for Zipfian distribution (will limit keys to positive).
 R for uniform Random.
 S for Sequential.
 P for Parallel (Sequential were each client has a subset of the key\-range).
@@ -195,6 +196,10 @@ The standard deviation used in the Gaussian distribution
 \fB\-\-key\-median\fR
 The median point used in the Gaussian distribution
 (default is the center of the key range)
+.TP
+\fB\-\-key\-zipf\-exp\fR
+The exponent used in the zipf distribution, limit to (0, 5)
+(default is 1, though any number >2 seems insane)\n
 .SS "WAIT Options:"
 .TP
 \fB\-\-wait\-ratio\fR=\fI\,RATIO\/\fR

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -225,6 +225,7 @@ static void config_print_to_json(json_handler * jsonhandler, struct benchmark_co
     jsonhandler->write_obj("key_pattern"       ,"\"%s\"",       cfg->key_pattern);
     jsonhandler->write_obj("key_stddev"        ,"%f",           cfg->key_stddev);
     jsonhandler->write_obj("key_median"        ,"%f",           cfg->key_median);
+    jsonhandler->write_obj("key_zipf_exp"      ,"%f",           cfg->key_zipf_exp);
     jsonhandler->write_obj("reconnect_interval","%u",    		cfg->reconnect_interval);
     jsonhandler->write_obj("multi_key_get"     ,"%u",         	cfg->multi_key_get);
     jsonhandler->write_obj("authenticate"      ,"\"%s\"",      	cfg->authenticate ? cfg->authenticate : "");
@@ -365,6 +366,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_key_pattern,
         o_key_stddev,
         o_key_median,
+        o_key_zipf_exp,
         o_show_config,
         o_hide_histogram,
         o_print_percentiles,
@@ -439,6 +441,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         { "key-pattern",                1, 0, o_key_pattern },
         { "key-stddev",                 1, 0, o_key_stddev },
         { "key-median",                 1, 0, o_key_median },
+        { "key-zipf-exp",               1, 0, o_key_zipf_exp},
         { "reconnect-interval",         1, 0, o_reconnect_interval },
         { "multi-key-get",              1, 0, o_multi_key_get },
         { "authenticate",               1, 0, 'a' },
@@ -690,6 +693,14 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                         return -1;
                     }
                     break;
+                case o_key_zipf_exp:
+                    endptr = NULL;
+                    cfg->key_zipf_exp = strtod(optarg, &endptr);
+                    if (cfg->key_zipf_exp <= 0 || cfg->key_zipf_exp >= 5 || !endptr || *endptr != '\0') {
+                        fprintf(stderr, "error: key-zipf-exp must be within interval (0, 5).\n");
+                        return -1;
+                    }
+                    break;
                 case o_key_pattern:
                     cfg->key_pattern = optarg;
 
@@ -697,12 +708,14 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                         (cfg->key_pattern[key_pattern_set] != 'R' &&
                          cfg->key_pattern[key_pattern_set] != 'S' &&
                          cfg->key_pattern[key_pattern_set] != 'G' &&
+                         cfg->key_pattern[key_pattern_set] != 'Z' &&
                          cfg->key_pattern[key_pattern_set] != 'P') ||
                         (cfg->key_pattern[key_pattern_get] != 'R' &&
                          cfg->key_pattern[key_pattern_get] != 'S' &&
                          cfg->key_pattern[key_pattern_get] != 'G' &&
+                         cfg->key_pattern[key_pattern_get] != 'Z' &&
                          cfg->key_pattern[key_pattern_get] != 'P')) {
-                        fprintf(stderr, "error: key-pattern must be in the format of [S/R/G/P]:[S/R/G/P].\n");
+                        fprintf(stderr, "error: key-pattern must be in the format of [S/R/G/P/Z]:[S/R/G/P/Z].\n");
                         return -1;
                     }
 
@@ -939,12 +952,15 @@ void usage() {
             "      --key-pattern=PATTERN      Set:Get pattern (default: R:R)\n"
             "                                 G for Gaussian distribution.\n"
             "                                 R for uniform Random.\n"
+            "                                 Z for zipf distribution (will limit keys to positive).\n"
             "                                 S for Sequential.\n"
             "                                 P for Parallel (Sequential were each client has a subset of the key-range).\n"
             "      --key-stddev               The standard deviation used in the Gaussian distribution\n"
             "                                 (default is key range / 6)\n"
             "      --key-median               The median point used in the Gaussian distribution\n"
             "                                 (default is the center of the key range)\n"
+            "      --key-zipf-exp             The exponent used in the zipf distribution, limit to (0, 5)\n"
+            "                                 (default is 1, though any number >2 seems insane)\n"
             "\n"
             "WAIT Options:\n"
             "      --wait-ratio=RATIO         Set:Wait ratio (default is no WAIT commands - 1:0)\n"
@@ -1465,6 +1481,13 @@ int main(int argc, char *argv[])
         obj_gen->set_key_distribution(cfg.key_stddev, cfg.key_median);
     }
     obj_gen->set_expiry_range(cfg.expiry_range.min, cfg.expiry_range.max);
+    if (cfg.key_pattern[key_pattern_set] == 'Z' || cfg.key_pattern[key_pattern_get] == 'Z') {
+        if (cfg.key_zipf_exp == 0.0) {
+            // user can't specify 0.0, so 0.0 means unset
+            cfg.key_zipf_exp = 1.0;
+        }
+        obj_gen->set_key_zipf_distribution(cfg.key_zipf_exp);
+    }
 
     // Prepare output file
     FILE *outfile;

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -79,6 +79,7 @@ struct benchmark_config {
     unsigned long long key_maximum;
     double key_stddev;
     double key_median;
+    double key_zipf_exp;
     const char *key_pattern;
     unsigned int reconnect_interval;
     int multi_key_get;

--- a/obj_gen.h
+++ b/obj_gen.h
@@ -47,7 +47,7 @@ public:
 private:
     double gaussian_distribution(const double &stddev);
     bool m_hasSpare;
-	double m_spare;
+    double m_spare;
 };
 
 class data_object {
@@ -75,6 +75,7 @@ public:
 #define OBJECT_GENERATOR_KEY_GET_ITER   0
 #define OBJECT_GENERATOR_KEY_RANDOM    -1
 #define OBJECT_GENERATOR_KEY_GAUSSIAN  -2
+#define OBJECT_GENERATOR_KEY_ZIPFIAN   -3
 
 class object_generator {
 public:
@@ -98,6 +99,19 @@ protected:
     unsigned long long m_key_max;
     double m_key_stddev;
     double m_key_median;
+
+    // zipf will only be used for key generation
+    // adjusted min and max key for zipf, may be difference from user specified
+    unsigned long long m_key_zipf_min;
+    unsigned long long m_key_zipf_max;
+    // other persist data across generations
+    double m_key_zipf_exp;
+    double m_key_zipf_1mexp;
+    double m_key_zipf_1mexpInv;
+    double m_key_zipf_Hmin;
+    double m_key_zipf_Hmax;
+    double m_key_zipf_s;
+
     data_object m_object;
 
     std::vector<unsigned long long> m_next_key;
@@ -121,6 +135,7 @@ public:
 
     unsigned long long random_range(unsigned long long r_min, unsigned long long r_max);
     unsigned long long normal_distribution(unsigned long long r_min, unsigned long long r_max, double r_stddev, double r_median);
+    unsigned long long zipf_distribution();
 
     void set_random_data(bool random_data);
     void set_data_size_fixed(unsigned int size);
@@ -131,6 +146,7 @@ public:
     void set_key_prefix(const char *key_prefix);
     void set_key_range(unsigned long long key_min, unsigned long long key_max);
     void set_key_distribution(double key_stddev, double key_median);
+    void set_key_zipf_distribution(double key_exp);
     void set_random_seed(int seed);
 
     unsigned long long get_key_index(int iter);


### PR DESCRIPTION
This patch allows memtier generate keys that follows zipfian
distribution. An additional parameter --key-zipf-exp is introduced,
meaning P(Key = n) ~ n^{-exp}, which is bounded to (0, 5) to be sane.
The range of keys are limited to positive in this version.

Signed-off-by: Su Lifan <su-lifan@linux.alibaba.com>