### PR TITLE
Revert LATENCY_HDR_SEC_SIGDIGTS to 2. Optimize summarize_current_second by using hdr_value_at_percentiles() instead of N x hdr_value_at_percentile().

### DIFF
--- a/deps/hdr_histogram/hdr_histogram.h
+++ b/deps/hdr_histogram/hdr_histogram.h
@@ -285,6 +285,18 @@ int64_t hdr_max(const struct hdr_histogram* h);
 int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile);
 
 /**
+ * Get the values at the given percentiles.
+ *
+ * @param h "This" pointer.
+ * @param percentiles The ordered percentiles array to get the values for.
+ * @param length Number of elements in the arrays.
+ * @param values Destination array containing the values at the given percentiles.
+ * The values array should be allocated by the caller.
+ * @return 0 on success, ENOMEM if the provided destination array is null.
+ */
+int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percentiles, int64_t *values, size_t length);
+
+/**
  * Gets the standard deviation for the values in the histogram.
  *
  * @param h "This" pointer

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -117,8 +117,9 @@ run_stats::run_stats(benchmark_config *config) :
 {
     memset(&m_start_time, 0, sizeof(m_start_time));
     memset(&m_end_time, 0, sizeof(m_end_time));
-    quantiles_list = config->print_percentiles.quantile_list;
-
+    std::vector<float> quantiles_list_float = config->print_percentiles.quantile_list;
+    std::sort(quantiles_list_float.begin(), quantiles_list_float.end());
+    quantiles_list = std::vector<double>(quantiles_list_float.begin(), quantiles_list_float.end());
     if (config->arbitrary_commands->is_defined()) {
         setup_arbitrary_commands(config->arbitrary_commands->size());
     }
@@ -882,7 +883,7 @@ void run_stats::summarize(totals& result) const
 void result_print_to_json(json_handler * jsonhandler, const char * type, double ops_sec,
                           double hits, double miss, double moved, double ask, double kbs, double kbs_rx, double kbs_tx,
                           double latency, long m_total_latency, long ops,
-                          std::vector<float> quantile_list, struct hdr_histogram* latency_histogram, 
+                          std::vector<double> quantile_list, struct hdr_histogram* latency_histogram,
                           std::vector<unsigned int> timestamps, 
                           std::vector<one_sec_cmd_stats> timeserie_stats )
 {

--- a/run_stats.h
+++ b/run_stats.h
@@ -97,7 +97,7 @@ protected:
     totals m_totals;
 
     std::list<one_second_stats> m_stats;
-    std::vector<float> quantiles_list;
+    std::vector<double> quantiles_list;
 
     // current second stats ( appended to m_stats and reset every second )
     one_second_stats m_cur_stats;

--- a/run_stats_types.cpp
+++ b/run_stats_types.cpp
@@ -72,11 +72,14 @@ void one_sec_cmd_stats::merge(const one_sec_cmd_stats& other) {
     m_min_latency = other.m_min_latency < m_min_latency ? other.m_min_latency : m_min_latency;
 }
 
-void one_sec_cmd_stats::summarize_quantiles(safe_hdr_histogram histogram, std::vector<float> quantiles) {
-    for (std::size_t i = 0; i < quantiles.size(); i++){
-        const float quantile = quantiles[i];
-        const double value = hdr_value_at_percentile(histogram, quantile)/ (double) LATENCY_HDR_RESULTS_MULTIPLIER;
-        summarized_quantile_values.push_back(value);
+void one_sec_cmd_stats::summarize_quantiles(safe_hdr_histogram histogram, std::vector<double> sorted_quantiles) {
+    std::vector<int64_t> values(sorted_quantiles.size());
+    int result = hdr_value_at_percentiles(histogram, sorted_quantiles.data(), values.data(), sorted_quantiles.size());
+    if (result != 0) {
+        return;
+    }
+    for (std::size_t i = 0; i < sorted_quantiles.size(); i++) {
+        summarized_quantile_values.push_back(values[i] / static_cast<double>(LATENCY_HDR_RESULTS_MULTIPLIER));
     }
 }
 

--- a/run_stats_types.h
+++ b/run_stats_types.h
@@ -24,7 +24,7 @@
 #define LATENCY_HDR_SIGDIGTS 3
 #define LATENCY_HDR_SEC_MIN_VALUE 10
 #define LATENCY_HDR_SEC_MAX_VALUE 600000000 ## LL
-#define LATENCY_HDR_SEC_SIGDIGTS 3
+#define LATENCY_HDR_SEC_SIGDIGTS 2
 #define LATENCY_HDR_RESULTS_MULTIPLIER 1000
 #define LATENCY_HDR_GRANULARITY 10
 
@@ -90,7 +90,14 @@ public:
     one_sec_cmd_stats();
     void reset();
     void merge(const one_sec_cmd_stats& other);
-    void summarize_quantiles(safe_hdr_histogram histogram, std::vector<float> quantiles);
+    /**
+     * Summarizes quantiles from the given histogram.
+     *
+     * @param histogram The histogram from which quantile values are extracted.
+     * @param sorted_quantiles A sorted (ascending order) vector of quantiles for which values will be computed.
+     *                         The caller must ensure the vector is sorted from smallest to largest.
+     */
+    void summarize_quantiles(safe_hdr_histogram histogram, std::vector<double> sorted_quantiles);
     void update_op(unsigned int bytes_rx, unsigned int bytes_tx,  unsigned int latency);
     void update_op(unsigned int bytes_rx, unsigned int bytes_tx,  unsigned int latency, unsigned int hits, unsigned int misses);
     void update_moved_op(unsigned int bytes_rx, unsigned int bytes_tx,  unsigned int latency);


### PR DESCRIPTION
Fixes #294 

It also updates the hdr histogram dependency to make usage of 2 optimizations we've added there quite a while ago:
- https://github.com/HdrHistogram/HdrHistogram_c/pull/90
- https://github.com/HdrHistogram/HdrHistogram_c/pull/94

Altogether, we've reverted the regression introduced in v2.1.1 and also reduced by 22% the CPU usage for the same QPS (even a bit higher). 

Sample benchmark command:
```
./memtier_benchmark --hide-histogram --pipeline=1 -c 100 -t 100 -d 1000 --key-maximum=9625503 --key-pattern=R:R --ratio=1:0  --test-time=60
```


CPU usage fix and improvement (red is this PR) :
![10K connections,CPU per version (lower better)](https://github.com/user-attachments/assets/520c97d5-03dd-48ae-82e4-b4309fa1c728)

Ops/sec fix and improvement (red is this PR) :

![10K connections, ops_sec per version (higher better)](https://github.com/user-attachments/assets/694e9af7-6524-47bc-9759-f4a08c875cc2)
