### PR TITLE
shard_connection: Handle non-blocking I/O errors on Unix socket client connect

### DIFF
--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -288,16 +288,27 @@ int shard_connection::connect(struct connect_info* addr) {
     // call connect
     m_connection_state = conn_in_progress;
 
-    if (bufferevent_socket_connect(m_bev,
-                  m_unix_sockaddr ? (struct sockaddr *) m_unix_sockaddr : addr->ci_addr,
-                  m_unix_sockaddr ? sizeof(struct sockaddr_un) : addr->ci_addrlen) == -1) {
+    while (true) {
+        if (bufferevent_socket_connect(m_bev,
+                      m_unix_sockaddr ? (struct sockaddr *) m_unix_sockaddr : addr->ci_addr,
+                      m_unix_sockaddr ? sizeof(struct sockaddr_un) : addr->ci_addrlen) == 0) {
+            return 0;
+        }
+
+        if (errno == EINPROGRESS) {
+            return 0;
+        }
+
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            // resource temporarily unavailable; try again
+            continue;
+        }
+
         disconnect();
 
         benchmark_error_log("connect failed, error = %s\n", strerror(errno));
         return -1;
     }
-
-    return 0;
 }
 
 void shard_connection::disconnect() {


### PR DESCRIPTION
Currently, the client socket is configured as non-blocking, but non-blocking I/O errors are not properly handled on `connect(2)`. ([Reference](https://github.com/RedisLabs/memtier_benchmark/blob/2.1.0/shard_connection.cpp#L247))

This seems to be problematic for Unix socket clients, where a restrictive server TCP listen backlog (or a restrictive system setting for `net.core.somaxconn`) relative to the number of concurrent memtier_benchmark clients (`--clients`) results in persistent benchmark execution failures with `Resource temporarily unavailable`.

A simple reproduction case:

```bash
# Artifically restrict the listen(2) backlog queue size.
$ echo -en 'port 0\nunixsocket /tmp/redis.sock\ntcp-backlog 1\n' | ./redis-server -
...
```

```bash
$ ./memtier_benchmark -S /tmp/redis.sock --clients 100
Writing results to stdout
[RUN #1] Preparing benchmark client...
connect failed, error = Resource temporarily unavailable
prepare: failed to connect, test aborted.
error: failed to prepare thread 0 for test.
```

This patch augments the `connect(2)` path to handle `EINPROGRESS` and `EAGAIN`/`EWOULDBLOCK` errors; the connect is simply retried indefinitely for the latter case.

With this patch:

```bash
$ ./memtier_benchmark -S /tmp/redis.sock --clients 100
Writing results to stdout
[RUN #1] Preparing benchmark client...
[RUN #1] Launching threads now...
^CUN #1 27%,   2 secs]  4 threads:     1078250 ops,  359004 (avg:  359421) ops/sec, 14.87MB/sec (avg: 14.89MB/sec),  1.11 (avg:  1.11) msec latency
...
```