### PR TITLE
Support benchmarking servers with IPv6 addresses

### DIFF
--- a/config_types.cpp
+++ b/config_types.cpp
@@ -254,7 +254,7 @@ int server_addr::resolve(void)
     memset(&hints, 0, sizeof(hints));
     hints.ai_flags = AI_PASSIVE;
     hints.ai_socktype = SOCK_STREAM;
-    hints.ai_family = AF_INET;      // Don't play with IPv6 for now...
+    hints.ai_family = PF_UNSPEC;
 
     snprintf(port_str, sizeof(port_str)-1, "%u", m_port);
     m_last_error = getaddrinfo(m_hostname.c_str(), port_str, &hints, &m_server_addr);

--- a/config_types.h
+++ b/config_types.h
@@ -82,7 +82,7 @@ struct connect_info {
     int ci_protocol;
     socklen_t ci_addrlen;
     struct sockaddr *ci_addr;
-    char addr_buf[sizeof(struct sockaddr_in)];
+    char addr_buf[sizeof(struct sockaddr_storage)];
 };
 
 struct server_addr {


### PR DESCRIPTION
Resolves https://github.com/RedisLabs/memtier_benchmark/issues/156

Currently Memtier Benchmark is only capable of benchmarking servers with IPv4 addresses. This PR adds support for both IPv4 and IPv6 addresses.