### PR TITLE
Support forcing of IPv4/IPv6 resolution.

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -178,9 +178,14 @@ int client::connect(void)
         }
 
         // Just in case we got domain name and not ip, we convert it
-        struct sockaddr_in *ipv4 = (struct sockaddr_in *)addr.ci_addr;
-        char address[INET_ADDRSTRLEN];
-        inet_ntop(AF_INET, &(ipv4->sin_addr), address, INET_ADDRSTRLEN);
+        char address[INET6_ADDRSTRLEN];
+        if (addr.ci_family == PF_INET) {
+            struct sockaddr_in *ipv4 = (struct sockaddr_in *)addr.ci_addr;
+            inet_ntop(AF_INET, &(ipv4->sin_addr), address, INET_ADDRSTRLEN);
+        } else {
+            struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)addr.ci_addr;
+            inet_ntop(AF_INET6, &(ipv6->sin6_addr), address, INET6_ADDRSTRLEN);
+        }
 
         char port_str[20];
         snprintf(port_str, sizeof(port_str)-1, "%u", m_config->port);

--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -194,7 +194,7 @@ bool cluster_client::connect_shard_connection(shard_connection* sc, char* addres
     memset(&hints, 0, sizeof(hints));
     hints.ai_flags = AI_PASSIVE;
     hints.ai_socktype = SOCK_STREAM;
-    hints.ai_family = AF_INET;
+    hints.ai_family = AF_UNSPEC;
 
     int res = getaddrinfo(address, port, &hints, &addr_info);
     if (res != 0) {

--- a/config_types.cpp
+++ b/config_types.cpp
@@ -225,8 +225,8 @@ const char* config_weight_list::print(char *buf, int buf_len)
 }
 
 
-server_addr::server_addr(const char *hostname, int port) :
-    m_hostname(hostname), m_port(port), m_server_addr(NULL), m_used_addr(NULL), m_last_error(0)
+server_addr::server_addr(const char *hostname, int port, int resolution) :
+    m_hostname(hostname), m_port(port), m_server_addr(NULL), m_used_addr(NULL), m_resolution(resolution), m_last_error(0)
 {
     int error = resolve();
 
@@ -254,7 +254,7 @@ int server_addr::resolve(void)
     memset(&hints, 0, sizeof(hints));
     hints.ai_flags = AI_PASSIVE;
     hints.ai_socktype = SOCK_STREAM;
-    hints.ai_family = PF_UNSPEC;
+    hints.ai_family = m_resolution;
 
     snprintf(port_str, sizeof(port_str)-1, "%u", m_port);
     m_last_error = getaddrinfo(m_hostname.c_str(), port_str, &hints, &m_server_addr);

--- a/config_types.h
+++ b/config_types.h
@@ -86,7 +86,7 @@ struct connect_info {
 };
 
 struct server_addr {
-    server_addr(const char *hostname, int port);
+    server_addr(const char *hostname, int port, int resolution);
     virtual ~server_addr();
 
     int get_connect_info(struct connect_info *ci);
@@ -99,6 +99,7 @@ protected:
     int m_port;
     struct addrinfo *m_server_addr;
     struct addrinfo *m_used_addr;
+    int m_resolution;
     int m_last_error;
 };
 

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -99,7 +99,7 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
         "server = %s\n"
         "port = %u\n"
         "unix socket = %s\n"
-        "resolution %s\n"
+        "address family = %s\n"
         "protocol = %s\n"
 #ifdef USE_TLS
         "tls = %s\n"
@@ -205,7 +205,7 @@ static void config_print_to_json(json_handler * jsonhandler, struct benchmark_co
     jsonhandler->write_obj("server"            ,"\"%s\"",      	cfg->server);
     jsonhandler->write_obj("port"              ,"%u",          	cfg->port);
     jsonhandler->write_obj("unix socket"       ,"\"%s\"",      	cfg->unix_socket);
-    jsonhandler->write_obj("resolution"        ,"\"%s\"",      	cfg->resolution == AF_UNSPEC ? "Unspecified" : cfg->resolution == AF_INET ? "AF_INET" : "AF_INET6");
+    jsonhandler->write_obj("address family"    ,"\"%s\"",      	cfg->resolution == AF_UNSPEC ? "Unspecified" : cfg->resolution == AF_INET ? "AF_INET" : "AF_INET6");
     jsonhandler->write_obj("protocol"          ,"\"%s\"",      	get_protocol_name(cfg->protocol));
     jsonhandler->write_obj("out_file"          ,"\"%s\"",      	cfg->out_file);
 #ifdef USE_TLS

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -54,6 +54,7 @@ struct benchmark_config {
     unsigned short port;
     struct server_addr *server_addr;
     const char *unix_socket;
+    int resolution;
     enum PROTOCOL_TYPE protocol;
     const char *out_file;
     const char *client_stats;


### PR DESCRIPTION
Add new --ipv4 (-4) and --ipv6 (-6) command line options to force address resolution.

The default value is unspecified, and we will try resolving both.