### PR TITLE
see #238, data import broken

### DIFF
--- a/client.h
+++ b/client.h
@@ -45,7 +45,6 @@ class client;
 class client_group;
 struct benchmark_config;
 class object_generator;
-class data_object;
 
 #define SET_CMD_IDX 0
 #define GET_CMD_IDX 2
@@ -60,10 +59,6 @@ protected:
     struct event_base* m_event_base;
     bool m_initialized;
     bool m_end_set;
-
-    // key buffer
-    char m_key_buffer[250];
-    int m_key_len;
 
     // test related
     benchmark_config* m_config;
@@ -93,10 +88,10 @@ public:
 
     virtual get_key_response get_key_for_conn(unsigned int command_index, unsigned int conn_id, unsigned long long* key_index);
     virtual bool create_arbitrary_request(unsigned int command_index, struct timeval& timestamp, unsigned int conn_id);
-    bool create_wait_request(struct timeval& timestamp, unsigned int conn_id);
-    bool create_set_request(struct timeval& timestamp, unsigned int conn_id);
-    bool create_get_request(struct timeval& timestamp, unsigned int conn_id);
-    bool create_mget_request(struct timeval& timestamp, unsigned int conn_id);
+    virtual bool create_wait_request(struct timeval& timestamp, unsigned int conn_id);
+    virtual bool create_set_request(struct timeval& timestamp, unsigned int conn_id);
+    virtual bool create_get_request(struct timeval& timestamp, unsigned int conn_id);
+    virtual bool create_mget_request(struct timeval& timestamp, unsigned int conn_id);
 
     // client manager api's
     unsigned long long get_reqs_processed() {
@@ -185,7 +180,10 @@ protected:
     unsigned long long int m_errors;
 
     virtual bool finished(void);
-    virtual void create_request(struct timeval timestamp, unsigned int conn_id);
+    virtual bool create_wait_request(struct timeval& timestamp, unsigned int conn_id);
+    virtual bool create_set_request(struct timeval& timestamp, unsigned int conn_id);
+    virtual bool create_get_request(struct timeval& timestamp, unsigned int conn_id);
+    virtual bool create_mget_request(struct timeval& timestamp, unsigned int conn_id);
     virtual void handle_response(unsigned int conn_id, struct timeval timestamp,
                                  request *request, protocol_response *response);
 public:

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1484,6 +1484,11 @@ int main(int argc, char *argv[])
         }
         assert(obj_gen != NULL);
     } else {
+        // oss cluster API can't be enabled
+        if (cfg.cluster_mode) {
+            fprintf(stderr, "error: Cluster mode cannot be specified when importing.\n");
+            exit(1);
+        }
         // check paramters
         if (cfg.data_size ||
             cfg.data_size_list.is_defined() ||

--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -382,37 +382,9 @@ unsigned long long object_generator::get_key_index(int iter)
     return k;
 }
 
-const char* object_generator::get_key(int iter, unsigned int *len)
-{
-    unsigned int l;
-    m_key_index = get_key_index(iter);
-
-    // format key
-    l = snprintf(m_key_buffer, sizeof(m_key_buffer)-1,
-        "%s%llu", m_key_prefix, m_key_index);
-    if (len != NULL) *len = l;
-
-    return m_key_buffer;
-}
-
-data_object* object_generator::get_object(int iter)
-{
-    // compute key
-    (void) get_key(iter, NULL);
-
-    // compute value
-    unsigned int new_size = 0;
-    get_value(m_key_index, &new_size);
-
-    // compute expiry
-    unsigned int expiry = get_expiry();
-
-    // set object
-    m_object.set_key(m_key_buffer, strlen(m_key_buffer));
-    m_object.set_value(m_value_buffer, new_size);
-    m_object.set_expiry(expiry);
-
-    return &m_object;
+void object_generator::generate_key(unsigned long long key_index) {
+    m_key_len = snprintf(m_key_buffer, sizeof(m_key_buffer)-1, "%s%llu", m_key_prefix, key_index);
+    m_key = m_key_buffer;
 }
 
 const char* object_generator::get_key_prefix() {
@@ -457,67 +429,6 @@ unsigned int object_generator::get_expiry() {
     }
 
     return expiry;
-}
-
-///////////////////////////////////////////////////////////////////////////
-
-data_object::data_object() :
-    m_key(NULL), m_key_len(0),
-    m_value(NULL), m_value_len(0),
-    m_expiry(0)
-{
-}
-
-data_object::~data_object()
-{
-    clear();
-}
-
-void data_object::clear(void)
-{
-    m_key = NULL;
-    m_key_len = 0;
-    m_value = NULL;
-    m_value_len = 0;
-    m_expiry = 0;
-}
-
-void data_object::set_key(const char* key, unsigned int key_len)
-{
-    m_key = key;
-    m_key_len = key_len;
-}
-
-const char* data_object::get_key(unsigned int* key_len)
-{
-    assert(key_len != NULL);
-    *key_len = m_key_len;
-
-    return m_key;
-}
-
-void data_object::set_value(const char* value, unsigned int value_len)
-{
-    m_value = value;
-    m_value_len = value_len;
-}
-
-const char* data_object::get_value(unsigned int *value_len)
-{
-    assert(value_len != NULL);
-    *value_len = m_value_len;
-
-    return m_value;
-}
-
-void data_object::set_expiry(unsigned int expiry)
-{
-    m_expiry = expiry;
-}
-
-unsigned int data_object::get_expiry(void)
-{
-    return m_expiry;
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -623,18 +534,8 @@ import_object_generator* import_object_generator::clone(void)
     return new import_object_generator(*this);
 }
 
-const char* import_object_generator::get_key(int iter, unsigned int *len)
-{
-    if (m_keys == NULL) {
-        return object_generator::get_key(iter, len);
-    } else {
-        unsigned int k = get_key_index(iter) - 1;
-        return m_keys->get(k, len);
-    }
-}
-
-data_object* import_object_generator::get_object(int iter)
-{
+void import_object_generator::read_next_item() {
+    /* Used by SET command to read an item that includes  KEY, VALUE, EXPIRE */
     memcache_item *i = m_reader.read_item();
 
     if (i == NULL && m_reader.is_eof()) {
@@ -648,26 +549,34 @@ data_object* import_object_generator::get_object(int iter)
     }
     m_cur_item = i;
 
-    m_object.set_value(m_cur_item->get_data(), m_cur_item->get_nbytes() - 2);
-    if (m_keys != NULL) {
-        m_object.set_key(m_cur_item->get_key(), m_cur_item->get_nkey());
-    } else {
-        unsigned int tmplen;
-        const char *tmpkey = object_generator::get_key(iter, &tmplen);
-        m_object.set_key(tmpkey, tmplen);
-    }
+    m_key = m_cur_item->get_key();
+    m_key_len = m_cur_item->get_nkey();
+}
+
+void import_object_generator::read_next_key(unsigned long long key_index) {
+    /* Used by GET command that needs only a KEY */
+    m_key = m_keys->get(key_index-1, (unsigned int *)&m_key_len);
+}
+
+const char* import_object_generator::get_value(unsigned long long key_index, unsigned int *len) {
+    assert(m_cur_item != NULL);
+
+    *len = m_cur_item->get_nbytes() - 2;
+    return m_cur_item->get_data();
+}
+
+unsigned int import_object_generator::get_expiry() {
+    assert(m_cur_item != NULL);
 
     // compute expiry
-    int expiry = 0;
+    unsigned int expiry = 0;
     if (!m_no_expiry) {
         if (m_expiry_max > 0) {
             expiry = random_range(m_expiry_min, m_expiry_max);
         } else {
             expiry = m_cur_item->get_exptime();
         }
-        m_object.set_expiry(expiry);
     }
 
-    return &m_object;
+    return expiry;
 }
-

--- a/obj_gen.h
+++ b/obj_gen.h
@@ -50,26 +50,6 @@ private:
 	double m_spare;
 };
 
-class data_object {
-protected:
-    const char *m_key;
-    unsigned int m_key_len;
-    const char *m_value;
-    unsigned int m_value_len;
-    unsigned int m_expiry;
-public:
-    data_object();
-    ~data_object();
-
-    void clear(void);
-    void set_key(const char* key, unsigned int key_len);
-    const char* get_key(unsigned int* key_len);
-    void set_value(const char* value, unsigned int value_len);
-    const char* get_value(unsigned int* value_len);
-    void set_expiry(unsigned int expiry);
-    unsigned int get_expiry(void);
-};
-
 #define OBJECT_GENERATOR_KEY_ITERATORS  2 /* number of iterators */
 #define OBJECT_GENERATOR_KEY_SET_ITER   1
 #define OBJECT_GENERATOR_KEY_GET_ITER   0
@@ -98,12 +78,13 @@ protected:
     unsigned long long m_key_max;
     double m_key_stddev;
     double m_key_median;
-    data_object m_object;
 
     std::vector<unsigned long long> m_next_key;
 
     unsigned long long m_key_index;
     char m_key_buffer[250];
+    const char *m_key;
+    int m_key_len;
     char *m_value_buffer;
     int m_random_fd;
     gaussian_noise m_random;
@@ -132,14 +113,14 @@ public:
     void set_key_range(unsigned long long key_min, unsigned long long key_max);
     void set_key_distribution(double key_stddev, double key_median);
     void set_random_seed(int seed);
-
     unsigned long long get_key_index(int iter);
-    virtual const char* get_key(int iter, unsigned int *len);
-    virtual data_object* get_object(int iter);
+    void generate_key(unsigned long long key_index);
+    const char * get_key() { return m_key; }
+    int get_key_len() { return m_key_len; }
 
     const char * get_key_prefix();
-    const char* get_value(unsigned long long key_index, unsigned int *len);
-    unsigned int get_expiry();
+    virtual const char* get_value(unsigned long long key_index, unsigned int *len);
+    virtual unsigned int get_expiry();
 };
 
 class imported_keylist;
@@ -175,8 +156,11 @@ public:
     virtual ~import_object_generator();
     virtual import_object_generator* clone(void);
 
-    virtual const char* get_key(int iter, unsigned int *len);
-    virtual data_object* get_object(int iter);
+    void read_next_item(void);
+    void read_next_key(unsigned long long key_index);
+
+    virtual const char* get_value(unsigned long long key_index, unsigned int *len);
+    virtual unsigned int get_expiry();
 
     bool open_file(void);
 };

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -611,11 +611,10 @@ void shard_connection::send_mget_command(struct timeval* sent_time, const keylis
 }
 
 void shard_connection::send_verify_get_command(struct timeval* sent_time, const char *key, int key_len,
-                                               const char *value, int value_len, int expiry, unsigned int offset) {
+                                               const char *value, int value_len, unsigned int offset) {
     int cmd_size = 0;
 
-    benchmark_debug_log("GET key=[%.*s] value_len=%u expiry=%u\n",
-                        key_len, key, value_len, expiry);
+    benchmark_debug_log("Verify GET key=[%.*s] value_len=%u\n", key_len, key, value_len);
 
     cmd_size = m_protocol->write_command_get(key, key_len, offset);
     push_req(new verify_request(rt_get, cmd_size, sent_time, 1, key, key_len, value, value_len));

--- a/shard_connection.h
+++ b/shard_connection.h
@@ -98,7 +98,7 @@ public:
                           const char *key, int key_len, unsigned int offset);
     void send_mget_command(struct timeval* sent_time, const keylist* key_list);
     void send_verify_get_command(struct timeval* sent_time, const char *key, int key_len,
-                                 const char *value, int value_len, int expiry, unsigned int offset);
+                                 const char *value, int value_len, unsigned int offset);
     int send_arbitrary_command(const command_arg *arg);
     int send_arbitrary_command(const command_arg *arg, const char *val, int val_len);
     void send_arbitrary_command_end(size_t command_index, struct timeval* sent_time, int cmd_size);

