### PR TITLE
shard_connection: Support abstract Unix socket clients

### DIFF
--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -138,6 +138,7 @@ shard_connection::shard_connection(unsigned int id, connections_manager *conns_m
         m_address(NULL),
         m_port(NULL),
         m_unix_sockaddr(NULL),
+        m_unix_sockaddrlen(0),
         m_bev(NULL),
         m_event_timer(NULL),
         m_request_per_cur_interval(0),
@@ -162,9 +163,19 @@ shard_connection::shard_connection(unsigned int id, connections_manager *conns_m
         m_unix_sockaddr = (struct sockaddr_un *) malloc(sizeof(struct sockaddr_un));
         assert(m_unix_sockaddr != NULL);
 
+        memset(m_unix_sockaddr, 0, sizeof(struct sockaddr_un));
         m_unix_sockaddr->sun_family = AF_UNIX;
-        strncpy(m_unix_sockaddr->sun_path, m_config->unix_socket, sizeof(m_unix_sockaddr->sun_path) - 1);
-        m_unix_sockaddr->sun_path[sizeof(m_unix_sockaddr->sun_path) - 1] = '\0';
+
+        // Consider any Unix socket path prefixed with @ an abstract socket.
+        // In this scenario, sun_path[0] must be a null byte, and addrlen should be terminated at
+        // exactly the socket name length; see the manpage for unix(7).
+        if (m_config->unix_socket[0] == '@') {
+            strncpy(&m_unix_sockaddr->sun_path[1], &m_config->unix_socket[1], strlen(m_config->unix_socket) - 1);
+            m_unix_sockaddrlen = offsetof(struct sockaddr_un, sun_path) + strlen(m_config->unix_socket);
+        } else {
+            strncpy(m_unix_sockaddr->sun_path, m_config->unix_socket, sizeof(m_unix_sockaddr->sun_path) - 1);
+            m_unix_sockaddrlen = sizeof(struct sockaddr_un);
+        }
     }
 
     m_protocol = abs_protocol->clone();
@@ -321,7 +332,7 @@ int shard_connection::connect(struct connect_info *addr)
     m_connection_state = conn_in_progress;
 
     if (bufferevent_socket_connect(m_bev, m_unix_sockaddr ? (struct sockaddr *) m_unix_sockaddr : addr->ci_addr,
-                                   m_unix_sockaddr ? sizeof(struct sockaddr_un) : addr->ci_addrlen) == -1) {
+                                   m_unix_sockaddr ? m_unix_sockaddrlen : addr->ci_addrlen) == -1) {
         disconnect();
 
         benchmark_error_log("connect failed, error = %s\n", strerror(errno));

--- a/shard_connection.h
+++ b/shard_connection.h
@@ -174,6 +174,7 @@ private:
     std::string m_readable_id;
 
     struct sockaddr_un *m_unix_sockaddr;
+    int m_unix_sockaddrlen;
     struct bufferevent *m_bev;
     struct event_base *m_event_base;
     struct event *m_event_timer;


### PR DESCRIPTION
This PR introduces support for `--unix-socket` to accept an [abstract Unix socket](https://man7.org/linux/man-pages/man7/unix.7.html) when the socket name prefixed with `@`.

Motivation: I am orchestrating execution of the `memtier_benchmark` binary against Redis protocol-compliant servers in an environment where the filesystem is not writable and binding TCP listeners is not preferred. Abstract Unix sockets are a convenient solution for this scenario.

## Verification

### Preparation

```bash
$ redis-server --port 6120
```

### Unix socket file

```bash
$ socat -d UNIX-LISTEN:/tmp/redis.sock,reuseaddr,fork TCP:localhost:6120
```

```bash
$ netstat -ax | grep redis
unix  2      [ ACC ]     STREAM     LISTENING     223273   /tmp/redis.sock
```

```bash
$ ./memtier_benchmark --unix-socket /tmp/redis.sock --clients 1 --threads 1 --test-time 1
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,   1 secs]  0 threads:         173 ops,     171 (avg:     172) ops/sec, 7.31KB/sec (avg: 7.34KB/sec),  5.79 (avg:  5.78) msec latency

1         Threads
1         Connections per thread
1         Seconds


ALL STATS
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets           15.99          ---          ---         6.28750         3.32700        41.98300        41.98300         1.23 
Gets          156.88         0.00       156.88         5.72912         3.74300        22.27100        51.96700         6.11 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals        172.87         0.00       156.88         5.78076         3.61500        29.95100        51.96700         7.34
```

### Abstract Unix socket

```bash
$ socat -d ABSTRACT-LISTEN:redis.sock,reuseaddr,fork TCP:localhost:6120
```

```bash
$ netstat -ax | grep redis
unix  2      [ ACC ]     STREAM     LISTENING     239347   @redis.sock
```

```bash
$ ./memtier_benchmark --unix-socket @redis.sock --clients 1 --threads 1 --test-time 1
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
[RUN #1 100%,   1 secs]  0 threads:         151 ops,     149 (avg:     150) ops/sec, 6.38KB/sec (avg: 6.41KB/sec),  6.64 (avg:  6.62) msec latency

1         Threads
1         Connections per thread
1         Seconds


ALL STATS
============================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------------------------
Sets           13.99          ---          ---        12.56800         4.41500       111.61500       111.61500         1.07 
Gets          136.92         0.00       136.92         6.01606         4.04700        29.69500        38.91100         5.34 
Waits           0.00          ---          ---             ---             ---             ---             ---          --- 
Totals        150.91         0.00       136.92         6.62352         4.15900        29.69500       111.61500         6.41
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection setup for `--unix-socket` by changing how `sockaddr_un` is populated and the `addrlen` passed to `connect`, which can affect connectivity on different platforms/path lengths.
> 
> **Overview**
> Adds support for **abstract Unix domain sockets** when `--unix-socket` is prefixed with `@` by building a `sockaddr_un` with a leading NUL `sun_path` and computing the correct `addrlen`.
> 
> Introduces `m_unix_sockaddrlen` to track the per-socket address length and uses it in `bufferevent_socket_connect`, while also zero-initializing the `sockaddr_un` for safer initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bccd7038b1c3dfe21b899f634c22062216763353. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->