### PR TITLE
Randomize values' contents for each client independently.

### DIFF
--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -440,7 +440,7 @@ const char* object_generator::get_value(unsigned long long key_index, unsigned i
 
     // modify object content in case of random data
     if (m_random_data) {
-        m_value_buffer[m_value_buffer_mutation_pos++]++;
+        m_value_buffer[m_value_buffer_mutation_pos++] += m_random.get_random();
         if (m_value_buffer_mutation_pos >= m_value_buffer_size)
             m_value_buffer_mutation_pos = 0;
     }


### PR DESCRIPTION
Currently all clients sends the same sequence of data contents.

This change allows per-client randomization in case --distinct-client-seed is passed.

Signed-off-by: Roman Gershman <romange@gmail.com>