### PR TITLE
Migrate to v4 of actions/upload-artifact and actions/download-artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
           cd sources && dpkg-buildpackage -S
     - name: Upload source package artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: source-${{ matrix.dist }}
         path: |
@@ -76,7 +76,7 @@ jobs:
     - name: Prepare sbuild environment
       run: sudo ./debian/setup_sbuild.sh ${{ matrix.dist }} ${{ env.BUILD_ARCH }}
     - name: Get source package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: source-${{ matrix.dist }}
     - name: Build binary package
@@ -87,7 +87,7 @@ jobs:
             --build ${{ env.BUILD_ARCH }} \
             --dist ${{ matrix.dist }} *.dsc
     - name: Upload binary package artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: binary-${{ matrix.dist }}-${{ matrix.arch }}
         path: |
@@ -109,7 +109,9 @@ jobs:
     container: ${{ matrix.image }}
     steps:
     - name: Get binary packages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
+      with:
+        name: binary-${{ matrix.dist }}-${{ env.ARCH }}
     - name: Install packages
       run: |
         apt-get update
@@ -130,7 +132,9 @@ jobs:
       env:
         APT_SIGNING_KEY: ${{ secrets.APT_SIGNING_KEY }}
     - name: Get binary packages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
+      with:
+        name: binary-${{ matrix.dist }}-${{ env.ARCH }}
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use v4 of actions/upload-artifact and actions/download-artifact, following the [deprecation](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/) and [migration guidelines](https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md) outlined in the respective repositories.