### PR TITLE
Include rate-limiting Readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,42 @@ Also, the ratio and the key generator is per client (and not connection).
 In this case, setting the ratio to 1:1 does not guarantee 100% hits because
 the keys spread to different connections/nodes.
 
+
+
+### Using rate-limiting for informed benchmarking
+
+When you impose a rate limit on your benchmark tests, you're essentially mimicking a controlled production environment. This setup is crucial for understanding how latency behaves under certain throughput constraints. Here's why benchmarking latency in a rate-limited scenario is important:
+
+
+1. **Realistic Performance Metrics**: In real-world scenarios, systems often operate under various limitations. Understanding how these limitations affect latency gives you a more accurate picture of system performance, than simply running benchmarks at full stress level.
+
+1. **Capacity Planning**: By observing latency at different rate limits, you can better plan for scaling your infrastructure. It helps in identifying at what point increased load leads to unacceptable latency, guiding decisions about when to scale up.
+
+1. **Quality of Service (QoS) Guarantees**: For services that require a certain level of performance guarantee, knowing the latency at specific rate limits helps in setting realistic QoS benchmarks.
+
+1. **Identifying Bottlenecks**: Rate-limited benchmarking can help in identifying bottlenecks in your system. If latency increases disproportionately with a small increase in rate limit, it may indicate a bottleneck that needs attention.
+
+1. **Comparative Analysis**: It enables the comparison of different solutions, configurations or hardware in terms of how they handle latency under simmilar benchmark conditions.
+
+
+#### Using rate-limiting in memtier
+
+To use this feature, add the `--rate-limiting`` parameter followed by the desired RPS per connection.
+
+
+```
+memtier_benchmark [other options] --rate-limiting=<RPS>
+```
+
+Note: When using rate-limiting together with cluster-mode option, the rate-limit is associated to the connection for each node.
+
+
+#### Rate limited example: 100% writes, 1M Keys, 60 seconds benchmark at 10K RPS
+
+```
+memtier_benchmark --ratio=1:0 --test-time=60 --rate-limiting=100 -t 2 -c 50 --key-pattern=P:P --key-maximum 1000000
+```
+
 ### Full latency spectrum analysis
 
 For distributions that are non-normal, such as the latency, many “basic rules” of normally distributed statistics are violated.  Instead of computing just the mean, which tries to express the whole distribution in a single result, we can use a sampling of the distribution at intervals -- percentiles, which tell you how many requests actually would experience that delay. 


### PR DESCRIPTION
This PR includes documentation on why/when you should use a rate-limited benchmark, and provides one example of it in the readme for simpler comprehension. 