### PR TITLE
Bumping version to 2.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ dnl You should have received a copy of the GNU General Public License
 dnl along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 AC_PREREQ(2.59)
-AC_INIT(memtier_benchmark,2.1.4,oss@redis.com)
+AC_INIT(memtier_benchmark,2.2.0,oss@redis.com)
 AC_CONFIG_SRCDIR([memtier_benchmark.cpp])
 AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE


### PR DESCRIPTION
## Summary

This PR bumps the version from **2.1.4** to **2.2.0** to include recent feature additions and improvements.

### New Features on 2.2.0 (the reason for the minor bump)
- Added option to print and save all results when running multiple test iterations (#298 by @Yuval-Ariel).
- Initial support for keys following Zipfian distribution (#166 by @lfsu-ali).
- Enabled Zipfian key distribution for arbitrary commands (#314 by @filipecosta90).
- Added `--uri` flag to `memtier_benchmark` (compatible with `redis-cli` and `redis-benchmark` URI parsing) (#311 by @filipecosta90).

### Improvements & Fixes
- Improved deconstruction performance of `imported_keylist` (#239 by @DarrenJiang13).
- Fixed request handling issue (#307 by @maxb-io).
- Removed `ubuntu-20.04` from build matrix following GitHub deprecation (#309 by @paulorsousa).
- Added macOS installation instructions via Homebrew (#313 by @paulorsousa).

