### PR TITLE
Remove ubuntu-20.04 from build-build matrix due to GH removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        platform: [ubuntu-22.04, ubuntu-20.04]
+        platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- More info at https://github.com/actions/runner-images/issues/11101