### PR TITLE
Enable specifying the tls protocol version to use via --tls-protocols argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,18 @@ jobs:
       run: |
         TLS=1 ./tests/run_tests.sh
 
+    - name: Test OSS TCP TLS v1.2
+      if: matrix.platform == 'ubuntu-latest'
+      timeout-minutes: 10
+      run: |
+        TLS_PROTOCOLS="tlsv1.2" TLS=1 ./tests/run_tests.sh
+
+    - name: Test OSS TCP TLS v1.3
+      if: matrix.platform == 'ubuntu-latest'
+      timeout-minutes: 10
+      run: |
+        TLS_PROTOCOLS="tlsv1.3" TLS=1 ./tests/run_tests.sh
+
     - name: Test OSS-CLUSTER TCP
       timeout-minutes: 10
       run: |

--- a/config_types.cpp
+++ b/config_types.cpp
@@ -92,7 +92,6 @@ config_quantiles::config_quantiles(){
 
 }
 
-
 config_quantiles::config_quantiles(const char *str)
 {
     assert(str != NULL);

--- a/config_types.cpp
+++ b/config_types.cpp
@@ -92,6 +92,7 @@ config_quantiles::config_quantiles(){
 
 }
 
+
 config_quantiles::config_quantiles(const char *str)
 {
     assert(str != NULL);

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -39,6 +39,19 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+
+#define REDIS_TLS_PROTO_TLSv1       (1<<0)
+#define REDIS_TLS_PROTO_TLSv1_1     (1<<1)
+#define REDIS_TLS_PROTO_TLSv1_2     (1<<2)
+#define REDIS_TLS_PROTO_TLSv1_3     (1<<3)
+
+/* Use safe defaults */
+#ifdef TLS1_3_VERSION
+#define REDIS_TLS_PROTO_DEFAULT     (REDIS_TLS_PROTO_TLSv1_2|REDIS_TLS_PROTO_TLSv1_3)
+#else
+#define REDIS_TLS_PROTO_DEFAULT     (REDIS_TLS_PROTO_TLSv1_2)
+#endif
+
 #endif
 
 #include <stdexcept>
@@ -296,6 +309,8 @@ static void config_init_defaults(struct benchmark_config *cfg)
         cfg->hdr_prefix = "";
     if (!cfg->print_percentiles.is_defined())
         cfg->print_percentiles = config_quantiles("50,99,99.9");
+    if (!cfg->tls_protocols)
+        cfg->tls_protocols = REDIS_TLS_PROTO_DEFAULT;
 }
 
 static int generate_random_seed()
@@ -404,6 +419,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_tls_cacert,
         o_tls_skip_verify,
         o_tls_sni,
+        o_tls_protocols,
         o_hdr_file_prefix,
         o_help
     };
@@ -423,6 +439,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         { "cacert",                     1, 0, o_tls_cacert },
         { "tls-skip-verify",            0, 0, o_tls_skip_verify },
         { "sni",                        1, 0, o_tls_sni },
+        { "tls-protocols",              1, 0, o_tls_protocols },
 #endif
         { "out-file",                   1, 0, 'o' },
         { "hdr-file-prefix",            1, 0, o_hdr_file_prefix },
@@ -863,6 +880,35 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                 case o_tls_sni:
                     cfg->tls_sni = optarg;
                     break;
+                case o_tls_protocols:
+                {
+                    const char tls_delimiter = ',';
+                    char* tls_token = strtok(optarg, &tls_delimiter);
+                    // Loop through the tokens and print them
+                    while (tls_token != nullptr) {
+                        if (!strcasecmp(tls_token, "tlsv1"))
+                            cfg->tls_protocols |= REDIS_TLS_PROTO_TLSv1;
+                        else if (!strcasecmp(tls_token, "tlsv1.1"))
+                            cfg->tls_protocols |= REDIS_TLS_PROTO_TLSv1_1;
+                        else if (!strcasecmp(tls_token, "tlsv1.2"))
+                            cfg->tls_protocols |= REDIS_TLS_PROTO_TLSv1_2;
+                        else if (!strcasecmp(tls_token, "tlsv1.3")) {
+    #ifdef TLS1_3_VERSION
+                            cfg->tls_protocols |= REDIS_TLS_PROTO_TLSv1_3;
+    #else
+                            fprintf(stderr, "TLSv1.3 is specified in tls-protocols but not supported by OpenSSL.");
+                            return -1;
+    #endif
+                        } else {
+                            fprintf(stderr, "Invalid tls-protocols specified. "
+                                    "Use a combination of 'TLSv1', 'TLSv1.1', 'TLSv1.2' and 'TLSv1.3'.");
+                            return -1;
+                            break;
+                        }
+                        tls_token = strtok(nullptr, &tls_delimiter);
+                    }
+                    break;
+                }
 #endif
             default:
                     return -1;
