### PR TITLE
Pinning rltest to the last release prior to redis-py 4 as a requirement

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,4 +1,3 @@
 redis>=3.0.0
-git+https://github.com/Grokzen/redis-py-cluster.git@master
-git+https://github.com/RedisLabsModules/RLTest.git@master
+rltest==0.4.2
 git+https://github.com/RedisLabs/mbdirector.git@master


### PR DESCRIPTION
This allows a longer-tail migration to the latest version as each repository is ready, without breaking individual projects.
