### PR TITLE
CI: bump Ubuntu runner version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        platform: [ubuntu-latest, ubuntu-18.04]
+        platform: [ubuntu-latest, ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 18.04 is no longer supported by GitHub.