### PR TITLE
List ingress and egress separately on JSON and CSV exports. Include BW and also raw values per second

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -445,14 +445,16 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp,
     switch (request->m_type) {
         case rt_get:
             m_stats.update_get_op(&timestamp,
-                                  request->m_size + response->get_total_len(),
+                                  response->get_total_len(),
+                                  request->m_size,
                                   ts_diff(request->m_sent_time, timestamp),
                                   response->get_hits(),
                                   request->m_keys - response->get_hits());
             break;
         case rt_set:
             m_stats.update_set_op(&timestamp,
-                                  request->m_size + response->get_total_len(),
+                                  response->get_total_len(),
+                                  request->m_size,
                                   ts_diff(request->m_sent_time, timestamp));
             break;
         case rt_wait:
@@ -462,7 +464,8 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp,
         case rt_arbitrary: {
             arbitrary_request *ar = static_cast<arbitrary_request *>(request);
             m_stats.update_arbitrary_op(&timestamp,
-                                        request->m_size + response->get_total_len(),
+                                        response->get_total_len(),
+                                        request->m_size,
                                         ts_diff(request->m_sent_time, timestamp),
                                         ar->index);
             break;

--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -418,16 +418,19 @@ void cluster_client::handle_moved(unsigned int conn_id, struct timeval timestamp
     // update stats
     if (request->m_type == rt_get) {
         m_stats.update_moved_get_op(&timestamp,
-                                    request->m_size + response->get_total_len(),
+                                    response->get_total_len(),
+                                    request->m_size,
                                     ts_diff(request->m_sent_time, timestamp));
     } else if (request->m_type == rt_set) {
         m_stats.update_moved_set_op(&timestamp,
-                                    request->m_size + response->get_total_len(),
+                                    response->get_total_len(),
+                                    request->m_size,
                                     ts_diff(request->m_sent_time, timestamp));
      } else if (request->m_type == rt_arbitrary) {
         arbitrary_request *ar = static_cast<arbitrary_request *>(request);
         m_stats.update_moved_arbitrary_op(&timestamp,
-                                    request->m_size + response->get_total_len(),
+                                    response->get_total_len(),
+                                    request->m_size,
                                     ts_diff(request->m_sent_time, timestamp),
                                     ar->index);
     } else {
@@ -452,16 +455,19 @@ void cluster_client::handle_ask(unsigned int conn_id, struct timeval timestamp,
     // update stats
     if (request->m_type == rt_get) {
         m_stats.update_ask_get_op(&timestamp,
-                                    request->m_size + response->get_total_len(),
+                                    response->get_total_len(),
+                                    request->m_size,
                                     ts_diff(request->m_sent_time, timestamp));
     } else if (request->m_type == rt_set) {
         m_stats.update_ask_set_op(&timestamp,
-                                    request->m_size + response->get_total_len(),
+                                    response->get_total_len(),
+                                    request->m_size,
                                     ts_diff(request->m_sent_time, timestamp));
     } else if (request->m_type == rt_arbitrary) {
         arbitrary_request *ar = static_cast<arbitrary_request *>(request);
         m_stats.update_ask_arbitrary_op(&timestamp,
-                                    request->m_size + response->get_total_len(),
+                                    response->get_total_len(),
+                                    request->m_size,
                                     ts_diff(request->m_sent_time, timestamp),
                                     ar->index);
     } else {

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -172,82 +172,82 @@ void run_stats::roll_cur_stats(struct timeval* ts)
     }
 }
 
-void run_stats::update_get_op(struct timeval* ts, unsigned int bytes, unsigned int latency, unsigned int hits, unsigned int misses)
+void run_stats::update_get_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency, unsigned int hits, unsigned int misses)
 {
     roll_cur_stats(ts);
-    m_cur_stats.m_get_cmd.update_op(bytes, latency, hits, misses);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_get_cmd.update_op(bytes_rx, bytes_tx, latency, hits, misses);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
     hdr_record_value(m_get_latency_histogram,latency);
     hdr_record_value(inst_m_get_latency_histogram,latency);
 }
 
-void run_stats::update_set_op(struct timeval* ts, unsigned int bytes, unsigned int latency)
+void run_stats::update_set_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency)
 {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_set_cmd.update_op(bytes, latency);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_set_cmd.update_op(bytes_rx, bytes_tx, latency);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
     hdr_record_value(m_set_latency_histogram,latency);
     hdr_record_value(inst_m_set_latency_histogram,latency);
 }
 
-void run_stats::update_moved_get_op(struct timeval* ts, unsigned int bytes, unsigned int latency)
+void run_stats::update_moved_get_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency)
 {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_get_cmd.update_moved_op(bytes, latency);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_get_cmd.update_moved_op(bytes_rx, bytes_tx, latency);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
     hdr_record_value(m_get_latency_histogram,latency);
     hdr_record_value(inst_m_get_latency_histogram,latency);
 }
 
-void run_stats::update_moved_set_op(struct timeval* ts, unsigned int bytes, unsigned int latency)
+void run_stats::update_moved_set_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency)
 {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_set_cmd.update_moved_op(bytes, latency);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_set_cmd.update_moved_op(bytes_rx, bytes_tx, latency);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
     hdr_record_value(m_set_latency_histogram,latency);
     hdr_record_value(inst_m_set_latency_histogram,latency);
 }
 
