### PR TITLE
Enable OpenSSL to load a configuration file during initialization

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -34,6 +34,8 @@
 #include <sys/resource.h>
 
 #ifdef USE_TLS
+#include <openssl/crypto.h>
+#include <openssl/conf.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
@@ -1215,6 +1217,14 @@ static void init_openssl(void)
         fprintf(stderr, "Failed to initialize OpenSSL random entropy.\n");
         exit(1);
     }
+
+    //Enable memtier benchmark to load an OpenSSL config file.
+    #if OPENSSL_VERSION_NUMBER < 0x10100000L
+    OPENSSL_config(NULL);
+    #else
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+    #endif
+
 
     init_openssl_threads();
 }


### PR DESCRIPTION
Enable OpenSSL to load a configuration file using the standard openssl.cnf file. 
In this way, we can change the default OpenSSL ENGINE, as well as configure other capabilities. 
This aligns memtier benchmark to a similarly added capability in Redis here : https://github.com/redis/redis/pull/8143

By providing this capability to memtier benchmark, we can ensure that memtier benchmark and redis are using the same OpenSSL configuration (e.g. ENGINE) while performing a test. 