### PR TITLE
add support for resp3

### DIFF
--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -342,7 +342,7 @@ bool cluster_client::get_key_for_conn(unsigned int conn_id, int iter, unsigned l
         }
 
         // in case connection is during cluster slots command, his slots mapping not relevant
-        if (m_connections[other_conn_id]->get_cluster_slots_state() != slots_done)
+        if (m_connections[other_conn_id]->get_cluster_slots_state() != setup_done)
             continue;
 
         // store key for other connection, if queue is not full
@@ -429,7 +429,7 @@ void cluster_client::handle_moved(unsigned int conn_id, struct timeval timestamp
     }
 
     // connection already issued 'cluster slots' command, wait for slots mapping to be updated
-    if (m_connections[conn_id]->get_cluster_slots_state() != slots_done)
+    if (m_connections[conn_id]->get_cluster_slots_state() != setup_done)
         return;
 
     // queue may stored uncorrected mapping indexes, empty them

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -352,6 +352,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
     enum extended_options {
         o_test_time = 128,
         o_ratio,
+        o_resp,
         o_pipeline,
         o_data_size_range,
         o_data_size_list,
@@ -400,6 +401,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         { "port",                       1, 0, 'p' },
         { "unix-socket",                1, 0, 'S' },
         { "protocol",                   1, 0, 'P' },
+        { "resp",                       1, 0, o_resp },
 #ifdef USE_TLS
         { "tls",                        0, 0, o_tls },
         { "cert",                       1, 0, o_tls_cert },
@@ -588,6 +590,14 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                     cfg->ratio = config_ratio(optarg);
                     if (!cfg->ratio.is_defined()) {
                         fprintf(stderr, "error: ratio must be expressed as [0-n]:[0-n].\n");
+                        return -1;
+                    }
+                    break;
+                case o_resp:
+                    endptr = NULL;
+                    cfg->resp = (unsigned int) strtoul(optarg, &endptr, 10);
+                    if (!cfg->resp || !endptr || *endptr != '\0' || cfg->resp < 2 || cfg->resp > 3) {
+                        fprintf(stderr, "error: resp must be either 2 or 3.\n");
                         return -1;
                     }
                     break;
@@ -860,6 +870,7 @@ void usage() {
             "  -P, --protocol=PROTOCOL        Protocol to use (default: redis).  Other\n"
             "                                 supported protocols are memcache_text,\n"
             "                                 memcache_binary.\n"
+            "      --resp                     RESP protocol version.\n"
             "  -a, --authenticate=CREDENTIALS Authenticate using specified credentials.\n"
             "                                 A simple password is used for memcache_text\n"
             "                                 and Redis <= 5.x. <USER>:<PASSWORD> can be\n"

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -41,12 +41,20 @@ enum key_pattern_index {
     key_pattern_get       = 2
 };
 
+enum PROTOCOL_TYPE {
+    PROTOCOL_REDIS_DEFAULT,
+    PROTOCOL_RESP2,
+    PROTOCOL_RESP3,
+    PROTOCOL_MEMCACHE_TEXT,
+    PROTOCOL_MEMCACHE_BINARY,
+};
+
 struct benchmark_config {
     const char *server;
     unsigned short port;
     struct server_addr *server_addr;
     const char *unix_socket;
-    const char *protocol;
+    enum PROTOCOL_TYPE protocol;
     const char *out_file;
     const char *client_stats;
     unsigned int run_count;
@@ -83,7 +91,6 @@ struct benchmark_config {
     unsigned int reconnect_interval;
     int multi_key_get;
     const char *authenticate;
-    unsigned int resp;
     int select_db;
     bool no_expiry;
     bool resolve_on_connect;
@@ -110,5 +117,6 @@ struct benchmark_config {
 
 extern void benchmark_log_file_line(int level, const char *filename, unsigned int line, const char *fmt, ...);
 extern void benchmark_log(int level, const char *fmt, ...);
+bool is_redis_protocol(enum PROTOCOL_TYPE type);
 
 #endif /* _MEMTIER_BENCHMARK_H */

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -83,6 +83,7 @@ struct benchmark_config {
     unsigned int reconnect_interval;
     int multi_key_get;
     const char *authenticate;
+    unsigned int resp;
     int select_db;
     bool no_expiry;
     bool resolve_on_connect;

--- a/protocol.h
+++ b/protocol.h
@@ -168,11 +168,6 @@ public:
     void clear(void);
 };
 
-enum PROTOCOL_CONFIGURATION {
-    PROTOCOL_CONF_RESP2,
-    PROTOCOL_CONF_RESP3,
-};
-
 class abstract_protocol {
 protected:
     struct evbuffer* m_read_buf;
@@ -189,7 +184,7 @@ public:
 
     virtual int select_db(int db) = 0;
     virtual int authenticate(const char *credentials) = 0;
-    virtual int configure_protocol(enum PROTOCOL_CONFIGURATION conf) = 0;
+    virtual int configure_protocol(enum PROTOCOL_TYPE type) = 0;
     virtual int write_command_cluster_slots() = 0;
     virtual int write_command_set(const char *key, int key_len, const char *value, int value_len, int expiry, unsigned int offset) = 0;
     virtual int write_command_get(const char *key, int key_len, unsigned int offset) = 0;
@@ -205,6 +200,6 @@ public:
     struct protocol_response* get_response(void) { return &m_last_response; }
 };
 
-class abstract_protocol *protocol_factory(const char *proto_name);
+class abstract_protocol *protocol_factory(enum PROTOCOL_TYPE type);
 
 #endif  /* _PROTOCOL_H */

--- a/protocol.h
+++ b/protocol.h
@@ -124,7 +124,7 @@ public:
     void set_status(const char *status);
     const char *get_status(void);
 
-    void set_error(bool error);
+    void set_error();
     bool is_error(void);
 
     void set_value(const char *value, unsigned int value_len);
@@ -168,6 +168,11 @@ public:
     void clear(void);
 };
 
+enum PROTOCOL_CONFIGURATION {
+    PROTOCOL_CONF_RESP2,
+    PROTOCOL_CONF_RESP3,
+};
+
 class abstract_protocol {
 protected:
     struct evbuffer* m_read_buf;
@@ -184,6 +189,7 @@ public:
 
     virtual int select_db(int db) = 0;
     virtual int authenticate(const char *credentials) = 0;
+    virtual int configure_protocol(enum PROTOCOL_CONFIGURATION conf) = 0;
     virtual int write_command_cluster_slots() = 0;
     virtual int write_command_set(const char *key, int key_len, const char *value, int value_len, int expiry, unsigned int offset) = 0;
     virtual int write_command_get(const char *key, int key_len, unsigned int offset) = 0;

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -253,7 +253,7 @@ int shard_connection::connect(struct connect_info* addr) {
     // set required setup commands
     m_authentication = m_config->authenticate ? setup_none : setup_done;
     m_db_selection = m_config->select_db ? setup_none : setup_done;
-    m_hello = m_config->resp != 0 ? setup_none : setup_done;
+    m_hello = (m_config->protocol == PROTOCOL_RESP2 || m_config->protocol == PROTOCOL_RESP3) ? setup_none : setup_done;
 
     // setup socket
     int sockfd = setup_socket(addr);
@@ -363,7 +363,7 @@ void shard_connection::send_conn_setup_commands(struct timeval timestamp) {
 
     if (m_hello == setup_none) {
         benchmark_debug_log("sending HELLO command.\n");
-        m_protocol->configure_protocol(m_config->resp == 3 ? PROTOCOL_CONF_RESP3 : PROTOCOL_CONF_RESP2);
+        m_protocol->configure_protocol(m_config->protocol);
         push_req(new request(rt_hello, 0, &timestamp, 0));
         m_hello = setup_sent;
     }

--- a/shard_connection.h
+++ b/shard_connection.h
@@ -37,11 +37,7 @@ class abstract_protocol;
 class object_generator;
 
 enum connection_state { conn_disconnected, conn_in_progress, conn_connected };
-
-enum configuration_state {conf_none, conf_sent, conf_done};
-enum authentication_state { auth_none, auth_sent, auth_done };
-enum select_db_state { select_none, select_sent, select_done };
-enum cluster_slots_state { slots_none, slots_sent, slots_done };
+enum setup_state {setup_none, setup_sent, setup_done};
 
 enum request_type { rt_unknown, rt_set, rt_get, rt_wait, rt_arbitrary, rt_auth, rt_select_db, rt_cluster_slots, rt_hello };
 struct request {
@@ -107,19 +103,11 @@ public:
     int send_arbitrary_command(const command_arg *arg, const char *val, int val_len);
     void send_arbitrary_command_end(size_t command_index, struct timeval* sent_time, int cmd_size);
 
-    void set_authentication() {
-        m_authentication = auth_none;
-    }
-
-    void set_select_db() {
-        m_db_selection = select_none;
-    }
-
     void set_cluster_slots() {
-        m_cluster_slots = slots_none;
+        m_cluster_slots = setup_none;
     }
 
-    enum cluster_slots_state get_cluster_slots_state() {
+    enum setup_state get_cluster_slots_state() {
         return m_cluster_slots;
     }
 
@@ -180,10 +168,10 @@ private:
 
     enum connection_state m_connection_state;
 
-    enum configuration_state m_hello;
-    enum authentication_state m_authentication;
-    enum select_db_state m_db_selection;
-    enum cluster_slots_state m_cluster_slots;
+    enum setup_state m_hello;
+    enum setup_state m_authentication;
+    enum setup_state m_db_selection;
+    enum setup_state m_cluster_slots;
 };
 
 #endif //MEMTIER_BENCHMARK_SHARD_CONNECTION_H

--- a/shard_connection.h
+++ b/shard_connection.h
@@ -38,11 +38,12 @@ class object_generator;
 
 enum connection_state { conn_disconnected, conn_in_progress, conn_connected };
 
+enum configuration_state {conf_none, conf_sent, conf_done};
 enum authentication_state { auth_none, auth_sent, auth_done };
 enum select_db_state { select_none, select_sent, select_done };
 enum cluster_slots_state { slots_none, slots_sent, slots_done };
 
-enum request_type { rt_unknown, rt_set, rt_get, rt_wait, rt_arbitrary, rt_auth, rt_select_db, rt_cluster_slots };
+enum request_type { rt_unknown, rt_set, rt_get, rt_wait, rt_arbitrary, rt_auth, rt_select_db, rt_cluster_slots, rt_hello };
 struct request {
     request_type m_type;
     struct timeval m_sent_time;
@@ -179,10 +180,10 @@ private:
 
     enum connection_state m_connection_state;
 
+    enum configuration_state m_hello;
     enum authentication_state m_authentication;
     enum select_db_state m_db_selection;
     enum cluster_slots_state m_cluster_slots;
-
 };
 
 #endif //MEMTIER_BENCHMARK_SHARD_CONNECTION_H


### PR DESCRIPTION
- add new command line argument, '--resp', to send HELLO command
  at the begining of a connection to set the RESP mode: 2 or 3.
- the redis protocol component updated to support the new RESP 3 types.
  exceptional are:
  - Push type: Maybe will be added on next phase, but need to understand better
    how and what does it mean to benchmark Redis with push commands.
  - Streamed strings & Streamed aggregated: Currently not used by Redis.