### PR TITLE
Testing ubuntu and debian builds on CI. all v1/v2 actions to v4 migrated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
-        apt-get -qq update
-        apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev
+        apt-get -qq update -y
+        apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev -y
 
     - name: Build
       run: autoreconf -ivf && ./configure && make -j

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   smoketest-build-distros:
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       ARCH: amd64
       # required by ubuntu:bionic
@@ -23,6 +24,7 @@ jobs:
     - name: Checkout Code for other versions
       if: matrix.image != 'ubuntu:bionic'
       uses: actions/checkout@v4
+
     - name: Install dependencies
       run: |
         apt-get -qq update -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     container: ${{ matrix.image }}
     name: Build ${{ matrix.image }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: ${{ matrix.image == 'ubuntu:18.04' && 'actions/checkout@v3' || 'actions/checkout@v4' }}
     - name: Install dependencies
       run: |
         apt-get -qq update -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
-        sudo apt-get -qq update
-        sudo apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev
+        apt-get -qq update
+        apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev
 
     - name: Build
       run: autoreconf -ivf && ./configure && make -j

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       # required by ubuntu:bionic
       # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      DEBIAN_FRONTEND: noninteractive
     strategy:
       matrix:
         image: ${{ fromJSON(vars.SMOKE_TEST_IMAGES) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -qq update -y
-        apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev -y
+        apt-get install -y \
+        build-essential autoconf automake libpcre3-dev libevent-dev \
+        pkg-config zlib1g-dev libssl-dev libboost-all-dev cmake flex
 
     - name: Build
       run: autoreconf -ivf && ./configure && make -j

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,25 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  smoketest-build-distros:
+    runs-on: ubuntu-latest
+    env:
+      ARCH: amd64
+    strategy:
+      matrix:
+        image: ${{ fromJSON(vars.SMOKE_TEST_IMAGES) }}
+    container: ${{ matrix.image }}
+    name: Build ${{ matrix.image }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev
+
+    - name: Build
+      run: autoreconf -ivf && ./configure && make -j
+
   build-notls:
     runs-on: ubuntu-latest
     steps:
@@ -107,7 +126,7 @@ jobs:
     runs-on: macos-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent openssl@${{ matrix.openssl }}
     - name: Build
@@ -122,7 +141,7 @@ jobs:
         platform: [macos-12]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent openssl@1.1
     - name: Build
@@ -135,7 +154,7 @@ jobs:
         platform: [macos-12]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent pkg-config
     - name: Install openssl v1.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,13 @@ jobs:
     container: ${{ matrix.image }}
     name: Build ${{ matrix.image }}
     steps:
-    - uses: ${{ matrix.image == 'ubuntu:18.04' && 'actions/checkout@v3' || 'actions/checkout@v4' }}
+    - name: Checkout Code for ubuntu:bionic
+      if: matrix.image == 'ubuntu:bionic'
+      uses: actions/checkout@v3
+
+    - name: Checkout Code for other versions
+      if: matrix.image != 'ubuntu:bionic'
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         apt-get -qq update -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ARCH: amd64
+      # required by ubuntu:bionic
+      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       matrix:
         image: ${{ fromJSON(vars.SMOKE_TEST_IMAGES) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,9 +160,6 @@ jobs:
   publish-to-apt:
     env:
       DEB_S3_VERSION: "0.11.3"
-      # required by ubuntu:bionic
-      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     runs-on: ubuntu-latest
     environment: build
     needs: smoke-test-packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,15 @@ jobs:
           exit 1
         fi
         echo "BUILD_ARCH=$BUILD_ARCH" >> $GITHUB_ENV
-    - name: Get binary packages
+    - name: Get binary packages for ubuntu:bionic
+      if: matrix.image == 'ubuntu:bionic'
+      uses: actions/download-artifact@v3
+      with:
+        name: binary-${{ env.BUILD_ARCH }}-${{ env.ARCH }}
+        path: binary-${{ env.BUILD_ARCH }}-${{ env.ARCH }}
+
+    - name: Get binary packages for other versions
+      if: matrix.image != 'ubuntu:bionic'
       uses: actions/download-artifact@v4
       with:
         name: binary-${{ env.BUILD_ARCH }}-${{ env.ARCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,9 @@ jobs:
     needs: build-binary-package
     env:
       ARCH: amd64
+      # required by ubuntu:bionic
+      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       matrix:
         image: ${{ fromJSON(vars.SMOKE_TEST_IMAGES) }}
@@ -149,6 +152,9 @@ jobs:
   publish-to-apt:
     env:
       DEB_S3_VERSION: "0.11.3"
+      # required by ubuntu:bionic
+      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     runs-on: ubuntu-latest
     environment: build
     needs: smoke-test-packages


### PR DESCRIPTION
To ensure we validate some of the steps of the release we're now testing with the SMOKE_TEST_IMAGES on CI and not only on release.

Sample of focal failure due focal check v4 issue:
https://github.com/RedisLabs/memtier_benchmark/actions/runs/11999571766/job/33447645699

fixed on v3 being used only for focal:
https://github.com/RedisLabs/memtier_benchmark/actions/runs/11999864960/job/33448272461?pr=282