### PR TITLE
Upgrade CI Python version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.10'
         architecture: x64
 
     - name: Install Python dependencies


### PR DESCRIPTION
The current version is broken as Python 3.6 is no longer available.