### PR TITLE
macOS-12 environment is deprecated. Switching actions to macOS-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,12 @@ jobs:
 
   # According to https://github.com/actions/runner-images/blob/macos-14-arm64/20241119.509/images/macos/macos-14-arm64-Readme.md
   # [macOS] OpenSSL 1.1 will be removed and OpenSSL 3 will be the default for all macOS images from November 4, 2024
-  # so use macos-12 which does not have the deprecation notice
+  # so use macos-13 which does not have the deprecation notice
+  # macos-13 details: https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
   build-macos-openssl-1-1:
     strategy:
       matrix:
-        platform: [macos-12]
+        platform: [macos-13]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4
@@ -165,7 +166,7 @@ jobs:
   build-macos-openssl-1-0-2:
     strategy:
       matrix:
-        platform: [macos-12]
+        platform: [macos-13]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
from worfklow: https://github.com/RedisLabs/memtier_benchmark/actions/runs/12622199253/job/35169853336?pr=286 

> Annotations
2 errors
GitHub Actions has encountered an internal error when running your job.
The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721

To address this we're switching to macos-13 which still has openssl 1.1 according to https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md