### PR TITLE
Test build source package, build binary package and smoke test on CI.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,15 @@ on:
         description: "Docker images for smoke testing (comma-separated, e.g., ubuntu:20.04,ubuntu:22.04,ubuntu:24.04)"
         required: false
         default: "ubuntu:20.04,ubuntu:22.04,ubuntu:24.04"
+      build_runner:
+        description: "os in which build steps run on"
+        required: false
+        default: "ubuntu-22.04"
+        type: string
 jobs:
   build-source-package:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.build_runner }}
+    continue-on-error: true
     strategy:
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
@@ -27,6 +33,24 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: sources
+    - name: Validate configure.ac version matches GitHub Release (only on release)
+      if: github.event.release.tag_name != ''
+      env:
+        VERSION: ${{ github.event.release.tag_name }}
+      run: |
+        # Extract the current version from configure.ac
+        CURRENT_VERSION=$(awk -F'[(),]' '/AC_INIT/ {print $3}' sources/configure.ac | tr -d ' ')
+
+        echo "Current configure.ac version: $CURRENT_VERSION"
+        echo "GitHub Release version: $VERSION"
+
+        # Check if versions match
+        if [ "$CURRENT_VERSION" != "$VERSION" ]; then
+          echo "❌ Version mismatch! configure.ac: $CURRENT_VERSION, GitHub Release: $VERSION"
+          exit 1  # Fail the build
+        else
+          echo "Version match. Proceeding with the build."
+        fi
     - name: Install dependencies
       run: |
           sudo apt-get update && \
@@ -63,7 +87,8 @@ jobs:
             memtier-benchmark_*.tar.*
 
   build-binary-package:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.build_runner }}
+    continue-on-error: true
     environment: build
     strategy:
       matrix:
@@ -121,7 +146,7 @@ jobs:
           *.deb
 
   smoke-test-packages:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.build_runner }}
     needs: build-binary-package
     env:
       ARCH: amd64


### PR DESCRIPTION
  - we were able to reproduce the error from   https://github.com/RedisLabs/memtier_benchmark/actions/runs/13053957118/job/36420569728 in https://github.com/RedisLabs/memtier_benchmark/actions/runs/13237772497/job/36946536026?pr=299 and fix it. 
- Ensure that if we're on a release action that the release version matches the one in the code/artifacts.