-void run_stats::update_moved_arbitrary_op(struct timeval *ts, unsigned int bytes,
+void run_stats::update_moved_arbitrary_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx,
                                     unsigned int latency, size_t request_index) {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_ar_commands.at(request_index).update_moved_op(bytes, latency);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_ar_commands.at(request_index).update_moved_op(bytes_rx, bytes_tx, latency);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
 
     struct hdr_histogram* hist = m_ar_commands_latency_histograms.at(request_index);
     hdr_record_value(hist,latency);
 }
 
-void run_stats::update_ask_get_op(struct timeval* ts, unsigned int bytes, unsigned int latency)
+void run_stats::update_ask_get_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency)
 {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_get_cmd.update_ask_op(bytes, latency);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_get_cmd.update_ask_op(bytes_rx, bytes_tx, latency);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
     hdr_record_value(m_get_latency_histogram,latency);
     hdr_record_value(inst_m_get_latency_histogram,latency);
 }
 
-void run_stats::update_ask_set_op(struct timeval* ts, unsigned int bytes, unsigned int latency)
+void run_stats::update_ask_set_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency)
 {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_set_cmd.update_ask_op(bytes, latency);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_set_cmd.update_ask_op(bytes_rx, bytes_tx, latency);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
     hdr_record_value(m_set_latency_histogram,latency);
     hdr_record_value(inst_m_set_latency_histogram,latency);
 }
 
