### PR TITLE
Use SO_LINGER with timeout 0 to avoid thousands of server sockets in TIME_WAIT when using small reconnect intervals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
         sudo apt-get install redis
         sudo service redis-server stop
 
+    - name: Increase connection limit
+      run: |
+        sudo sysctl -w net.ipv4.tcp_fin_timeout=10
+        sudo sysctl -w net.ipv4.tcp_tw_reuse=1
+        ulimit -n 40960
+
     - name: Generate TLS test certificates
       if: matrix.platform == 'ubuntu-latest'
       run: |

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -352,6 +352,8 @@ def test_default_set_get_1_1(env):
 
 # run each test on different env
 def test_short_reconnect_interval(env):
+    # cluster mode dose not support reconnect-interval option
+    env.skipOnCluster()
     benchmark_specs = {"name": env.testName, "args": ['--reconnect-interval=1']}
     addTLSArgs(benchmark_specs, env)
     config = get_default_memtier_config()

--- a/tests/tests_oss_simple_flow.py
+++ b/tests/tests_oss_simple_flow.py
@@ -351,6 +351,33 @@ def test_default_set_get_1_1(env):
     env.assertEqual(merged_command_stats['cmdstat_set']['calls'], merged_command_stats['cmdstat_get']['calls'])
 
 # run each test on different env
+def test_short_reconnect_interval(env):
+    benchmark_specs = {"name": env.testName, "args": ['--reconnect-interval=1']}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config()
+    master_nodes_list = env.getMasterNodesList()
+    overall_expected_request_count = get_expected_request_count(config)
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    # Create a temporary directory
+    test_dir = tempfile.mkdtemp()
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+
+    # benchmark.run() returns True if the return code of memtier_benchmark was 0
+    memtier_ok = benchmark.run()
+
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+    merged_command_stats = {'cmdstat_set': {'calls': 0}, 'cmdstat_get': {'calls': 0}}
+    overall_request_count = agg_info_commandstats(master_nodes_connections, merged_command_stats)
+    assert_minimum_memtier_outcomes(config, env, memtier_ok, overall_expected_request_count, overall_request_count)
+
+
+# run each test on different env
 def test_default_set_get_3_runs(env):
     run_count = 3
     benchmark_specs = {"name": env.testName, "args": ['--run-count={}'.format(run_count)]}


### PR DESCRIPTION
- Fixes #232 
- Fixes #259 
