### PR TITLE
GH actions deprecation fixes: migrate checkout github action from v2 to v4 and openssl@1.1/1.0 fixes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       matrix:
         openssl: ["3.0"]
-    runs-on: macos-latest
+    runs-on: macos-15
     continue-on-error: true
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,11 +124,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: brew install autoconf automake libtool libevent pkg-config
-    - name: Install openssl v1.0.2
-      run: brew install rbenv/tap/openssl@1.0
+      run: brew install autoconf automake libtool libevent openssl@1.1
     - name: Build
-      run: autoreconf -ivf && PKG_CONFIG_PATH=`brew --prefix openssl@1.0`/lib/pkgconfig ./configure && make
+      run: autoreconf -ivf && PKG_CONFIG_PATH=`brew --prefix openssl@1.1`/lib/pkgconfig ./configure && make
 
 
   build-macos-openssl-1-0-2:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,12 +104,12 @@ jobs:
     strategy:
       matrix:
         openssl: ["3.0"]
-    runs-on: macos-15
+    runs-on: macos-latest
     continue-on-error: true
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: brew install autoconf automake libtool libevent pkg-config openssl@${{ matrix.openssl }}
+      run: brew install autoconf automake libtool libevent openssl@${{ matrix.openssl }}
     - name: Build
       run: autoreconf -ivf && PKG_CONFIG_PATH=`brew --prefix openssl@${{ matrix.openssl }}`/lib/pkgconfig ./configure && make
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build-notls:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
@@ -21,7 +21,7 @@ jobs:
         platform: [ubuntu-latest, ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
@@ -103,7 +103,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        openssl: ["1.1", "3.0"]
+        openssl: ["3.0"]
     runs-on: macos-latest
     continue-on-error: true
     steps:
@@ -112,6 +112,24 @@ jobs:
       run: brew install autoconf automake libtool libevent pkg-config openssl@${{ matrix.openssl }}
     - name: Build
       run: autoreconf -ivf && PKG_CONFIG_PATH=`brew --prefix openssl@${{ matrix.openssl }}`/lib/pkgconfig ./configure && make
+
+  # According to https://github.com/actions/runner-images/blob/macos-14-arm64/20241119.509/images/macos/macos-14-arm64-Readme.md
+  # [macOS] OpenSSL 1.1 will be removed and OpenSSL 3 will be the default for all macOS images from November 4, 2024
+  # so use macos-12 which does not have the deprecation notice
+  build-macos-openssl-1-1:
+    strategy:
+      matrix:
+        platform: [macos-12]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: brew install autoconf automake libtool libevent pkg-config
+    - name: Install openssl v1.0.2
+      run: brew install rbenv/tap/openssl@1.0
+    - name: Build
+      run: autoreconf -ivf && PKG_CONFIG_PATH=`brew --prefix openssl@1.0`/lib/pkgconfig ./configure && make
+
 
   build-macos-openssl-1-0-2:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
   build-macos-openssl-1-0-2:
     strategy:
       matrix:
-        platform: [macos-latest]
+        platform: [macos-12]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: sources
     - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
         exclude: ${{ fromJSON(vars.BUILD_EXCLUDE) }}
     needs: build-source-package
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Determine build architecture
       run: |
           if [ ${{ matrix.arch }} = "i386" ]; then


### PR DESCRIPTION
## checkout change 
Following the error in: https://github.com/RedisLabs/memtier_benchmark/actions/runs/11958405087/job/33340558967

```
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```

we can see in https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ node12 is deprectated and node16 as well. 
We should bump checkout actions from v2 to v4 to solve this.

## macos changes

According to https://github.com/actions/runner-images/blob/macos-14-arm64/20241119.509/images/macos/macos-14-arm64-Readme.md
 > [macOS] OpenSSL 1.1 will be removed and OpenSSL 3 will be the default for all macOS images from November 4, 2024
 
 so we  use macos-12 which does not have the deprecation notice and won't fail.