-void run_stats::update_ask_arbitrary_op(struct timeval *ts, unsigned int bytes,
+void run_stats::update_ask_arbitrary_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx,
                                           unsigned int latency, size_t request_index) {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_ar_commands.at(request_index).update_ask_op(bytes, latency);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_ar_commands.at(request_index).update_ask_op(bytes_rx, bytes_tx, latency);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
 
     struct hdr_histogram* hist = m_ar_commands_latency_histograms.at(request_index);
     hdr_record_value(hist,latency);
@@ -257,18 +257,18 @@ void run_stats::update_wait_op(struct timeval *ts, unsigned int latency)
 {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_wait_cmd.update_op(0, latency);
-    m_totals.update_op(0, latency);
+    m_cur_stats.m_wait_cmd.update_op(0,0, latency);
+    m_totals.update_op(0,0, latency);
     hdr_record_value(m_wait_latency_histogram,latency);
     hdr_record_value(inst_m_wait_latency_histogram,latency);
 }
 
-void run_stats::update_arbitrary_op(struct timeval *ts, unsigned int bytes,
+void run_stats::update_arbitrary_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx,
                                     unsigned int latency, size_t request_index) {
     roll_cur_stats(ts);
 
-    m_cur_stats.m_ar_commands.at(request_index).update_op(bytes, latency);
-    m_totals.update_op(bytes, latency);
+    m_cur_stats.m_ar_commands.at(request_index).update_op(bytes_rx, bytes_tx, latency);
+    m_totals.update_op(bytes_rx, bytes_tx, latency);
 
     struct hdr_histogram* hist = m_ar_commands_latency_histograms.at(request_index);
     struct hdr_histogram* inst_hist = inst_m_ar_commands_latency_histograms.at(request_index);
@@ -294,7 +294,7 @@ unsigned long int run_stats::get_duration_usec(void)
 
 unsigned long int run_stats::get_total_bytes(void)
 {
-    return m_totals.m_bytes;
+    return m_totals.m_bytes_rx+m_totals.m_bytes_tx;
 }
 
 unsigned long int run_stats::get_total_ops(void)
@@ -317,8 +317,8 @@ void run_stats::save_csv_one_sec(FILE *f,
                                  unsigned long int& total_set_ops,
                                  unsigned long int& total_wait_ops) {
     fprintf(f, "Per-Second Benchmark Data\n");
-    fprintf(f, "Second,SET Requests,SET Average Latency,SET Total Bytes,"
-               "GET Requests,GET Average Latency,GET Total Bytes,GET Misses,GET Hits,"
+    fprintf(f, "Second,SET Requests,SET Average Latency,SET Total Bytes,SET Total Bytes TX,SET Total Bytes RX,"
+               "GET Requests,GET Average Latency,GET Total Bytes,GET Total Bytes TX,GET Total Bytes RX,GET Misses,GET Hits,"
                "WAIT Requests,WAIT Average Latency\n");
 
     total_get_ops = 0;
@@ -327,14 +327,18 @@ void run_stats::save_csv_one_sec(FILE *f,
     for (std::list<one_second_stats>::iterator i = m_stats.begin();
          i != m_stats.end(); i++) {
 
-        fprintf(f, "%u,%lu,%u.%06u,%lu,%lu,%u.%06u,%lu,%u,%u,%lu,%u.%06u\n",
+        fprintf(f, "%u,%lu,%u.%06u,%lu,%lu,%lu,%lu,%u.%06u,%lu,%lu,%lu,%u,%u,%lu,%u.%06u\n",
                 i->m_second,
                 i->m_set_cmd.m_ops,
                 USEC_FORMAT(AVERAGE(i->m_set_cmd.m_total_latency, i->m_set_cmd.m_ops)),
-                i->m_set_cmd.m_bytes,
+                i->m_set_cmd.m_bytes_rx + i->m_set_cmd.m_bytes_tx,
+                i->m_set_cmd.m_bytes_tx,
+                i->m_set_cmd.m_bytes_rx,
                 i->m_get_cmd.m_ops,
                 USEC_FORMAT(AVERAGE(i->m_get_cmd.m_total_latency, i->m_get_cmd.m_ops)),
-                i->m_get_cmd.m_bytes,
+                i->m_get_cmd.m_bytes_rx + i->m_get_cmd.m_bytes_tx,
+                i->m_get_cmd.m_bytes_tx,
+                i->m_get_cmd.m_bytes_rx,
                 i->m_get_cmd.m_misses,
                 i->m_get_cmd.m_hits,
                 i->m_wait_cmd.m_ops,
@@ -487,7 +491,9 @@ void run_stats::save_csv_arbitrary_commands_one_sec(FILE *f,
     for (unsigned int i=0; i<command_list.size(); i++) {
         std::string command_name = command_list[i].command_name;
 
-        fprintf(f, ",%s Requests,%s Average Latency,%s Total Bytes",
+        fprintf(f, ",%s Requests,%s Average Latency,%s Total Bytes,%s Total Bytes TX,%s Total Bytes RX",
+                command_name.c_str(),
+                command_name.c_str(),
                 command_name.c_str(),
                 command_name.c_str(),
                 command_name.c_str());
@@ -503,10 +509,13 @@ void run_stats::save_csv_arbitrary_commands_one_sec(FILE *f,
         for (unsigned int i=0; i<stat->m_ar_commands.size(); i++) {
             one_sec_cmd_stats& arbitrary_command_stats = stat->m_ar_commands[i];
 
-            fprintf(f, "%lu,%u.%06u,%lu,",
+            fprintf(f, "%lu,%u.%06u,%lu,%lu,%lu,",
                 arbitrary_command_stats.m_ops,
                 USEC_FORMAT(AVERAGE(arbitrary_command_stats.m_total_latency, arbitrary_command_stats.m_ops)),
-                arbitrary_command_stats.m_bytes);
+                arbitrary_command_stats.m_bytes_rx+arbitrary_command_stats.m_bytes_tx,
+                arbitrary_command_stats.m_bytes_tx,
+                arbitrary_command_stats.m_bytes_rx
+                );
 
             total_arbitrary_commands_ops.at(i) += arbitrary_command_stats.m_ops;
         }
@@ -698,8 +707,8 @@ void run_stats::debug_dump(void)
                             i->m_set_cmd.m_ops,
                             i->m_get_cmd.m_ops,
                             i->m_wait_cmd.m_ops,
-                            i->m_set_cmd.m_bytes,
-                            i->m_get_cmd.m_bytes,
+                            i->m_set_cmd.m_bytes_rx+i->m_set_cmd.m_bytes_tx,
+                            i->m_get_cmd.m_bytes_rx+i->m_get_cmd.m_bytes_tx,
                             i->m_get_cmd.m_hits,
                             i->m_get_cmd.m_misses);
     }
@@ -806,7 +815,8 @@ void run_stats::summarize(totals& result) const
 
     // total ops, bytes
     result.m_ops = totals.m_set_cmd.m_ops + totals.m_get_cmd.m_ops + totals.m_wait_cmd.m_ops + totals.m_ar_commands.ops();
-    result.m_bytes = totals.m_set_cmd.m_bytes + totals.m_get_cmd.m_bytes + totals.m_ar_commands.bytes();
+    result.m_bytes_rx = totals.m_set_cmd.m_bytes_rx + totals.m_get_cmd.m_bytes_rx + totals.m_ar_commands.bytes();
+    result.m_bytes_tx = totals.m_set_cmd.m_bytes_tx + totals.m_get_cmd.m_bytes_tx + totals.m_ar_commands.bytes();
 
     // cmd/sec
     result.m_set_cmd.summarize(totals.m_set_cmd, test_duration_usec);
@@ -831,13 +841,15 @@ void run_stats::summarize(totals& result) const
         result.m_latency = 0;
     }
 
-    result.m_bytes_sec = (result.m_bytes / 1024.0) / test_duration_usec * 1000000;
+    result.m_bytes_sec = ((result.m_bytes_rx + result.m_bytes_tx) / 1024.0) / test_duration_usec * 1000000;
+    result.m_bytes_sec_rx = (result.m_bytes_rx / 1024.0) / test_duration_usec * 1000000;
+    result.m_bytes_sec_tx = (result.m_bytes_tx / 1024.0) / test_duration_usec * 1000000;
     result.m_moved_sec = (double) (totals.m_set_cmd.m_moved + totals.m_get_cmd.m_moved) / test_duration_usec * 1000000;
     result.m_ask_sec = (double) (totals.m_set_cmd.m_ask + totals.m_get_cmd.m_ask) / test_duration_usec * 1000000;
 }
 
 void result_print_to_json(json_handler * jsonhandler, const char * type, double ops,
-                          double hits, double miss, double moved, double ask, double kbs, 
+                          double hits, double miss, double moved, double ask, double kbs, double kbs_rx, double kbs_tx,
                           std::vector<float> quantile_list, struct hdr_histogram* latency_histogram, 
                           std::vector<unsigned int> timestamps, 
                           std::vector<one_sec_cmd_stats> timeserie_stats )
@@ -864,7 +876,11 @@ void result_print_to_json(json_handler * jsonhandler, const char * type, double 
         jsonhandler->write_obj("Average Latency","%.3f", avg_latency);
         jsonhandler->write_obj("Min Latency","%.3f", min_latency);
         jsonhandler->write_obj("Max Latency","%.3f", max_latency);
+        // preserve KB/sec for backwards compatibility
         jsonhandler->write_obj("KB/sec","%.2f", kbs);
+        jsonhandler->write_obj("KB/sec RX/TX","%.2f", kbs);
+        jsonhandler->write_obj("KB/sec RX","%.2f", kbs_rx);
+        jsonhandler->write_obj("KB/sec TX","%.2f", kbs_tx);
         jsonhandler->open_nesting("Time-Serie");
         for (std::size_t i = 0; i < timeserie_stats.size(); i++){
             char timestamp_str[16];
@@ -873,6 +889,8 @@ void result_print_to_json(json_handler * jsonhandler, const char * type, double 
             const bool sec_has_samples = cmd_stats.m_ops > 0;
             snprintf(timestamp_str,sizeof(timestamp_str)-1,"%d", timestamp);
             jsonhandler->open_nesting(timestamp_str);
+            jsonhandler->write_obj("Bytes RX","%lld", cmd_stats.m_bytes_rx);
+            jsonhandler->write_obj("Bytes TX","%lld", cmd_stats.m_bytes_tx);
             jsonhandler->write_obj("Count","%lld", cmd_stats.m_ops);
             if (sec_has_samples){
                 jsonhandler->write_obj("Average Latency","%.3f", cmd_stats.m_avg_latency);
@@ -1189,6 +1207,8 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list& co
                                  cluster_mode ? m_totals.m_ar_commands[i].m_moved_sec : -1,
                                  cluster_mode ? m_totals.m_ar_commands[i].m_ask_sec : -1,
                                  m_totals.m_ar_commands[i].m_bytes_sec,
+                                 m_totals.m_ar_commands[i].m_bytes_sec_rx,
+                                 m_totals.m_ar_commands[i].m_bytes_sec_tx,
                                  quantiles_list,
                                  arbitrary_command_latency_histogram,
                                  timestamps,
@@ -1205,6 +1225,8 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list& co
                              cluster_mode ? m_totals.m_set_cmd.m_moved_sec : -1,
                              cluster_mode ? m_totals.m_set_cmd.m_ask_sec : -1,
                              m_totals.m_set_cmd.m_bytes_sec,
+                             m_totals.m_set_cmd.m_bytes_sec_rx,
+                             m_totals.m_set_cmd.m_bytes_sec_tx,
                              quantiles_list,
                              m_set_latency_histogram,
                              timestamps,
@@ -1216,6 +1238,8 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list& co
                              cluster_mode ? m_totals.m_get_cmd.m_moved_sec : -1,
                              cluster_mode ? m_totals.m_get_cmd.m_ask_sec : -1,
                              m_totals.m_get_cmd.m_bytes_sec,
+                             m_totals.m_get_cmd.m_bytes_sec_rx,
+                             m_totals.m_get_cmd.m_bytes_sec_tx,
                              quantiles_list,
                              m_get_latency_histogram,
                              timestamps,
@@ -1226,6 +1250,8 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list& co
                              0.0,
                              cluster_mode ? 0.0 : -1,
                              cluster_mode ? 0.0 : -1,
+                             0.0,
+                             0.0,
                              0.0,
                              quantiles_list,
                              m_wait_latency_histogram,
@@ -1240,6 +1266,8 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list& co
                          cluster_mode ? m_totals.m_moved_sec : -1,
                          cluster_mode ? m_totals.m_ask_sec : -1,
                          m_totals.m_bytes_sec,
+                         m_totals.m_bytes_sec_rx,
+                         m_totals.m_bytes_sec_tx,
                          quantiles_list,
                          m_totals.latency_histogram,
                          timestamps,

--- a/run_stats.h
+++ b/run_stats.h
@@ -121,21 +121,21 @@ public:
     void set_start_time(struct timeval* start_time);
     void set_end_time(struct timeval* end_time);
 
-    void update_get_op(struct timeval* ts, unsigned int bytes, unsigned int latency, unsigned int hits, unsigned int misses);
-    void update_set_op(struct timeval* ts, unsigned int bytes, unsigned int latency);
+    void update_get_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency, unsigned int hits, unsigned int misses);
+    void update_set_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency);
 
-    void update_moved_get_op(struct timeval* ts, unsigned int bytes, unsigned int latency);
-    void update_moved_set_op(struct timeval* ts, unsigned int bytes, unsigned int latency);
-    void update_moved_arbitrary_op(struct timeval *ts, unsigned int bytes,
+    void update_moved_get_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency);
+    void update_moved_set_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency);
+    void update_moved_arbitrary_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx,
                              unsigned int latency, size_t arbitrary_index);
 
-    void update_ask_get_op(struct timeval* ts, unsigned int bytes, unsigned int latency);
-    void update_ask_set_op(struct timeval* ts, unsigned int bytes, unsigned int latency);
-    void update_ask_arbitrary_op(struct timeval *ts, unsigned int bytes,
+    void update_ask_get_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency);
+    void update_ask_set_op(struct timeval* ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency);
+    void update_ask_arbitrary_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx,
                                    unsigned int latency, size_t arbitrary_index);
 
     void update_wait_op(struct timeval* ts, unsigned int latency);
-    void update_arbitrary_op(struct timeval *ts, unsigned int bytes,
+    void update_arbitrary_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx,
                              unsigned int latency, size_t arbitrary_index);
 
     void aggregate_average(const std::vector<run_stats>& all_stats);

--- a/run_stats_types.h
+++ b/run_stats_types.h
@@ -75,7 +75,8 @@ public:
 
 class one_sec_cmd_stats {
 public:
-    unsigned long int m_bytes;
+    unsigned long int m_bytes_rx;
+    unsigned long int m_bytes_tx;
     unsigned long int m_ops;
     unsigned int m_hits;
     unsigned int m_misses;
@@ -90,10 +91,10 @@ public:
     void reset();
     void merge(const one_sec_cmd_stats& other);
     void summarize_quantiles(safe_hdr_histogram histogram, std::vector<float> quantiles);
-    void update_op(unsigned int bytes, unsigned int latency);
-    void update_op(unsigned int bytes, unsigned int latency, unsigned int hits, unsigned int misses);
-    void update_moved_op(unsigned int bytes, unsigned int latency);
-    void update_ask_op(unsigned int bytes, unsigned int latency);
+    void update_op(unsigned int bytes_rx, unsigned int bytes_tx,  unsigned int latency);
+    void update_op(unsigned int bytes_rx, unsigned int bytes_tx,  unsigned int latency, unsigned int hits, unsigned int misses);
+    void update_moved_op(unsigned int bytes_rx, unsigned int bytes_tx,  unsigned int latency);
+    void update_ask_op(unsigned int bytes_rx, unsigned int bytes_tx,  unsigned int latency);
 };
 
 class one_second_stats; // forward declaration
@@ -135,6 +136,8 @@ class totals_cmd {
 public:
     double m_ops_sec;
     double m_bytes_sec;
+    double m_bytes_sec_rx;
+    double m_bytes_sec_tx;
     double m_moved_sec;
     double m_ask_sec;
     double m_latency;
@@ -173,17 +176,22 @@ public:
     safe_hdr_histogram latency_histogram;
     double m_ops_sec;
     double m_bytes_sec;
+    double m_bytes_sec_rx;
+    double m_bytes_sec_tx;
     double m_hits_sec;
     double m_misses_sec;
     double m_moved_sec;
     double m_ask_sec;
     unsigned long long int m_latency;
-    unsigned long int m_bytes;
+    // number of bytes received
+    unsigned long int m_bytes_rx;
+    // number of bytes sent
+    unsigned long int m_bytes_tx;
     unsigned long int m_ops;
     totals();
     void setup_arbitrary_commands(size_t n_arbitrary_commands);
     void add(const totals& other);
-    void update_op(unsigned long int bytes, unsigned int latency);
+    void update_op(unsigned long int bytes_rx, unsigned long int bytes_tx, unsigned int latency);
 };
 
 

--- a/tests/include.py
+++ b/tests/include.py
@@ -158,3 +158,31 @@ def agg_keyspace_range(master_nodes_connections):
                 shard_count = int(shard_reply['db0']['keys'])
         overall_keyspace_range = overall_keyspace_range + shard_count
     return overall_keyspace_range
+
+
+def get_column_csv(filename,column_name):
+    found = False
+    with open(filename,"r") as fd:
+        stop_line = 0
+        lines = fd.readlines()
+        for line in lines:
+            # CSV is the first part of file
+            if "Full-Test GET Latency" in line or len(line) == 0:
+                break
+            stop_line = stop_line + 1
+        print(stop_line)
+        csv_lines = lines[1:stop_line-1]
+        header_line = csv_lines[0].strip().split(",")
+        col_pos = -1
+        for col_index,col in enumerate(header_line):
+            if column_name == col:
+                col_pos = col_index
+                found = True
+        data_lines = []
+        for line in csv_lines[1:]:
+            data_lines.append(line.strip().split(","))
+        column_data = []
+        if found is True:
+            for line in data_lines:
+                column_data.append(line[col_pos])
+    return found, column_data

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -102,7 +102,7 @@ def test_default_set(env):
     for master_connection in master_nodes_connections:
         master_connection.execute_command("CONFIG", "RESETSTAT")
 
-    benchmark_specs = {"name": env.testName, "args": ['--pipeline=10','--ratio=1:0','--key-pattern=R:R','--key-minimum={}'.format(key_min),'--key-maximum={}'.format(key_max)]}
+    benchmark_specs = {"name": env.testName, "args": ['--client-stats',f'{test_dir}/set_client_stats','--pipeline=10','--ratio=1:0','--key-pattern=R:R','--key-minimum={}'.format(key_min),'--key-maximum={}'.format(key_max)]}
     addTLSArgs(benchmark_specs, env)
     config = get_default_memtier_config(threads=2, clients=10, requests=200000)
     master_nodes_list = env.getMasterNodesList()
@@ -110,11 +110,9 @@ def test_default_set(env):
 
     add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
 
-    # Create a temporary directory
-    test_dir = tempfile.mkdtemp()
-
     config = RunConfig(test_dir, env.testName, config, {})
-    ensure_clean_benchmark_folder(config.results_dir)
+    results_dir = config.results_dir
+    ensure_clean_benchmark_folder(results_dir)
 
     benchmark = Benchmark.from_json(config, benchmark_specs)
 
@@ -129,8 +127,45 @@ def test_default_set(env):
     assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count,
                                     overall_request_count)
 
+    # Assert that all CSV BW metrics are properly stored and calculated
+    first_client_csv_stats = '{0}/set_client_stats-1-0-0.csv'.format(test_dir)
+    found, set_tx_column_data = get_column_csv(first_client_csv_stats,"SET Total Bytes TX")
+    env.assertTrue(found)
+    found, set_rx_column_data = get_column_csv(first_client_csv_stats,"SET Total Bytes RX")
+    env.assertTrue(found)
+    found, set_tx_rx_column_data = get_column_csv(first_client_csv_stats,"SET Total Bytes")
+    env.assertTrue(found)
+    found, set_reqs_column_data = get_column_csv(first_client_csv_stats,"SET Requests")
+    env.assertTrue(found)
+    for col_pos, ops_sec in enumerate(set_reqs_column_data):
+        if int(ops_sec) > 0:
+            set_tx = int(set_tx_column_data[col_pos])
+            set_rx = int(set_rx_column_data[col_pos])
+            set_tx_rx = int(set_tx_rx_column_data[col_pos])
+            env.assertTrue(set_tx > 0)
+            env.assertTrue(set_rx > 0)
+            env.assertTrue(set_tx_rx > 0)
+            env.assertAlmostEqual(set_tx_rx,set_tx+set_rx,1)
+
+    # the GET bw should be 0
+    found, get_tx_column_data = get_column_csv(first_client_csv_stats,"GET Total Bytes TX")
+    env.assertTrue(found)
+    found, get_rx_column_data = get_column_csv(first_client_csv_stats,"GET Total Bytes RX")
+    env.assertTrue(found)
+    found, get_tx_rx_column_data = get_column_csv(first_client_csv_stats,"GET Total Bytes")
+    env.assertTrue(found)
+    for col_pos, ops_sec in enumerate(set_reqs_column_data):
+        if int(ops_sec) > 0:
+            get_tx = int(get_tx_column_data[col_pos])
+            get_rx = int(get_rx_column_data[col_pos])
+            get_tx_rx = int(get_tx_rx_column_data[col_pos])
+            env.assertTrue(get_tx == 0)
+            env.assertTrue(get_rx == 0)
+            env.assertTrue(get_tx_rx == 0)
+            env.assertAlmostEqual(set_tx_rx,set_tx+set_rx,1)
+
+    ## Assert that all JSON BW metrics are properly stored and calculated
     json_filename = '{0}/mb.json'.format(config.results_dir)
-    ## Assert that all BW metrics are properly stored and calculated
     with open(json_filename) as results_json:
         results_dict = json.load(results_json)
         set_metrics = results_dict['ALL STATS']['Sets']

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -129,6 +129,36 @@ def test_default_set(env):
     assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count,
                                     overall_request_count)
 
+    json_filename = '{0}/mb.json'.format(config.results_dir)
+    ## Assert that all BW metrics are properly stored and calculated
+    with open(json_filename) as results_json:
+        results_dict = json.load(results_json)
+        set_metrics = results_dict['ALL STATS']['Sets']
+        get_metrics = results_dict['ALL STATS']['Gets']
+        set_metrics_ts = results_dict['ALL STATS']['Sets']["Time-Serie"]
+        get_metrics_ts = results_dict['ALL STATS']['Gets']["Time-Serie"]
+        for metric_name in ["KB/sec RX/TX","KB/sec RX","KB/sec TX","KB/sec"]:
+            # assert the metric exists
+            env.assertTrue(metric_name in set_metrics)
+            env.assertTrue(metric_name in get_metrics)
+            # assert the metric value is non zero on writes and zero on reads
+            set_metric_value_kbs = set_metrics[metric_name]
+            get_metric_value_kbs = get_metrics[metric_name]
+            env.assertTrue(set_metric_value_kbs > 0)
+            env.assertTrue(get_metric_value_kbs == 0)
+
+        for second_data in set_metrics_ts.values():
+            bytes_rx = second_data["Bytes RX"]
+            bytes_tx = second_data["Bytes TX"]
+            env.assertTrue(bytes_rx > 0)
+            env.assertTrue(bytes_tx > 0)
+
+        for second_data in get_metrics_ts.values():
+            bytes_rx = second_data["Bytes RX"]
+            bytes_tx = second_data["Bytes TX"]
+            env.assertTrue(bytes_rx == 0)
+            env.assertTrue(bytes_tx == 0)
+
 def test_default_set_get(env):
     benchmark_specs = {"name": env.testName, "args": []}
     addTLSArgs(benchmark_specs, env)
@@ -154,6 +184,35 @@ def test_default_set_get(env):
     overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
     assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
 
+    json_filename = '{0}/mb.json'.format(config.results_dir)
+    ## Assert that all BW metrics are properly stored and calculated
+    with open(json_filename) as results_json:
+        results_dict = json.load(results_json)
+        set_metrics = results_dict['ALL STATS']['Sets']
+        get_metrics = results_dict['ALL STATS']['Gets']
+        set_metrics_ts = results_dict['ALL STATS']['Sets']["Time-Serie"]
+        get_metrics_ts = results_dict['ALL STATS']['Gets']["Time-Serie"]
+        for metric_name in ["KB/sec RX/TX","KB/sec RX","KB/sec TX","KB/sec"]:
+            # assert the metric exists
+            env.assertTrue(metric_name in set_metrics)
+            env.assertTrue(metric_name in get_metrics)
+            # assert the metric value is non zero given we've had write and read
+            set_metric_value_kbs = set_metrics[metric_name]
+            get_metric_value_kbs = get_metrics[metric_name]
+            env.assertTrue(set_metric_value_kbs > 0)
+            env.assertTrue(get_metric_value_kbs > 0)
+
+        for second_data in set_metrics_ts.values():
+            bytes_rx = second_data["Bytes RX"]
+            bytes_tx = second_data["Bytes TX"]
+            env.assertTrue(bytes_rx > 0)
+            env.assertTrue(bytes_tx > 0)
+
+        for second_data in get_metrics_ts.values():
+            bytes_rx = second_data["Bytes RX"]
+            bytes_tx = second_data["Bytes TX"]
+            env.assertTrue(bytes_rx > 0)
+            env.assertTrue(bytes_tx > 0)
 
 def test_default_set_get_with_print_percentiles(env):
     p_str = '0,10,20,30,40,50,60,70,80,90,95,100'

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -150,12 +150,18 @@ def test_default_set(env):
         for second_data in set_metrics_ts.values():
             bytes_rx = second_data["Bytes RX"]
             bytes_tx = second_data["Bytes TX"]
-            env.assertTrue(bytes_rx > 0)
-            env.assertTrue(bytes_tx > 0)
+            count = second_data["Count"]
+            # if we had commands on that second the BW needs to be > 0
+            if count > 0:
+                env.assertTrue(bytes_rx > 0)
+                env.assertTrue(bytes_tx > 0)
 
         for second_data in get_metrics_ts.values():
             bytes_rx = second_data["Bytes RX"]
             bytes_tx = second_data["Bytes TX"]
+            # This test is write only so there should be no reads RX/TX and count
+            count = second_data["Count"]
+            env.assertTrue(count == 0)
             env.assertTrue(bytes_rx == 0)
             env.assertTrue(bytes_tx == 0)
 
@@ -205,14 +211,19 @@ def test_default_set_get(env):
         for second_data in set_metrics_ts.values():
             bytes_rx = second_data["Bytes RX"]
             bytes_tx = second_data["Bytes TX"]
-            env.assertTrue(bytes_rx > 0)
-            env.assertTrue(bytes_tx > 0)
+            count = second_data["Count"]
+            # if we had commands on that second the BW needs to be > 0
+            if count > 0:
+                env.assertTrue(bytes_rx > 0)
+                env.assertTrue(bytes_tx > 0)
 
         for second_data in get_metrics_ts.values():
             bytes_rx = second_data["Bytes RX"]
             bytes_tx = second_data["Bytes TX"]
-            env.assertTrue(bytes_rx > 0)
-            env.assertTrue(bytes_tx > 0)
+            # if we had commands on that second the BW needs to be > 0
+            if count > 0:
+                env.assertTrue(bytes_rx > 0)
+                env.assertTrue(bytes_tx > 0)
 
 def test_default_set_get_with_print_percentiles(env):
     p_str = '0,10,20,30,40,50,60,70,80,90,95,100'


### PR DESCRIPTION
The following PR:
- List ingress and egress separately on JSON and CSV exports. 
- Include overall BW results in the JSON and CSV and also raw values per second in the JSON timeseries
- This PR is backwards compatible on the JSON output

excerpt from the json output showcasing the added overall metrics ("KB/sec RX/TX", "KB/sec RX", "KB/sec TX") and the per second ones ("Bytes RX","Bytes TX")

```
,"Gets":{
			"Count": 2000000
			,"Ops/sec": 311352.91
			,"Hits/sec": 311352.91
			,"Misses/sec": 0.00
			,"Latency": 0.643
			,"Average Latency": 0.643
			,"Min Latency": 0.008
			,"Max Latency": 5.183
			,"KB/sec": 20922.58
			,"KB/sec RX/TX": 20922.58
			,"KB/sec RX": 11858.17
			,"KB/sec TX": 9064.41
			,"Time-Serie":{
				"0":{
					"Bytes RX": 12263160
					,"Bytes TX": 9372271
					,"Count": 314440
(...)
(...)
```
