### PR TITLE
Moved integration testing logic out of github actions and included testing section on Readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       run: |
         sudo apt-get -qq update
         sudo apt-get install autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev
+
     - name: Build
       run: autoreconf -ivf && ./configure && make -j
     - name: Setup Python
@@ -25,27 +26,12 @@ jobs:
     - name: Install Python dependencies
       run: pip install -r ./tests/test_requirements.txt
 
-    - name: Cache Redis
-      id: cache-redis
-      uses: actions/cache@v1
-      with:
-        path: /home/runner/work/redis
-        key: ${{ runner.os }}-redis
-
-    - name: Check out Redis
-      if: steps.cache-redis.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: 'redis/redis'
-        ref: 'unstable'
-        path: 'redis'
-
-    - name: Build and run Redis
-      if: steps.cache-redis.outputs.cache-hit != 'true'
+    - name: Install Redis
       run: |
-        cd redis
-        make BUILD_TLS=yes -j
-        ./src/redis-server --version
+        curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+        sudo apt-get -qq update
+        sudo apt-get install redis
 
     - name: Generate TLS test certificates
       if: matrix.platform == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,29 +15,21 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get install autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev
     - name: Build
-      run: autoreconf -ivf && ./configure && make
+      run: autoreconf -ivf && ./configure && make -j
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.6'
+        architecture: x64
 
