### PR TITLE
Remove libpcre3-dev dependency from build and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
 
+# CI testing includes:
+# - Debian versions: 11 (bullseye), 12 (bookworm), 13 (trixie), sid (unstable)
+# - Various smoke test images (configurable via repository variables)
+# - TLS and no-TLS builds
+# - Code coverage and static analysis
+
 on: [push, pull_request]
 
 jobs:
@@ -30,8 +36,46 @@ jobs:
       run: |
         apt-get -qq update -y
         apt-get install -y \
-        build-essential autoconf automake libpcre3-dev libevent-dev \
+        build-essential autoconf automake libevent-dev \
         pkg-config zlib1g-dev libssl-dev libboost-all-dev cmake flex
+
+    - name: Build
+      run: autoreconf -ivf && ./configure && make -j
+
+  test-debian-versions:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    strategy:
+      matrix:
+        debian_version:
+          - "debian:bullseye"    # Debian 11 (oldstable)
+          - "debian:bookworm"    # Debian 12 (stable)
+          - "debian:trixie"      # Debian 13 (testing)
+          - "debian:sid"         # Debian unstable
+    container: ${{ matrix.debian_version }}
+    name: Test ${{ matrix.debian_version }}
+    steps:
+    - name: Install git and basic tools
+      run: |
+        apt-get update -qq
+        apt-get install -y git ca-certificates
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: |
+        apt-get update -qq
+        apt-get install -y \
+          build-essential \
+          autoconf \
+          automake \
+          pkg-config \
+          libevent-dev \
+          zlib1g-dev \
+          libssl-dev
 
     - name: Build
       run: autoreconf -ivf && ./configure && make -j
@@ -43,7 +87,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev
+        sudo apt-get install lcov autoconf automake pkg-config libevent-dev
 
     - name: Build
       run: autoreconf -ivf && ./configure --disable-tls && make -j
@@ -55,7 +99,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev
+        sudo apt-get install lcov autoconf automake pkg-config libevent-dev
 
     - name: Build
       run: autoreconf -ivf && ./configure --disable-tls && make -j
@@ -70,7 +114,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get install lcov autoconf automake pkg-config libevent-dev libpcre3-dev libssl-dev
+        sudo apt-get install lcov autoconf automake pkg-config libevent-dev libssl-dev
 
     - name: Build
       # for coverage reports we need to use Ubuntu 22.04 or lower

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
           sudo apt-get update && \
           sudo apt-get install \
-            build-essential autoconf automake libpcre3-dev libevent-dev \
+            build-essential autoconf automake libevent-dev \
             pkg-config zlib1g-dev libssl-dev libboost-all-dev cmake flex \
             debhelper dput
     - name: Create changelog

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update
 RUN \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y \
-    build-essential autoconf automake libpcre3-dev libevent-dev \
+    build-essential autoconf automake libevent-dev \
     pkg-config zlib1g-dev libssl-dev libboost-all-dev cmake flex
 COPY . /memtier_benchmark
 WORKDIR /memtier_benchmark

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,7 +2,7 @@ FROM alpine:latest as builder
 RUN \
   apk add \
     make g++ autoconf automake libtool pkgconfig \
-    pcre-dev libevent-dev zlib-dev openssl-dev
+    libevent-dev zlib-dev openssl-dev
 COPY . /src
 WORKDIR /src
 RUN autoreconf -ivf && ./configure && make && make install
@@ -11,6 +11,6 @@ FROM alpine:latest
 LABEL Description="memtier_benchmark"
 COPY --from=builder /usr/local/bin/memtier_benchmark /usr/local/bin/memtier_benchmark
 RUN \
-  apk add libstdc++ pcre libevent zlib openssl
+  apk add libstdc++ libevent zlib openssl
 
 ENTRYPOINT ["memtier_benchmark"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ brew install memtier_benchmark
 The following libraries are required for building:
 
 * libevent 2.0.10 or newer.
-* libpcre 8.x.
 * OpenSSL (unless TLS support is disabled by `./configure --disable-tls`).
 
 The following tools are required
@@ -75,7 +74,7 @@ The following tools are required
 Use the following to install prerequisites:
 ```
 $ sudo yum install autoconf automake make gcc-c++ \
-    pcre-devel zlib-devel libmemcached-devel libevent-devel openssl-devel
+    zlib-devel libmemcached-devel libevent-devel openssl-devel
 ```
 
 #### Ubuntu/Debian
@@ -83,7 +82,7 @@ $ sudo yum install autoconf automake make gcc-c++ \
 Use the following to install prerequisites:
 
 ```
-$ sudo apt-get install build-essential autoconf automake libpcre3-dev \
+$ sudo apt-get install build-essential autoconf automake \
     libevent-dev pkg-config zlib1g-dev libssl-dev
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AC_HEADER_DIRENT
 AC_CHECK_HEADERS([stdlib.h string.h sys/time.h getopt.h limits.h malloc.h stdlib.h unistd.h utime.h assert.h sys/socket.h sys/types.h])
 AC_CHECK_HEADERS([fcntl.h netinet/tcp.h])
 AC_CHECK_HEADERS([pthread.h])
-AC_CHECK_HEADERS([pcre.h zlib.h])
+AC_CHECK_HEADERS([zlib.h])
 AC_CHECK_HEADERS([event2/event.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -72,7 +72,7 @@ AS_IF([test "x$enable_tls" != "xno"], [
 # clock_gettime requires -lrt on old glibc only.
 AC_SEARCH_LIBS([clock_gettime], [rt], , AC_MSG_ERROR([rt is required libevent.]))
 
-AC_CHECK_LIB([pcre], [pcre_compile], , AC_MSG_ERROR([pcre is required; try installing libpcre3-dev.]))
+
 AC_CHECK_LIB([z], [deflateInit_], , AC_MSG_ERROR([zlib is required; try installing zlib1g-dev.]))
 AC_CHECK_LIB([pthread], [pthread_create], , AC_MSG_ERROR([pthread is required.]))
 AC_CHECK_LIB([socket], [gai_strerror])

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: memtier-benchmark
 Section: admin
 Priority: optional
 Maintainer: Redis Ltd. <oss@redislabs.com>
-Build-Depends: debhelper-compat (= 10), dh-autoreconf, bash-completion, pkg-config, libpcre3-dev, libevent-dev, libssl-dev, zlib1g-dev
+Build-Depends: debhelper-compat (= 10), dh-autoreconf, bash-completion, pkg-config, libevent-dev, libssl-dev, zlib1g-dev
 Standards-Version: 4.4.1
 Homepage: https://github.com/RedisLabs/memtier_benchmark
 


### PR DESCRIPTION
Fixes #315 

This PR removes the libpcre3-dev / pcre dependency across the project since it is no longer required for building or running memtier_benchmark.

Changes include:

- Dropped libpcre3-dev from CI workflows, Dockerfiles, and Debian packaging.
- Updated configure.ac to stop checking for pcre.
- Cleaned up README.md and installation instructions to reflect updated requirements.
- Including debian build checks on CI. 