@@ -903,6 +949,7 @@ void usage() {
             "      --key=FILE                 Use specified private key for TLS\n"
             "      --cacert=FILE              Use specified CA certs bundle for TLS\n"
             "      --tls-skip-verify          Skip verification of server certificate\n"
+            "      --tls-protocols            Specify the tls protocol version to use, comma delemited. Use a combination of 'TLSv1', 'TLSv1.1', 'TLSv1.2' and 'TLSv1.3'"
             "      --sni=STRING               Add an SNI header\n"
 #endif
             "  -x, --run-count=NUMBER         Number of full-test iterations to perform\n"
@@ -1310,6 +1357,15 @@ int main(int argc, char *argv[])
 
         cfg.openssl_ctx = SSL_CTX_new(SSLv23_client_method());
         SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+
+        if (!(cfg.tls_protocols & REDIS_TLS_PROTO_TLSv1))
+            SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1);
+        if (!(cfg.tls_protocols & REDIS_TLS_PROTO_TLSv1_1))
+            SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1_1);
+        if (!(cfg.tls_protocols & REDIS_TLS_PROTO_TLSv1_2))
+            SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1_2);
+        if (!(cfg.tls_protocols & REDIS_TLS_PROTO_TLSv1_3))
+            SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1_3);
 
         if (cfg.tls_cert) {
             if (!SSL_CTX_use_certificate_chain_file(cfg.openssl_ctx, cfg.tls_cert)) {

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -884,7 +884,6 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                 {
                     const char tls_delimiter = ',';
                     char* tls_token = strtok(optarg, &tls_delimiter);
-                    // Loop through the tokens and print them
                     while (tls_token != nullptr) {
                         if (!strcasecmp(tls_token, "tlsv1"))
                             cfg->tls_protocols |= REDIS_TLS_PROTO_TLSv1;

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -111,6 +111,7 @@ struct benchmark_config {
     const char *tls_cacert;
     bool tls_skip_verify;
     const char *tls_sni;
+    int tls_protocols;
     SSL_CTX *openssl_ctx;
 #endif
 };

--- a/tests/include.py
+++ b/tests/include.py
@@ -10,7 +10,7 @@ TLS_PROTOCOLS = os.environ.get("TLS_PROTOCOLS", "")
 
 def ensure_tls_protocols(master_nodes_connections):
     if TLS_PROTOCOLS != "":
-        # ensure if we run again on a different key pattern the dataset doesn't grow
+        # if we've specified the TLS_PROTOCOLS env variable ensure the server enforces thos protocol versions
         for master_connection in master_nodes_connections:
             master_connection.execute_command("CONFIG", "SET", "tls-protocols", TLS_PROTOCOLS)
 

--- a/tests/include.py
+++ b/tests/include.py
@@ -5,6 +5,14 @@ MEMTIER_BINARY = os.environ.get("MEMTIER_BINARY", "memtier_benchmark")
 TLS_CERT = os.environ.get("TLS_CERT", "")
 TLS_KEY = os.environ.get("TLS_KEY", "")
 TLS_CACERT = os.environ.get("TLS_CACERT", "")
+TLS_PROTOCOLS = os.environ.get("TLS_PROTOCOLS", "")
+
+
+def ensure_tls_protocols(master_nodes_connections):
+    if TLS_PROTOCOLS != "":
+        # ensure if we run again on a different key pattern the dataset doesn't grow
+        for master_connection in master_nodes_connections:
+            master_connection.execute_command("CONFIG", "SET", "tls-protocols", TLS_PROTOCOLS)
 
 
 def assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count,
@@ -24,6 +32,10 @@ def assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_re
             debugPrintMemtierOnError(config, env)
 
 def add_required_env_arguments(benchmark_specs, config, env, master_nodes_list):
+    # if we've specified TLS_PROTOCOLS ensure we configure it on redis
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+    ensure_tls_protocols(master_nodes_connections)
+
     # check if environment is cluster
     if env.isCluster():
         benchmark_specs["args"].append("--cluster-mode")
@@ -91,6 +103,8 @@ def addTLSArgs(benchmark_specs, env):
             benchmark_specs['args'].append('--key={}'.format(TLS_KEY))
         else:
             benchmark_specs['args'].append('--tls-skip-verify')
+        if TLS_PROTOCOLS != "":
+            benchmark_specs['args'].append('--tls-protocols={}'.format(TLS_PROTOCOLS))
             
 
 


### PR DESCRIPTION
By default it will always try to use v1.2 and v1.3. 
It allows specifying multiple versions via comma delimiter. 

# Examples:

## Using either v1.1 or v1.2
```
./memtier_benchmark   --cert ~/redislabs/redis/tests/tls/redis.crt     --key ~/redislabs/redis/tests/tls/redis.key --cacert ~/redislabs/redis/tests/tls/ca.crt  -c 1 -t 1 --tls --hide-histogram --tls-protocols tlsv1.1,tlsv1.2
```

Confirmation of data capture that indeed we're using v1.2:
![image](https://github.com/RedisLabs/memtier_benchmark/assets/5832149/1c0989e7-e0e2-4b5a-9cb4-0c782cf848ee)



## Using only v1.3
```
./memtier_benchmark   --cert ~/redislabs/redis/tests/tls/redis.crt     --key ~/redislabs/redis/tests/tls/redis.key --cacert ~/redislabs/redis/tests/tls/ca.crt  -c 1 -t 1 --tls --hide-histogram --tls-protocols tlsv1.3
```

Confirmation of data capture that indeed we're using v1.3:
![image](https://github.com/RedisLabs/memtier_benchmark/assets/5832149/e9655108-4079-448f-97ee-db5ea651c121)

## Trying to use an non allowed version by the server (v1.1) -- check error

```
$ ./memtier_benchmark   --cert ~/redislabs/redis/tests/tls/redis.crt     --key ~/redislabs/redis/tests/tls/redis.key --cacert ~/redislabs/redis/tests/tls/ca.crt  -c 1 -t 1 --tls --hide-histogram --tls-protocols tlsv1.1 -n 2
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
TLS connection error: no protocols available
TLS connection error: (null)
[RUN #1 0%,   0 secs]  0 threads:           0 ops,       0 (avg:       0) ops/sec, 0.00KB/sec (avg: 0.00KB/sec),  0.00 (avg:  0.00) msec latency

1         Threads
1         Connections per thread
2         Requests per client


ALL STATS
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets            0.00          ---          ---             ---             ---             ---             ---         0.00 
Gets            0.00         0.00         0.00             ---             ---             ---             ---         0.00 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals          0.00         0.00         0.00            -nan         0.00000         0.00000         0.00000         0.00 

```