### PR TITLE
Fix upstream missing USE_TLS macro guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,18 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  build-notls:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev
+
+    - name: Build
+      run: autoreconf -ivf && ./configure --disable-tls && make -j
+
   build-ubuntu:
     strategy:
       matrix:

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -312,8 +312,10 @@ static void config_init_defaults(struct benchmark_config *cfg)
         cfg->hdr_prefix = "";
     if (!cfg->print_percentiles.is_defined())
         cfg->print_percentiles = config_quantiles("50,99,99.9");
+#ifdef USE_TLS
     if (!cfg->tls_protocols)
         cfg->tls_protocols = REDIS_TLS_PROTO_DEFAULT;
+#endif
 }
 
 static int generate_random_seed()


### PR DESCRIPTION
The current master as of 9ddfcff fails to build without TLS.
It seems that changes from bec3471f were not guarded by the correct macro.
```
memtier_benchmark.cpp:320:15: error: no member named 'tls_protocols' in 'benchmark_config'
  320 |     if (!cfg->tls_protocols)                                               
      |          ~~~  ^                                                            
memtier_benchmark.cpp:321:14: error: no member named 'tls_protocols' in 'benchmark_config'
  321 |         cfg->tls_protocols = REDIS_TLS_PROTO_DEFAULT;                      
      |         ~~~  ^                                                             
memtier_benchmark.cpp:321:30: error: use of undeclared identifier 'REDIS_TLS_PROTO_DEFAULT'
  321 |         cfg->tls_protocols = REDIS_TLS_PROTO_DEFAULT;                      
      |                              ^                                             
memtier_benchmark.cpp:330:16: warning: variable 'ignore' set but not used [-Wunused-but-set-variable]
  330 |         size_t ignore = fread(&R, sizeof(R), 1, f);                        
      |                ^ 
```