### PR TITLE
Doing coverage checks on Ubuntu 22.04 instead of latest due to autoconf lcov >= 2.0 issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,22 @@ jobs:
     - name: Build
       run: autoreconf -ivf && ./configure --disable-tls && make -j
 
+  build-ubuntu-latest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev
+
+    - name: Build
+      run: autoreconf -ivf && ./configure --disable-tls && make -j
+
   build-ubuntu:
     strategy:
       matrix:
-        platform: [ubuntu-latest, ubuntu-20.04]
+        platform: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4
@@ -61,6 +73,8 @@ jobs:
         sudo apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev
 
     - name: Build
+      # for coverage reports we need to use Ubuntu 22.04 or lower
+      # (given Ubuntu 24.04 uses lcov >= 2.0 which is not support on autoconf still)
       run: autoreconf -ivf && ./configure --enable-code-coverage && make -j
     - name: Setup Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
CI on memtier is failing [reference failure](https://github.com/RedisLabs/memtier_benchmark/actions/runs/12734599388/job/35492362676) but due to ubuntu 24.04 support (they should have changed ubuntu:latest to it). 
Related to lcov >= 2.0 version check. To fix it we should do coverage checks on Ubuntu 22.04 instead of latest. 
On 24.04 we have:

```
Get:42 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 lcov all 2.0-4ubuntu2 [223 kB]
```

and we want:

```
checking for lcov version... invalid
configure: error: You must have one of the following versions of lcov: 1.6 1.7 1.8 1.9 1.10 1.11 1.12 1.13 1.14 1.15 1.16 (found: /etc/lcovrc).
Error: Process completed with exit code 1.
```

reference happening to others:
https://github.com/autoconf-archive/autoconf-archive/pull/298#issuecomment-2408527940

> After my github-actions runner was updated to ubuntu 24.04.1 (latest) it received new version of lcov.
 This also broke my CI/CD workflow. I hope maintainers will address this issue!
 For now I will downgrade my runner to ubuntu 22.04.