### PR TITLE
Avoid c++11 nullptr and use 0 on null comparison

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -884,7 +884,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                 {
                     const char tls_delimiter = ',';
                     char* tls_token = strtok(optarg, &tls_delimiter);
-                    while (tls_token != nullptr) {
+                    while (tls_token != 0) {
                         if (!strcasecmp(tls_token, "tlsv1"))
                             cfg->tls_protocols |= REDIS_TLS_PROTO_TLSv1;
                         else if (!strcasecmp(tls_token, "tlsv1.1"))
@@ -904,7 +904,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                             return -1;
                             break;
                         }
-                        tls_token = strtok(nullptr, &tls_delimiter);
+                        tls_token = strtok(0, &tls_delimiter);
                     }
                     break;
                 }


### PR DESCRIPTION
Fixes #235 

nullptr was introduced in c++11 and if your compiler does not support it will happen the error of #235 . This PR addresses it.

Reference: https://www.stroustrup.com/bs_faq2.html#null