### PR TITLE
improve the performance of imported_keylist deconstruction

### DIFF
--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -529,10 +529,10 @@ imported_keylist::imported_keylist(const char *filename)
 
 imported_keylist::~imported_keylist()
 {
-    while (!m_keys.empty()) {
-        free(m_keys.front());
-        m_keys.erase(m_keys.begin());
+    for (unsigned int i = 0; i < m_keys.size(); i++) {
+        free(m_keys[i]);
     }
+    m_keys.clear();
 }
 
 bool imported_keylist::read_keys(void)


### PR DESCRIPTION
# Problem
When I run `memtier_benchmark` with `--data-import` (including 500000 keys),  it took a long time to quit after benchmark finished. 
With pstack, I found the process was waiting in `~imported_keylist()`
```
...
#6  std::vector<imported_keylist::key*, std::allocator<imported_keylist::key*> >::erase (__position=..., this=0x1e685e8) at /usr/include/c++/9/bits/stl_vector.h:1428
#7  imported_keylist::~imported_keylist (this=0x1e685e0, __in_chrg=<optimized out>) at obj_gen.cpp:534
#8  0x0000000000407a1a in main (argc=<optimized out>, argv=<optimized out>) at memtier_benchmark.cpp:1641
```

# Solution
`erase()` one by one for a dead vector wastes some time. So I replaced `erase()` with `clear()`, which makes it much faster. 