--- a/tests/data-import-2-keys-expiration.txt
+++ b/tests/data-import-2-keys-expiration.txt
@@ -1,0 +1,3 @@
+dumpflags, time, exptime, nbytes, nsuffix, it_flags, clsid, nkey, key, data
+0, 0, 10, 12, 0, 0, 0, 4, key1, xxxxxxxxxx
+0, 0, 10, 14, 0, 0, 0, 4, key2, aaaaaaaaaaaa

--- a/tests/data-import-2-keys.txt
+++ b/tests/data-import-2-keys.txt
@@ -1,0 +1,3 @@
+dumpflags, time, exptime, nbytes, nsuffix, it_flags, clsid, nkey, key, data
+0, 0, 0, 12, 0, 0, 0, 4, key1, xxxxxxxxxx
+0, 0, 0, 14, 0, 0, 0, 4, key2, aaaaaaaaaaaa

--- a/tests/include.py
+++ b/tests/include.py
@@ -1,11 +1,14 @@
 import glob
 import os
+import logging
 
 MEMTIER_BINARY = os.environ.get("MEMTIER_BINARY", "memtier_benchmark")
 TLS_CERT = os.environ.get("TLS_CERT", "")
+ROOT_FOLDER = os.environ.get("ROOT_FOLDER", "")
 TLS_KEY = os.environ.get("TLS_KEY", "")
 TLS_CACERT = os.environ.get("TLS_CACERT", "")
 TLS_PROTOCOLS = os.environ.get("TLS_PROTOCOLS", "")
