### PR TITLE
Fix incorrect calculation of weighted average of elapsed time

### DIFF
--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -104,9 +104,12 @@ inline unsigned long int ts_diff_now(struct timeval a)
 inline timeval timeval_factorial_average(timeval a, timeval b, unsigned int weight)
 {
     timeval tv;
-    double factor = ((double)weight - 1) / weight;
-    tv.tv_sec   = factor * a.tv_sec  + (double)b.tv_sec  / weight ;
-    tv.tv_usec  = factor * a.tv_usec + (double)b.tv_usec / weight ;
+    unsigned long long a_usec = a.tv_sec * 1000000 + a.tv_usec;
+    unsigned long long b_usec = b.tv_sec * 1000000 + b.tv_usec;
+    unsigned long long average = (a_usec * (weight - 1) + b_usec) / weight;
+
+    tv.tv_sec = average / 1000000;
+    tv.tv_usec = average % 1000000;
     return (tv);
 }
 


### PR DESCRIPTION
Hello,

I found that `timeval_factorial_average` function calculated incorrect the average of the elapsed time, so I fixed it.

The original version calculates averages separately for seconds and microseconds.
This sometimes causes the average of X and X to be X-1 and the measured throughputs to be unstable.
I have even seen the total average time become negative.

This code below shows an example of the parameters that causes incorrect calculation.

```
#include <assert.h>
#include <stdio.h>
#include <sys/time.h>

typedef struct timeval timeval;

// original version
inline timeval timeval_factorial_average(timeval a, timeval b,
                                         unsigned int weight) {
  timeval tv;
  double factor = ((double)weight - 1) / weight;
  tv.tv_sec = factor * a.tv_sec + (double)b.tv_sec / weight;
  tv.tv_usec = factor * a.tv_usec + (double)b.tv_usec / weight;
  return (tv);
}

int main() {
  timeval x = {1677215184, 515990}; // Fri, 24 Feb 2023 05:06:24 GMT
  timeval y = timeval_factorial_average(x, x, 7); // y must be the same as x

  printf("x.tv_sec = %ld, x.tv_usec = %ld\n", x.tv_sec, x.tv_usec);
  printf("y.tv_sec = %ld, y.tv_usec = %ld\n", y.tv_sec, y.tv_usec);

  assert(x.tv_sec == y.tv_sec && x.tv_usec == y.tv_usec); // this assertion fails

  return 0;
}
```

Thank you.
