### PR TITLE
Fixed build for tls v1.3 on openssl v1.0.2. Added CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,17 @@ jobs:
       run: brew install autoconf automake libtool libevent pkg-config openssl@1.1
     - name: Build
       run: autoreconf -ivf && PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig ./configure && make
+
+  build-macos-openssl-1.0:
+    strategy:
+      matrix:
+        platform: [macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: brew install autoconf automake libtool libevent pkg-config
+    - name: Install openssl v1.0.2
+      run: brew install rbenv/tap/openssl@1.0
+    - name: Build
+      run: autoreconf -ivf && PKG_CONFIG_PATH=/usr/local/opt/openssl@1.0/lib/pkgconfig ./configure && make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,14 +103,14 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        platform: [macos-latest]
-    runs-on: ${{ matrix.platform }}
+        openssl: ["1.1", "3.0"]
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: brew install autoconf automake libtool libevent pkg-config openssl@1.1
+      run: brew install autoconf automake libtool libevent pkg-config openssl@${{ matrix.openssl }}
     - name: Build
-      run: autoreconf -ivf && PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig ./configure && make
+      run: autoreconf -ivf && PKG_CONFIG_PATH=/usr/local/opt/openssl@${{ matrix.openssl }}/lib/pkgconfig ./configure && make
 
   build-macos-openssl-1-0-2:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Build
       run: autoreconf -ivf && PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig ./configure && make
 
-  build-macos-openssl-1.0:
+  build-macos-openssl-1-0-2:
     strategy:
       matrix:
         platform: [macos-latest]

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ On Ubuntu/Debian distributions, simply install all prerequisites as follows:
 To build natively on macOS, use Homebrew to install the required dependencies:
 
 ```
-$ brew install autoconf automake libtool libevent pkg-config openssl@1.1
+$ brew install autoconf automake libtool libevent pkg-config openssl@3.0
 ```
 
 When running `./configure`, if it fails to find libssl it may be necessary to
 tweak the `PKG_CONFIG_PATH` environment variable:
 
 ```
-PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig ./configure
+PKG_CONFIG_PATH=/usr/local/opt/openssl@3.0/lib/pkgconfig ./configure
 ```
 
 ### Building and installing

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1392,8 +1392,11 @@ int main(int argc, char *argv[])
             SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1_1);
         if (!(cfg.tls_protocols & REDIS_TLS_PROTO_TLSv1_2))
             SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1_2);
+// TLS 1.3 is only available as from version 1.1.1.
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
         if (!(cfg.tls_protocols & REDIS_TLS_PROTO_TLSv1_3))
             SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1_3);
+#endif
 
         if (cfg.tls_cert) {
             if (!SSL_CTX_use_certificate_chain_file(cfg.openssl_ctx, cfg.tls_cert)) {


### PR DESCRIPTION
This PR:
- Fixes https://github.com/RedisLabs/memtier_benchmark/issues/235
- Introduces an CI check for openssl v1.0.2 build. 

Reproduced via:
```
brew install rbenv/tap/openssl@1.0
autoreconf -ivf
PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@1.0/lib/pkgconfig" ./configure
make
```


error:
```
(base) fco@fcos-Air memtier_benchmark % make
make  all-am
make[1]: Entering directory '/Users/fco/redislabs/memtier_benchmark'
  CXX      memtier_benchmark-memtier_benchmark.o
memtier_benchmark.cpp:328:16: warning: variable 'ignore' set but not used [-Wunused-but-set-variable]
        size_t ignore = fread(&R, sizeof(R), 1, f);
               ^
memtier_benchmark.cpp:1396:50: error: use of undeclared identifier 'SSL_OP_NO_TLSv1_3'
            SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1_3);
                                                 ^
1 warning and 1 error generated.
make[1]: *** [Makefile:751: memtier_benchmark-memtier_benchmark.o] Error 1
make[1]: Leaving directory '/Users/fco/redislabs/memtier_benchmark'
make: *** [Makefile:492: all] Error 2
```