+VERBOSE = bool(int(os.environ.get("VERBOSE","0")))
 
 
 def ensure_tls_protocols(master_nodes_connections):
@@ -27,6 +30,7 @@ def assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_re
         env.assertTrue(os.path.isfile('{0}/mb.json'.format(config.results_dir)))
         if overall_request_delta is None:
             # assert we have the expected request count
+            logging.debug(f"Checking if expected value {overall_expected_request_count} matches the actual value {overall_request_count}")
             env.assertEqual(overall_expected_request_count, overall_request_count)
         else:
             env.assertAlmostEqual(overall_expected_request_count, overall_request_count,overall_request_delta)
@@ -35,6 +39,10 @@ def assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_re
             debugPrintMemtierOnError(config, env)
 
 def add_required_env_arguments(benchmark_specs, config, env, master_nodes_list):
+    if VERBOSE:
+        import logging
+        logging.basicConfig(level=logging.DEBUG)
+
     # if we've specified TLS_PROTOCOLS ensure we configure it on redis
     master_nodes_connections = env.getOSSMasterNodesConnectionList()
     ensure_tls_protocols(master_nodes_connections)
@@ -137,6 +145,7 @@ def assert_keyspace_range(env, key_max, key_min, master_nodes_connections):
     expected_keyspace_range = key_max - key_min + 1
     overall_keyspace_range = agg_keyspace_range(master_nodes_connections)
     # assert we have the expected keyspace range
