### PR TITLE
Always print out stderr/out output on test failures.

### DIFF
--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -24,13 +24,11 @@ def test_default_set_get(env):
 
     # benchmark.run() returns True if the return code of memtier_benchmark was 0
     memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env, memtier_ok)
 
     master_nodes_connections = env.getOSSMasterNodesConnectionList()
     merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
-    assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
-                                    overall_request_count)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
 
 
 def test_default_set_get_with_print_percentiles(env):
@@ -54,13 +52,11 @@ def test_default_set_get_with_print_percentiles(env):
 
     # benchmark.run() returns True if the return code of memtier_benchmark was 0
     memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env, memtier_ok)
 
     master_nodes_connections = env.getOSSMasterNodesConnectionList()
     merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
-    assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
-                                    overall_request_count)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
     json_filename = '{0}/mb.json'.format(config.results_dir)
 
     hdr_files_sufix = ["_FULL_RUN_1","_SET_command_run_1","_GET_command_run_1"]
@@ -103,13 +99,11 @@ def test_default_set_get_1_1(env):
 
     # benchmark.run() returns True if the return code of memtier_benchmark was 0
     memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env, memtier_ok)
 
     master_nodes_connections = env.getOSSMasterNodesConnectionList()
     merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
-    assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
-                                    overall_request_count)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
 
     # assert same number of gets and sets
     env.assertEqual(merged_command_stats['cmdstat_set']['calls'], merged_command_stats['cmdstat_get']['calls'])
@@ -136,13 +130,11 @@ def test_default_set_get_3_runs(env):
 
     # benchmark.run() returns True if the return code of memtier_benchmark was 0
     memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env, memtier_ok)
 
     master_nodes_connections = env.getOSSMasterNodesConnectionList()
     merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
-    assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
-                                    overall_request_count)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
 
 
 def test_default_arbitrary_command_pubsub(env):
@@ -151,7 +143,6 @@ def test_default_arbitrary_command_pubsub(env):
     addTLSArgs(benchmark_specs, env)
     config = get_default_memtier_config()
     master_nodes_list = env.getMasterNodesList()
-    overall_expected_request_count = 0
 
     add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
 
@@ -163,9 +154,8 @@ def test_default_arbitrary_command_pubsub(env):
 
     benchmark = Benchmark.from_json(config, benchmark_specs)
 
-    # benchmark.run() returns True if the return code of memtier_benchmark was 0
-    memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env, memtier_ok)
+    if not benchmark.run():
+        debugPrintMemtierOnError(config, env)
 
 
 def test_default_arbitrary_command_set(env):
@@ -188,13 +178,11 @@ def test_default_arbitrary_command_set(env):
 
     # benchmark.run() returns True if the return code of memtier_benchmark was 0
     memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env, memtier_ok)
 
     master_nodes_connections = env.getOSSMasterNodesConnectionList()
     merged_command_stats = {'cmdstat_set': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
-    assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
-                                    overall_request_count)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
 
 
 def test_default_arbitrary_command_hset(env):
@@ -217,10 +205,9 @@ def test_default_arbitrary_command_hset(env):
 
     # benchmark.run() returns True if the return code of memtier_benchmark was 0
     memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env, memtier_ok)
 
     master_nodes_connections = env.getOSSMasterNodesConnectionList()
     merged_command_stats = {'cmdstat_hset': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
-    assert_minimum_memtier_outcomes(config, env, memtier_ok, merged_command_stats, overall_expected_request_count,
-                                    overall_request_count)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
+


### PR DESCRIPTION
Also do some minor cleanups around unused args.