### PR TITLE
Restoring docker build

### DIFF
--- a/.github/workflows/dockers.yml
+++ b/.github/workflows/dockers.yml
@@ -1,0 +1,56 @@
+---
+
+name: Build dockers
+
+on:
+
+  push:
+    branches:
+      - master
+
+  workflow_dispatch:
+
+jobs:
+
+  docker:
+    name: Build dockers
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: tell me
+        run: |
+          set
+          echo Ref ${{github.ref}}
+          echo Event ${{github.event_name}}
+          echo Tag ${{github.event.release.tag_name}}
+
+      - name: build and push in master
+        uses: docker/build-push-action@v4
+        if: ${{ github.event.release.tag_name == '' }}
+        with:
+          push: true
+          tags: redislabs/memtier-benchmark:edge
+          context: .
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+
+      - name: build and push on release
+        uses: docker/build-push-action@v4
+        if: ${{ github.event.release.tag_name != '' }}
+        with:
+          push: true
+          tags: redislabs/memtier-benchmark:${{ github.event.release.tag_name }}
+          context: .
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7


### PR DESCRIPTION
It appears that github actions did not kick off, due to the inclusion of a tags specifier, in the push definition. This PR removes that.

Similarly, it appears that this is somehow not merged into master, though the git log shows it is. Hence, the PR.