+    logging.debug(f"Checking if expected keyspace value {expected_keyspace_range} matches the actual value {overall_keyspace_range}")
     env.assertEqual(expected_keyspace_range, overall_keyspace_range)
 
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -79,12 +79,12 @@ cd $ROOT/tests
 
 E=0
 [[ $OSS_STANDALONE == 1 ]] && {
-	(TLS_KEY=$TLS_KEY TLS_CERT=$TLS_CERT TLS_CACERT=$TLS_CACERT MEMTIER_BINARY=$MEMTIER_BINARY RLTEST_ARGS="${RLTEST_ARGS}" run_tests "tests on OSS standalone")
+	(ROOT_FOLDER=$ROOT TLS_KEY=$TLS_KEY TLS_CERT=$TLS_CERT TLS_CACERT=$TLS_CACERT MEMTIER_BINARY=$MEMTIER_BINARY RLTEST_ARGS="${RLTEST_ARGS}" run_tests "tests on OSS standalone")
 	((E |= $?))
 } || true
 
 [[ $OSS_CLUSTER == 1 ]] && {
-	(TLS_KEY=$TLS_KEY TLS_CERT=$TLS_CERT TLS_CACERT=$TLS_CACERT MEMTIER_BINARY=$MEMTIER_BINARY RLTEST_ARGS="${RLTEST_ARGS} --env oss-cluster --shards-count $SHARDS" run_tests "tests on OSS cluster")
+	(ROOT_FOLDER=$ROOT TLS_KEY=$TLS_KEY TLS_CERT=$TLS_CERT TLS_CACERT=$TLS_CACERT MEMTIER_BINARY=$MEMTIER_BINARY RLTEST_ARGS="${RLTEST_ARGS} --env oss-cluster --shards-count $SHARDS" run_tests "tests on OSS cluster")
 	((E |= $?))
 } || true
 

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -4,8 +4,7 @@ from include import *
 from mbdirector.benchmark import Benchmark
 from mbdirector.runner import RunConfig
 
