### PR TITLE
Fixed deprecated and casting build errors caught on recent compilers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@ AM_INIT_AUTOMAKE
 AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([m4])
 LT_INIT
+
 CXXFLAGS="-O2 -g -Wall"
 
 # Checks for programs.

--- a/configure.ac
+++ b/configure.ac
@@ -23,8 +23,7 @@ AM_INIT_AUTOMAKE
 AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([m4])
 LT_INIT
-
-CXXFLAGS="-O2 -g -Wall"
+CXXFLAGS="-O2 -g -Wall -std=c++98"
 
 # Checks for programs.
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AM_INIT_AUTOMAKE
 AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([m4])
 LT_INIT
-CXXFLAGS="-O2 -g -Wall -std=c++98"
+CXXFLAGS="-O2 -g -Wall"
 
 # Checks for programs.
 AC_PROG_CXX

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1675,7 +1675,7 @@ int main(int argc, char *argv[])
             run_stats average(&cfg);
             average.aggregate_average(all_stats);
             char average_header[50];
-            sprintf(average_header,"AGGREGATED AVERAGE RESULTS (%u runs)", cfg.run_count);
+            snprintf(average_header, 50, "AGGREGATED AVERAGE RESULTS (%u runs)", cfg.run_count);
             average.print(outfile, &cfg, average_header, jsonhandler);
         } else {
             all_stats.begin()->print(outfile, &cfg, "ALL STATS", jsonhandler);

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1675,7 +1675,7 @@ int main(int argc, char *argv[])
             run_stats average(&cfg);
             average.aggregate_average(all_stats);
             char average_header[50];
-            snprintf(average_header, 50, "AGGREGATED AVERAGE RESULTS (%u runs)", cfg.run_count);
+            snprintf(average_header, sizeof(average_header) , "AGGREGATED AVERAGE RESULTS (%u runs)", cfg.run_count);
             average.print(outfile, &cfg, average_header, jsonhandler);
         } else {
             all_stats.begin()->print(outfile, &cfg, "ALL STATS", jsonhandler);

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -548,7 +548,7 @@ void shard_connection::handle_event(short events)
         if (!m_conns_manager->get_reqs_processed()) {
             /* Set timer for request rate */
             if (m_config->request_rate) {
-                struct timeval interval = { 0, (long int)m_config->request_interval_microsecond };
+                struct timeval interval = { 0, (int)m_config->request_interval_microsecond };
                 m_request_per_cur_interval = m_config->request_per_interval;
                 m_event_timer = event_new(m_event_base, -1, EV_PERSIST, cluster_client_timer_handler, (void *)this);
                 event_add(m_event_timer, &interval);


### PR DESCRIPTION
- Fixes #247 
- I've set an old standard to make this work even for old compiler versions. Agree @YaacovHazan and @yossigo ?