### PR TITLE
Fix issue #211. Allow key_stddev and key_median options to be set values

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -694,7 +694,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                     break;
                 case o_key_stddev:
                     endptr = NULL;
-                    cfg->key_stddev = (unsigned int) strtof(optarg, &endptr);
+                    cfg->key_stddev = strtod(optarg, &endptr);
                     if (cfg->key_stddev<= 0 || !endptr || *endptr != '\0') {
                         fprintf(stderr, "error: key-stddev must be greater than zero.\n");
                         return -1;
@@ -702,7 +702,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                     break;
                 case o_key_median:
                     endptr = NULL;
-                    cfg->key_median = (unsigned int) strtof(optarg, &endptr);
+                    cfg->key_median = strtod(optarg, &endptr);
                     if (cfg->key_median<= 0 || !endptr || *endptr != '\0') {
                         fprintf(stderr, "error: key-median must be greater than zero.\n");
                         return -1;


### PR DESCRIPTION
I have fixed issue 211.
This changed key_stddev and key_median to read as unsigned long long.
In real-world use cases, the key ranges will be wide enough that the fractional portions will not matter.
