### PR TITLE
Fixed memory usage increasing over time due to per second histogram usage

### DIFF
--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -128,6 +128,7 @@ void run_stats::setup_arbitrary_commands(size_t n_arbitrary_commands) {
     m_totals.setup_arbitrary_commands(n_arbitrary_commands);
     m_cur_stats.setup_arbitrary_commands(n_arbitrary_commands);
     m_ar_commands_latency_histograms.resize(n_arbitrary_commands);
+    inst_m_ar_commands_latency_histograms.resize(n_arbitrary_commands);
 }
 
 void run_stats::set_start_time(struct timeval* start_time)

--- a/run_stats.h
+++ b/run_stats.h
@@ -97,6 +97,7 @@ protected:
     totals m_totals;
 
     std::list<one_second_stats> m_stats;
+    std::vector<float> quantiles_list;
 
     // current second stats ( appended to m_stats and reset every second )
     one_second_stats m_cur_stats;
@@ -105,6 +106,12 @@ protected:
     safe_hdr_histogram m_set_latency_histogram;
     safe_hdr_histogram m_wait_latency_histogram;
     std::vector<safe_hdr_histogram> m_ar_commands_latency_histograms;
+
+    // instantaneous command stats ( used in the per second latencies )
+    safe_hdr_histogram inst_m_get_latency_histogram;
+    safe_hdr_histogram inst_m_set_latency_histogram;
+    safe_hdr_histogram inst_m_wait_latency_histogram;
+    std::vector<safe_hdr_histogram> inst_m_ar_commands_latency_histograms;
 
     void roll_cur_stats(struct timeval* ts);
 
@@ -167,7 +174,7 @@ public:
     void print_avg_latency_column(output_table &table);
     void print_quantile_latency_column(output_table &table, double quantile, char* label);
     void print_kb_sec_column(output_table &table);
-    void print_json(json_handler *jsonhandler, arbitrary_command_list& command_list, bool cluster_mode, std::vector<float> quantile_list);
+    void print_json(json_handler *jsonhandler, arbitrary_command_list& command_list, bool cluster_mode);
     void print_histogram(FILE *out, json_handler* jsonhandler, arbitrary_command_list& command_list);
     void print(FILE *file, benchmark_config *config,
                const char* header = NULL, json_handler* jsonhandler = NULL);

--- a/run_stats_types.cpp
+++ b/run_stats_types.cpp
@@ -33,7 +33,10 @@ one_sec_cmd_stats::one_sec_cmd_stats() :
     m_misses(0),
     m_moved(0),
     m_ask(0),
-    m_total_latency(0) {
+    m_total_latency(0),
+    m_avg_latency(0.0),
+    m_max_latency(0.0),
+    m_min_latency(0.0) {
 }
 
 
@@ -45,7 +48,10 @@ void one_sec_cmd_stats::reset() {
     m_moved = 0;
     m_ask = 0;
     m_total_latency = 0;
-    hdr_reset(latency_histogram); 
+    m_avg_latency = 0;
+    m_max_latency = 0;
+    m_min_latency = 0;
+    summarized_quantile_values.clear();
 }
 
 void one_sec_cmd_stats::merge(const one_sec_cmd_stats& other) {
@@ -56,14 +62,27 @@ void one_sec_cmd_stats::merge(const one_sec_cmd_stats& other) {
     m_moved += other.m_moved;
     m_ask += other.m_ask;
     m_total_latency += other.m_total_latency;
-    hdr_add(latency_histogram,other.latency_histogram);
+    m_avg_latency = (double) m_total_latency / (double) m_ops / (double) LATENCY_HDR_RESULTS_MULTIPLIER;
+    m_max_latency = other.m_max_latency > m_max_latency ? other.m_max_latency : m_max_latency;
+    m_min_latency = other.m_min_latency < m_min_latency ? other.m_min_latency : m_min_latency;
+}
+
+void one_sec_cmd_stats::summarize_quantiles(safe_hdr_histogram histogram, std::vector<float> quantiles) {
+    const bool has_samples = m_ops>0;
+    for (std::size_t i = 0; i < quantiles.size(); i++){
+        const float quantile = quantiles[i];
+        const double value = hdr_value_at_percentile(histogram, quantile)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER;
+        summarized_quantile_values.push_back(value);
+    }
+    m_avg_latency = has_samples ? hdr_mean(histogram)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER : 0.0;
+    m_max_latency = has_samples ? hdr_max(histogram)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER : 0.0;
+    m_min_latency = has_samples ? hdr_min(histogram)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER : 0.0;
 }
 
 void one_sec_cmd_stats::update_op(unsigned int bytes, unsigned int latency) {
     m_bytes += bytes;
     m_ops++;
     m_total_latency += latency;
-    hdr_record_value(latency_histogram,latency);
 }
 
 void one_sec_cmd_stats::update_op(unsigned int bytes, unsigned int latency,
@@ -147,7 +166,6 @@ one_second_stats::one_second_stats(unsigned int second) :
 void one_second_stats::setup_arbitrary_commands(size_t n_arbitrary_commands) {
     m_ar_commands.setup(n_arbitrary_commands);
 }
-
 
 void one_second_stats::reset(unsigned int second) {
     m_second = second;

--- a/run_stats_types.cpp
+++ b/run_stats_types.cpp
@@ -35,8 +35,8 @@ one_sec_cmd_stats::one_sec_cmd_stats() :
     m_ask(0),
     m_total_latency(0),
     m_avg_latency(0.0),
-    m_max_latency(0.0),
-    m_min_latency(0.0) {
+    m_min_latency(0.0),
+    m_max_latency(0.0) {
 }
 
 

--- a/run_stats_types.h
+++ b/run_stats_types.h
@@ -82,10 +82,14 @@ public:
     unsigned int m_moved;
     unsigned int m_ask;
     unsigned long long int m_total_latency;
-    safe_hdr_histogram latency_histogram;
+    std::vector<double> summarized_quantile_values;
+    double m_avg_latency;
+    double m_min_latency;
+    double m_max_latency;
     one_sec_cmd_stats();
     void reset();
     void merge(const one_sec_cmd_stats& other);
+    void summarize_quantiles(safe_hdr_histogram histogram, std::vector<float> quantiles);
     void update_op(unsigned int bytes, unsigned int latency);
     void update_op(unsigned int bytes, unsigned int latency, unsigned int hits, unsigned int misses);
     void update_moved_op(unsigned int bytes, unsigned int latency);


### PR DESCRIPTION
Fixes #157 . 
Instead of keeping the raw histograms per second, we keep the computed percentiles that we need to store at the end of the benchmark. 

Using @weisiw script to check the memory we can confirm that the issue is gone 
![image](https://user-images.githubusercontent.com/5832149/181752606-0dbc1a91-0d48-49bb-962a-79b0c65cfd90.png)
