### PR TITLE
Add .gitattributes file for better behavior on Windows-based systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+* text eol=lf
+*.png binary


### PR DESCRIPTION
Adding this file will ensure text files are checked out on all dev systems as LF, which is **required** for this project to build correctly.

As mentioned in #163, if you check out this project on a Windows system and try to `docker build`, you'll get:
```
7.187 configure: creating ./config.status
.in'7 config.status: error: cannot find input file: `
```

I determined this is because text-based files **that are expected to be LF at build time** are being automatically checked out as CRLF on Windows machines. When those CRLF files are copied over to a Linux-based Docker context at build time, they cause the build to blow up. After renormalizing all text files as LF, the build succeeds as expected.

This change will ensure all contributors, no matter the dev OS, will be able to work with this repository as intended, immediately upon checkout, once and for all.