### PR TITLE
Add option to print all histograms instead of only BEST and WORST

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -159,7 +159,8 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
         "wait-ratio = %u:%u\n"
         "num-slaves = %u-%u\n"
         "wait-timeout = %u-%u\n"
-        "json-out-file = %s\n",
+        "json-out-file = %s\n"
+        "print-all-hists = %s\n",
         cfg->server,
         cfg->port,
         cfg->unix_socket,
@@ -209,7 +210,8 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
         cfg->wait_ratio.a, cfg->wait_ratio.b,
         cfg->num_slaves.min, cfg->num_slaves.max,
         cfg->wait_timeout.min, cfg->wait_timeout.max,
-        cfg->json_out_file);
+        cfg->json_out_file,
+        cfg->print_all_hists ? "yes" : "no");
 }
 
 static void config_print_to_json(json_handler * jsonhandler, struct benchmark_config *cfg)
@@ -267,6 +269,7 @@ static void config_print_to_json(json_handler * jsonhandler, struct benchmark_co
     jsonhandler->write_obj("wait-ratio"        ,"\"%u:%u\"",    cfg->wait_ratio.a, cfg->wait_ratio.b);
     jsonhandler->write_obj("num-slaves"        ,"\"%u:%u\"",    cfg->num_slaves.min, cfg->num_slaves.max);
     jsonhandler->write_obj("wait-timeout"      ,"\"%u-%u\"",   	cfg->wait_timeout.min, cfg->wait_timeout.max);
+    jsonhandler->write_obj("print-all-hists"   ,"\"%s\"",       cfg->print_all_hists ? "true" : "false");
 
     jsonhandler->close_nesting();
 }
@@ -403,6 +406,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_show_config,
         o_hide_histogram,
         o_print_percentiles,
+        o_print_all_hists,
         o_distinct_client_seed,
         o_randomize,
         o_client_stats,
@@ -456,6 +460,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         { "show-config",                0, 0, o_show_config },
         { "hide-histogram",             0, 0, o_hide_histogram },
         { "print-percentiles",          1, 0, o_print_percentiles },
+        { "print-all-hists",            0, 0, o_print_all_hists },
         { "distinct-client-seed",       0, 0, o_distinct_client_seed },
         { "randomize",                  0, 0, o_randomize },
         { "requests",                   1, 0, 'n' },
@@ -586,6 +591,9 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                         fprintf(stderr, "error: quantiles must be expressed as [0.0-100.0],[0.0-100.0](,...) .\n");
                         return -1;
                     }
+                    break;
+                case o_print_all_hists:                
+                    cfg->print_all_hists = true;
                     break;
                 case o_distinct_client_seed:
                     cfg->distinct_client_seed++;
@@ -977,6 +985,7 @@ void usage() {
             "      --show-config              Print detailed configuration before running\n"
             "      --hide-histogram           Don't print detailed latency histogram\n"
             "      --print-percentiles        Specify which percentiles info to print on the results table (by default prints percentiles: 50,99,99.9)\n"
+            "      --print-all-hists          When performing multiple test iterations, print histograms for all iterations\n"
             "      --cluster-mode             Run client in cluster mode\n"
             "  -h, --help                     Display this help\n"
             "  -v, --version                  Display version information\n"
@@ -1651,29 +1660,38 @@ int main(int argc, char *argv[])
             jsonhandler->close_nesting();
         }
 
-        // If more than 1 run was used, compute best, worst and average
+        // If more than 1 run was used display appropriate info
         if (cfg.run_count > 1) {
-            unsigned int min_ops_sec = (unsigned int) -1;
-            unsigned int max_ops_sec = 0;
-            run_stats* worst = NULL;
-            run_stats* best = NULL;
-            for (std::vector<run_stats>::iterator i = all_stats.begin(); i != all_stats.end(); i++) {
-                unsigned long usecs = i->get_duration_usec();
-                unsigned int ops_sec = (int)(((double)i->get_total_ops() / (usecs > 0 ? usecs : 1)) * 1000000);
-                if (ops_sec < min_ops_sec || worst == NULL) {
-                    min_ops_sec = ops_sec;
-                    worst = &(*i);
+            // User wants the best and worst
+            if (!cfg.print_all_hists) {
+                unsigned int min_ops_sec = (unsigned int) -1;
+                unsigned int max_ops_sec = 0;
+                run_stats* worst = NULL;
+                run_stats* best = NULL;
+                for (std::vector<run_stats>::iterator i = all_stats.begin(); i != all_stats.end(); i++) {
+                    unsigned long usecs = i->get_duration_usec();
+                    unsigned int ops_sec = (int)(((double)i->get_total_ops() / (usecs > 0 ? usecs : 1)) * 1000000);
+                    if (ops_sec < min_ops_sec || worst == NULL) {
+                        min_ops_sec = ops_sec;
+                        worst = &(*i);
+                    }
+                    if (ops_sec > max_ops_sec || best == NULL) {
+                        max_ops_sec = ops_sec;
+                        best = &(*i);
+                    }
                 }
-                if (ops_sec > max_ops_sec || best == NULL) {
-                    max_ops_sec = ops_sec;
-                    best = &(*i);
+
+                // Best results:
+                best->print(outfile, &cfg, "BEST RUN RESULTS", jsonhandler);
+                // worst results:
+                worst->print(outfile, &cfg, "WORST RUN RESULTS", jsonhandler);
+            // User wants to see a separate histogram per run
+            } else {
+                for (auto i = 0U; i < all_stats.size(); i++) {
+                    auto run_title = std::string("RUN #") + std::to_string(i + 1) + " RESULTS";
+                    all_stats[i].print(outfile, &cfg, run_title.c_str(), jsonhandler);
                 }
             }
-
-            // Best results:
-            best->print(outfile, &cfg, "BEST RUN RESULTS", jsonhandler);
-            // worst results:
-            worst->print(outfile, &cfg, "WORST RUN RESULTS", jsonhandler);
             // average results:
             run_stats average(&cfg);
             average.aggregate_average(all_stats);

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -63,6 +63,7 @@ struct benchmark_config {
     int show_config;
     int hide_histogram;
     config_quantiles print_percentiles;
+    bool print_all_hists;
     int distinct_client_seed;
     int randomize;
     int next_client_idx;


### PR DESCRIPTION
This functionallity is needed since sometimes theres a need to see a specific run's results.
Controlled by a new flag: --print-all-hists yes