-    - name: Cache pip
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip # This path is specific to Ubuntu
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('tests/test_requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
     - name: Install Python dependencies
-      run: pip install -r tests/test_requirements.txt
+      run: pip install -r ./tests/test_requirements.txt
 
     - name: Cache Redis
       id: cache-redis
       uses: actions/cache@v1
       with:
-        path: /home/runner/work/memtier_benchmark/memtier_benchmark/redis
+        path: /home/runner/work/redis
         key: ${{ runner.os }}-redis
 
     - name: Check out Redis
@@ -52,61 +44,41 @@ jobs:
       if: steps.cache-redis.outputs.cache-hit != 'true'
       run: |
         cd redis
-        make BUILD_TLS=yes
-        ./utils/gen-test-certs.sh
+        make BUILD_TLS=yes -j
         ./src/redis-server --version
 
-    - name: Test OSS TCP
+    - name: Generate TLS test certificates
+      if: matrix.platform == 'ubuntu-latest'
       run: |
-        cd tests 
-        MEMTIER_BINARY=./../memtier_benchmark \
-        python3 -m RLTest \
-        --env oss -v --clear-logs \
-        --oss-redis-path ../redis/src/redis-server
-        cd ..
+          ./tests/gen-test-certs.sh
+
+    - name: Test OSS TCP
+      timeout-minutes: 10
+      run: |
+        REDIS_SERVER=../redis/src/redis-server \
+        ./tests/run_tests.sh
 
     - name: Test OSS TCP TLS
       if: matrix.platform == 'ubuntu-latest'
+      timeout-minutes: 10
       run: |
-        cd tests
-        TLS_CERT=../redis/tests/tls/redis.crt \
-        TLS_KEY=../redis/tests/tls/redis.key \
-        TLS_CACERT=../redis/tests/tls/ca.crt \
-        MEMTIER_BINARY=../memtier_benchmark \
-        python3 -m RLTest \
-          --env oss -v --clear-logs \
-          --oss-redis-path ../redis/src/redis-server \
-          --tls-cert-file ../redis/tests/tls/redis.crt \
-          --tls-key-file ../redis/tests/tls/redis.key \
-          --tls-ca-cert-file ../redis/tests/tls/ca.crt \
-          --tls
-        cd ..
+        TLS=1 REDIS_SERVER=../redis/src/redis-server \
+        ./tests/run_tests.sh
 
     - name: Test OSS-CLUSTER TCP
+      timeout-minutes: 10
       run: |
-        cd tests 
-        MEMTIER_BINARY=./../memtier_benchmark \
-        python3 -m RLTest \
-        --env oss-cluster -v --clear-logs --shards-count 3 \
-        --oss-redis-path ../redis/src/redis-server
-        cd ..
+        OSS_STANDALONE=0 OSS_CLUSTER=1 \
+        REDIS_SERVER=../redis/src/redis-server \
+        ./tests/run_tests.sh
 
     - name: Test OSS-CLUSTER TCP TLS
+      timeout-minutes: 10
       if: matrix.platform == 'ubuntu-latest'
       run: |
-        cd tests
-        TLS_CERT=../redis/tests/tls/redis.crt \
-        TLS_KEY=../redis/tests/tls/redis.key \
-        TLS_CACERT=../redis/tests/tls/ca.crt \
-        MEMTIER_BINARY=../memtier_benchmark \
-        python3 -m RLTest \
-          --env oss-cluster --shards-count 3 -v --clear-logs \
-          --oss-redis-path ../redis/src/redis-server \
-          --tls-cert-file ../redis/tests/tls/redis.crt \
-          --tls-key-file ../redis/tests/tls/redis.key \
-          --tls-ca-cert-file ../redis/tests/tls/ca.crt \
-          --tls
-        cd ..
+        OSS_STANDALONE=0 OSS_CLUSTER=1 TLS=1 \
+        REDIS_SERVER=../redis/src/redis-server \
+        ./tests/run_tests.sh
 
   build-macos:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,21 +41,18 @@ jobs:
     - name: Test OSS TCP
       timeout-minutes: 10
       run: |
-        REDIS_SERVER=../redis/src/redis-server \
         ./tests/run_tests.sh
 
     - name: Test OSS TCP TLS
       if: matrix.platform == 'ubuntu-latest'
       timeout-minutes: 10
       run: |
-        TLS=1 REDIS_SERVER=../redis/src/redis-server \
-        ./tests/run_tests.sh
+        TLS=1 ./tests/run_tests.sh
 
     - name: Test OSS-CLUSTER TCP
       timeout-minutes: 10
       run: |
         OSS_STANDALONE=0 OSS_CLUSTER=1 \
-        REDIS_SERVER=../redis/src/redis-server \
         ./tests/run_tests.sh
 
     - name: Test OSS-CLUSTER TCP TLS
@@ -63,7 +60,6 @@ jobs:
       if: matrix.platform == 'ubuntu-latest'
       run: |
         OSS_STANDALONE=0 OSS_CLUSTER=1 TLS=1 \
-        REDIS_SERVER=../redis/src/redis-server \
         ./tests/run_tests.sh
 
   build-macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
         sudo apt-get -qq update
         sudo apt-get install redis
+        sudo service redis-server stop
 
     - name: Generate TLS test certificates
       if: matrix.platform == 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,11 @@ stamp-h1
 .vscode/*
 .idea/*
 
+# tls helper related files
+tests/tls/*
+
 # memtier outputs
 *.hgrm
 *.txt
+!/tests/test_requirements.txt
 __pycache__

--- a/README.md
+++ b/README.md
@@ -101,6 +101,33 @@ $ make
 $ make install
 ```
 
+#### Testing
+
+
+## Tests
+
+The project includes a basic set of integration tests.
+
+
+**Integration tests**
+
+
+Integration tests are based on [RLTest](https://github.com/RedisLabsModules/RLTest), and specific setup parameters can be provided
+to configure tests and topologies (OSS standalone and OSS cluster). By default the tests will be ran for all common commands, and with OSS standalone setup.
+
+
+To run all integration tests in a Python virtualenv, follow these steps:
+
+    $ mkdir -p .env
+    $ virtualenv .env
+    $ source .env/bin/activate
+    $ pip install -r tests/test_requirements.txt
+    $ ./tests/run_tests.sh
+
+To understand what test options are available simply run:
+
+    $ ./tests/run_tests.sh --help
+
 ## Using Docker
 
 Use available images on Docker Hub:

--- a/README.md
+++ b/README.md
@@ -103,9 +103,6 @@ $ make install
 
 #### Testing
 
-
-## Tests
-
 The project includes a basic set of integration tests.
 
 

--- a/tests/gen-test-certs.sh
+++ b/tests/gen-test-certs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Generate some test certificates which are used by the regression test suite:
+#
+#   tests/tls/ca.{crt,key}          Self signed CA certificate.
+#   tests/tls/redis.{crt,key}       A certificate with no key usage/policy restrictions.
+#   tests/tls/client.{crt,key}      A certificate restricted for SSL client usage.
+#   tests/tls/server.{crt,key}      A certificate restricted for SSL server usage.
+#   tests/tls/redis.dh              DH Params file.
+
+generate_cert() {
+    local name=$1
+    local cn="$2"
+    local opts="$3"
+
+    local keyfile=tests/tls/${name}.key
+    local certfile=tests/tls/${name}.crt
+
+    [ -f $keyfile ] || openssl genrsa -out $keyfile 2048
+    openssl req \
+        -new -sha256 \
+        -subj "/O=Redis Test/CN=$cn" \
+        -key $keyfile | \
+        openssl x509 \
+            -req -sha256 \
+            -CA tests/tls/ca.crt \
+            -CAkey tests/tls/ca.key \
+            -CAserial tests/tls/ca.txt \
+            -CAcreateserial \
+            -days 365 \
+            $opts \
+            -out $certfile
+}
+
+mkdir -p tests/tls
+[ -f tests/tls/ca.key ] || openssl genrsa -out tests/tls/ca.key 4096
+openssl req \
+    -x509 -new -nodes -sha256 \
+    -key tests/tls/ca.key \
+    -days 3650 \
+    -subj '/O=Redis Test/CN=Certificate Authority' \
+    -out tests/tls/ca.crt
+
+cat > tests/tls/openssl.cnf <<_END_
+[ server_cert ]
+keyUsage = digitalSignature, keyEncipherment
+nsCertType = server
+
+[ client_cert ]
+keyUsage = digitalSignature, keyEncipherment
+nsCertType = client
+_END_
+
+generate_cert server "Server-only" "-extfile tests/tls/openssl.cnf -extensions server_cert"
+generate_cert client "Client-only" "-extfile tests/tls/openssl.cnf -extensions client_cert"
+generate_cert redis "Generic-cert"
+
+[ -f tests/tls/redis.dh ] || openssl dhparam -out tests/tls/redis.dh 2048

--- a/tests/include.py
+++ b/tests/include.py
@@ -83,17 +83,21 @@ def addTLSArgs(benchmark_specs, env):
     if env.useTLS:
         benchmark_specs['args'].append('--tls')
         benchmark_specs['args'].append('--cert={}'.format(TLS_CERT))
-        benchmark_specs['args'].append('--key={}'.format(TLS_KEY))
         benchmark_specs['args'].append('--cacert={}'.format(TLS_CACERT))
+        if TLS_KEY != "":
+            benchmark_specs['args'].append('--key={}'.format(TLS_KEY))
+        else:
+            benchmark_specs['args'].append('--tls-skip-verify')
+            
 
 
-def get_default_memtier_config():
+def get_default_memtier_config(threads=10, clients=5, requests=1000):
     config = {
         "memtier_benchmark": {
             "binary": MEMTIER_BINARY,
-            "threads": 10,
-            "clients": 5,
-            "requests": 1000
+            "threads": threads,
+            "clients": clients,
+            "requests": requests
         },
     }
     return config
@@ -106,3 +110,4 @@ def ensure_clean_benchmark_folder(dirname):
     if os.path.exists(dirname):
         os.removedirs(dirname)
     os.makedirs(dirname)
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+[[ $VERBOSE == 1 ]] && set -x
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT=$(cd $HERE/.. && pwd)
+
+#----------------------------------------------------------------------------------------------
+
+help() {
+	cat <<-END
+		Run flow tests.
+
+		[ARGVARS...] tests.sh [--help|help]
+
+		Argument variables:
+
+		OSS_STANDALONE=0|1  General tests on standalone Redis (default)
+		TLS=0|1             Run tests with TLS enabled
+		OSS_CLUSTER=0|1     General tests on Redis OSS Cluster
+		SHARDS=n            Number of shards (default: 3)
+
+		REDIS_SERVER=path   Location of redis-server
+
+		TEST=test           Run specific test (e.g. test.py:test_name)
+
+		VERBOSE=1           Print commands
+
+	END
+}
+
+#----------------------------------------------------------------------------------------------
+
+run_tests() {
+	local title="$1"
+	if [[ -n $title ]]; then
+		printf "Running $title:\n\n"
+	fi
+
+	if [[ $VERBOSE == 1 ]]; then
+		echo "RLTest configuration:"
+		echo "$RLTEST_ARGS"
+	fi
+
+	cd $ROOT/tests
+
+	local E=0
+	{
+		$OP python3 -m RLTest $RLTEST_ARGS
+		((E |= $?))
+	} || true
+
+	return $E
+}
+
+#----------------------------------------------------------------------------------------------
+
+[[ $1 == --help || $1 == help ]] && {
+	help
+	exit 0
+}
+
+#----------------------------------------------------------------------------------------------
+
+OSS_STANDALONE=${OSS_STANDALONE:-1}
+OSS_CLUSTER=${OSS_CLUSTER:-0}
+SHARDS=${SHARDS:-3}
+
+TLS_KEY=$ROOT/tests/tls/redis.key
+TLS_CERT=$ROOT/tests/tls/redis.crt
+TLS_CACERT=$ROOT/tests/tls/ca.crt
+REDIS_SERVER=${REDIS_SERVER:-redis-server}
+MEMTIER_BINARY=$ROOT/memtier_benchmark
+
+RLTEST_ARGS=" --oss-redis-path $REDIS_SERVER"
+[[ $VERBOSE == 1 ]] && RLTEST_ARGS+=" -v"
+[[ $TLS == 1 ]] && RLTEST_ARGS+=" --tls-cert-file $TLS_CERT --tls-key-file $TLS_KEY --tls-ca-cert-file $TLS_CACERT --tls"
+
+cd $ROOT/tests
+
+E=0
+[[ $OSS_STANDALONE == 1 ]] && {
+	(TLS_KEY=$TLS_KEY TLS_CERT=$TLS_CERT TLS_CACERT=$TLS_CACERT MEMTIER_BINARY=$MEMTIER_BINARY RLTEST_ARGS="${RLTEST_ARGS}" run_tests "tests on OSS standalone")
+	((E |= $?))
+} || true
+
+[[ $OSS_CLUSTER == 1 ]] && {
+	(TLS_KEY=$TLS_KEY TLS_CERT=$TLS_CERT TLS_CACERT=$TLS_CACERT MEMTIER_BINARY=$MEMTIER_BINARY RLTEST_ARGS="${RLTEST_ARGS} --env oss-cluster --shards-count $SHARDS" run_tests "tests on OSS cluster")
+	((E |= $?))
+} || true
+
+exit $E

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -11,19 +11,16 @@ help() {
 	cat <<-END
 		Run flow tests.
 
-		[ARGVARS...] tests.sh [--help|help]
+		[ARGVARS...] run_tests.sh [--help|help]
 
 		Argument variables:
 
 		OSS_STANDALONE=0|1  General tests on standalone Redis (default)
-		TLS=0|1             Run tests with TLS enabled
 		OSS_CLUSTER=0|1     General tests on Redis OSS Cluster
+		TLS=0|1             Run tests with TLS enabled 
 		SHARDS=n            Number of shards (default: 3)
 
 		REDIS_SERVER=path   Location of redis-server
-
-		TEST=test           Run specific test (e.g. test.py:test_name)
-
 		VERBOSE=1           Print commands
 
 	END

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -114,7 +114,6 @@ def test_default_set_get_1_1(env):
     # assert same number of gets and sets
     env.assertEqual(merged_command_stats['cmdstat_set']['calls'], merged_command_stats['cmdstat_get']['calls'])
 
-
 # run each test on different env
 def test_default_set_get_3_runs(env):
     env.skipOnCluster()
@@ -141,6 +140,87 @@ def test_default_set_get_3_runs(env):
 
     master_nodes_connections = env.getOSSMasterNodesConnectionList()
     merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
+    overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
+                                    overall_request_count)
+
+
+def test_default_arbitrary_command_pubsub(env):
+    env.skipOnCluster()
+    benchmark_specs = {"name": env.testName, "args": ['--command=publish \"__key__\" \"__data__\"']}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config()
+    master_nodes_list = env.getMasterNodesList()
+    overall_expected_request_count = 0
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    # Create a temporary directory
+    test_dir = tempfile.mkdtemp()
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+
+    # benchmark.run() returns True if the return code of memtier_benchmark was 0
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(config, env, memtier_ok)
+
+
+def test_default_arbitrary_command_set(env):
+    env.skipOnCluster()
+    benchmark_specs = {"name": env.testName, "args": ['--command=SET __key__ __data__']}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config()
+    master_nodes_list = env.getMasterNodesList()
+    overall_expected_request_count = get_expected_request_count(config)
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    # Create a temporary directory
+    test_dir = tempfile.mkdtemp()
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+
+    # benchmark.run() returns True if the return code of memtier_benchmark was 0
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(config, env, memtier_ok)
+
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+    merged_command_stats = {'cmdstat_set': {'calls': 0}}
+    overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
+                                    overall_request_count)
+
+
+def test_default_arbitrary_command_hset(env):
+    env.skipOnCluster()
+    benchmark_specs = {"name": env.testName, "args": ['--command=HSET __key__ field1 __data__']}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config()
+    master_nodes_list = env.getMasterNodesList()
+    overall_expected_request_count = get_expected_request_count(config)
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    # Create a temporary directory
+    test_dir = tempfile.mkdtemp()
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+
+    # benchmark.run() returns True if the return code of memtier_benchmark was 0
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(config, env, memtier_ok)
+
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+    merged_command_stats = {'cmdstat_hset': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
     assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
                                     overall_request_count)


### PR DESCRIPTION
This PR clarifies how to test memtier_benchmark locally and uses the exact same script for CI testing. 

Details on how to to test memtier:

The project includes a basic set of integration tests.


**Integration tests**


Integration tests are based on [RLTest](https://github.com/RedisLabsModules/RLTest), and specific setup parameters can be provided
to configure tests and topologies (OSS standalone and OSS cluster). By default the tests will be ran for all common commands, and with OSS standalone setup.


To run all integration tests in a Python virtualenv, follow these steps:

    $ mkdir -p .env
    $ virtualenv .env
    $ source .env/bin/activate
    $ pip install -r tests/test_requirements.txt
    $ ./tests/run_tests.sh

To understand what test options are available simply run:

    $ ./tests/run_tests.sh --help