-import logging
-    
+
 def test_preload_and_set_get(env):
     key_max = 500000
     key_min = 1
@@ -368,14 +367,14 @@ def test_default_arbitrary_command_hset_multi_data_placeholders(env):
     benchmark_specs["args"].append('--command=HSET __key__ field1 __data__ field2 __data__ field3 __data__')
     config = get_default_memtier_config()
     master_nodes_list = env.getMasterNodesList()
-    overall_expected_request_count = get_expected_request_count(memtier_config)
+    overall_expected_request_count = get_expected_request_count(config)
 
-    add_required_env_arguments(benchmark_specs, memtier_config, env, master_nodes_list)
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
 
     # Create a temporary directory
     test_dir = tempfile.mkdtemp()
 
-    config = RunConfig(test_dir, env.testName, memtier_config, {})
+    config = RunConfig(test_dir, env.testName, config, {})
     ensure_clean_benchmark_folder(config.results_dir)
 
     benchmark = Benchmark.from_json(config, benchmark_specs)
@@ -430,12 +429,13 @@ def test_default_set_get_rate_limited(env):
             overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
             assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count, request_delta)
 
+
 def test_data_import(env):
     env.skipOnCluster()
     benchmark_specs = {"name": env.testName, "args": [f"--data-import={ROOT_FOLDER}/tests/data-import-2-keys.txt",'--ratio=1:1']}
     addTLSArgs(benchmark_specs, env)
     config = get_default_memtier_config()
-    master_nodes_list = env.getMasterNodesList()  
+    master_nodes_list = env.getMasterNodesList()
     overall_expected_request_count = get_expected_request_count(config,1, 2)
     add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
 
@@ -456,7 +456,7 @@ def test_data_import(env):
     memtier_ok = benchmark.run()
 
     assert_keyspace_range(env, 2, 1, master_nodes_connections)
-    
+
     merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
     assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
@@ -467,7 +467,7 @@ def test_data_import_setex(env):
     benchmark_specs = {"name": env.testName, "args": [f"--data-import={ROOT_FOLDER}/tests/data-import-2-keys-expiration.txt",'--ratio=1:1']}
     addTLSArgs(benchmark_specs, env)
     config = get_default_memtier_config()
-    master_nodes_list = env.getMasterNodesList()  
+    master_nodes_list = env.getMasterNodesList()
     overall_expected_request_count = get_expected_request_count(config,1, 2)
     add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
 
@@ -488,8 +488,7 @@ def test_data_import_setex(env):
     memtier_ok = benchmark.run()
 
     assert_keyspace_range(env, 2, 1, master_nodes_connections)
-    
+
     merged_command_stats = {'cmdstat_setex': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
     assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
-

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -420,6 +420,7 @@ def test_default_set_get_rate_limited(env):
             assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count, request_delta)
 
 def test_data_import(env):
+    env.skipOnCluster()
     benchmark_specs = {"name": env.testName, "args": [f"--data-import={ROOT_FOLDER}/tests/data-import-2-keys.txt",'--ratio=1:1']}
     addTLSArgs(benchmark_specs, env)
     config = get_default_memtier_config()
@@ -451,6 +452,7 @@ def test_data_import(env):
 
 
 def test_data_import_setex(env):
