### PR TITLE
Use libpcre3-dev on apt release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
           sudo apt-get update && \
           sudo apt-get install \
-            debhelper dput libevent-dev libpcre2-dev libssl-dev pkg-config
+            debhelper dput libevent-dev libpcre3-dev libssl-dev pkg-config
     - name: Create changelog
       env:
         VERSION: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}


### PR DESCRIPTION
Fixes issue detected on 2.1.4 release process: https://github.com/RedisLabs/memtier_benchmark/actions/runs/13049336672/job/36405897176

we're already using it in normal CI flows: https://github.com/RedisLabs/memtier_benchmark/blob/master/.github/workflows/ci.yml#L33