### PR TITLE
Create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+Dockerfile*
+**/Dockerfile*
+.gitignore
+**/.gitignore
+.gitattributes
+README*
+**/README*
+COPYING*
+**/COPYING*
+LICENSE*
+**/LICENSE*
+.github/*
+tests/*
+utils/*


### PR DESCRIPTION
This pull request creates a `.dockerignore` file to ensure that certain files and directories are excluded from Docker builds, and therefore do not unnecessarily invalidate Docker's build cache. The changes primarily focus on ignoring common files and directories that are not needed in the Docker context.