### PR TITLE
Issue #94, test hangs in cluster mode

### DIFF
--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -289,6 +289,10 @@ void shard_connection::disconnect() {
     }
     m_bev = NULL;
 
+    // empty pipeline
+    while (m_pending_resp)
+        delete pop_req();
+
     m_connection_state = conn_disconnected;
 
     // by default no need to send any setup request


### PR DESCRIPTION
When a connection is dropped, it needs to empty its pipeline of pending responses, so in case of reconnection, it won't hang waiting for old requests.