+    env.skipOnCluster()
     benchmark_specs = {"name": env.testName, "args": [f"--data-import={ROOT_FOLDER}/tests/data-import-2-keys-expiration.txt",'--ratio=1:1']}
     addTLSArgs(benchmark_specs, env)
     config = get_default_memtier_config()

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -4,7 +4,8 @@ from include import *
 from mbdirector.benchmark import Benchmark
 from mbdirector.runner import RunConfig
 
-
+import logging
+    
 def test_preload_and_set_get(env):
     key_max = 500000
     key_min = 1
@@ -355,16 +356,16 @@ def test_default_arbitrary_command_hset(env):
 def test_default_arbitrary_command_hset_multi_data_placeholders(env):
     benchmark_specs = {"name": env.testName, "args": ['--command=HSET __key__ field1 __data__ field2 __data__ field3 __data__']}
     addTLSArgs(benchmark_specs, env)
-    config = get_default_memtier_config()
+    memtier_config = get_default_memtier_config()
     master_nodes_list = env.getMasterNodesList()
-    overall_expected_request_count = get_expected_request_count(config)
+    overall_expected_request_count = get_expected_request_count(memtier_config)
 
-    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+    add_required_env_arguments(benchmark_specs, memtier_config, env, master_nodes_list)
 
     # Create a temporary directory
     test_dir = tempfile.mkdtemp()
 
-    config = RunConfig(test_dir, env.testName, config, {})
+    config = RunConfig(test_dir, env.testName, memtier_config, {})
     ensure_clean_benchmark_folder(config.results_dir)
 
     benchmark = Benchmark.from_json(config, benchmark_specs)
@@ -417,3 +418,65 @@ def test_default_set_get_rate_limited(env):
             merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
             overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
             assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count, request_delta)
+
+def test_data_import(env):
+    benchmark_specs = {"name": env.testName, "args": [f"--data-import={ROOT_FOLDER}/tests/data-import-2-keys.txt",'--ratio=1:1']}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config()
+    master_nodes_list = env.getMasterNodesList()  
+    overall_expected_request_count = get_expected_request_count(config,1, 2)
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    # Create a temporary directory
+    test_dir = tempfile.mkdtemp()
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+    # reset the commandstats
+    for master_connection in master_nodes_connections:
+        master_connection.execute_command("CONFIG", "RESETSTAT")
+
+    # benchmark.run() returns True if the return code of memtier_benchmark was 0
+    memtier_ok = benchmark.run()
+
+    assert_keyspace_range(env, 2, 1, master_nodes_connections)
+    
+    merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
+    overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
+
+
+def test_data_import_setex(env):
+    benchmark_specs = {"name": env.testName, "args": [f"--data-import={ROOT_FOLDER}/tests/data-import-2-keys-expiration.txt",'--ratio=1:1']}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config()
+    master_nodes_list = env.getMasterNodesList()  
+    overall_expected_request_count = get_expected_request_count(config,1, 2)
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    # Create a temporary directory
+    test_dir = tempfile.mkdtemp()
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+    # reset the commandstats
+    for master_connection in master_nodes_connections:
+        master_connection.execute_command("CONFIG", "RESETSTAT")
+
+    # benchmark.run() returns True if the return code of memtier_benchmark was 0
+    memtier_ok = benchmark.run()
+
+    assert_keyspace_range(env, 2, 1, master_nodes_connections)
+    
+    merged_command_stats = {'cmdstat_setex': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
+    overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
+


### PR DESCRIPTION
The PR includes some refactoring and cleanup around the following:
object_generator
- generate_key(), a new function that generates a key and stores it
   inside internal buffer (no need for a buffer at client level)

import_object_generator
- Align it to object_generator APIs of getting key/value/expire
- read_next_item - new function for reading the next item before
   creating SET command
- read_next_key - new function for reading (pointing) to the next
   key before creating the GET command

data_object
- Removed.
   We were already getting key/value/expire separately. Now that
   data-import and verify-data also moved to do it like that,
   we could remove it completely.

verify_client
- Unify the craate_request with its base class, and derive the
   create_x_request functions.