### PR TITLE
Add RPM packaging for Rocky 8/9/10 + AL2023 with x86_64/arm64 support

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - name: Install git and basic tools
       run: |
-        dnf install -y git rpm-build rpmdevtools
+        dnf install -y git rpm-build rpmdevtools rsync
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -223,12 +223,21 @@ jobs:
 
     - name: Install dependencies and RPM
       run: |
+        # Find RPM file (globstar not enabled by default)
+        RPM_FILE=$(find ./rpms -name "*.rpm" -type f ! -name "*debug*" | head -1)
+        if [ -z "$RPM_FILE" ]; then
+          echo "::error::No RPM file found in ./rpms"
+          find ./rpms -type f
+          exit 1
+        fi
+        echo "Installing: $RPM_FILE"
+
         if command -v dnf &> /dev/null; then
           dnf install -y libevent openssl
-          dnf install -y ./rpms/**/*.rpm || dnf install -y ./rpms/*.rpm
+          dnf install -y "$RPM_FILE"
         else
           yum install -y libevent openssl
-          yum install -y ./rpms/**/*.rpm || yum install -y ./rpms/*.rpm
+          yum install -y "$RPM_FILE"
         fi
 
     - name: Verify installation

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -1,0 +1,310 @@
+name: Build and Publish RPM Packages
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'debian/**'
+  pull_request:
+    branches:
+      - master
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'debian/**'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag name for testing (e.g., 2.1.2)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  build-srpm:
+    runs-on: ubuntu-latest
+    container: rockylinux:9
+    steps:
+    - name: Install git and basic tools
+      run: |
+        dnf install -y git rpm-build rpmdevtools
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup RPM build tree
+      run: rpmdev-setuptree
+
+    - name: Get version
+      id: version
+      run: |
+        # Use tag if available, otherwise extract from configure.ac
+        if [ -n "${{ github.event.inputs.tag_name }}" ]; then
+          VERSION="${{ github.event.inputs.tag_name }}"
+        elif [ -n "${{ github.event.release.tag_name }}" ]; then
+          VERSION="${{ github.event.release.tag_name }}"
+        else
+          VERSION=$(awk -F'[(),]' '/AC_INIT/ {gsub(/ /, "", $3); print $3}' configure.ac)
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Building version: $VERSION"
+
+    - name: Create source tarball
+      run: |
+        VERSION=${{ steps.version.outputs.version }}
+        mkdir -p memtier-benchmark-$VERSION
+        rsync -a --exclude='.git' --exclude='memtier-benchmark-*' . memtier-benchmark-$VERSION/
+        tar czf ~/rpmbuild/SOURCES/memtier-benchmark-$VERSION.tar.gz memtier-benchmark-$VERSION
+
+    - name: Update spec file version
+      run: |
+        VERSION=${{ steps.version.outputs.version }}
+        sed -i "s/^Version:.*/Version:        $VERSION/" rpm/memtier-benchmark.spec
+        cp rpm/memtier-benchmark.spec ~/rpmbuild/SPECS/
+
+    - name: Build SRPM
+      run: |
+        rpmbuild -bs ~/rpmbuild/SPECS/memtier-benchmark.spec
+
+    - name: Upload SRPM artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: srpm
+        path: ~/rpmbuild/SRPMS/*.src.rpm
+        retention-days: 5
+
+  build-rpm:
+    needs: build-srpm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # x86_64 builds
+          - distro: el8
+            image: rockylinux:8
+            arch: x86_64
+            runner: ubuntu-latest
+          - distro: el9
+            image: rockylinux:9
+            arch: x86_64
+            runner: ubuntu-latest
+          - distro: el10
+            image: rockylinux/rockylinux:10
+            arch: x86_64
+            runner: ubuntu-latest
+          - distro: amzn2023
+            image: amazonlinux:2023
+            arch: x86_64
+            runner: ubuntu-latest
+          # arm64 builds
+          - distro: el8
+            image: rockylinux:8
+            arch: aarch64
+            runner: ubuntu24-arm64-2-8
+          - distro: el9
+            image: rockylinux:9
+            arch: aarch64
+            runner: ubuntu24-arm64-2-8
+          - distro: el10
+            image: rockylinux/rockylinux:10
+            arch: aarch64
+            runner: ubuntu24-arm64-2-8
+          - distro: amzn2023
+            image: amazonlinux:2023
+            arch: aarch64
+            runner: ubuntu24-arm64-2-8
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.image }}
+    name: Build RPM (${{ matrix.distro }}-${{ matrix.arch }})
+    steps:
+    - name: Install build dependencies
+      run: |
+        if command -v dnf &> /dev/null; then
+          dnf install -y rpm-build gcc-c++ make autoconf automake libtool \
+            libevent-devel openssl-devel zlib-devel pkgconfig
+        else
+          yum install -y rpm-build gcc-c++ make autoconf automake libtool \
+            libevent-devel openssl-devel zlib-devel pkgconfig
+        fi
+
+    - name: Download SRPM
+      uses: actions/download-artifact@v4
+      with:
+        name: srpm
+
+    - name: Install SRPM
+      run: rpm -ivh *.src.rpm
+
+    - name: Build RPM
+      run: |
+        rpmbuild -bb ~/rpmbuild/SPECS/memtier-benchmark.spec
+
+    - name: Upload RPM artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: rpm-${{ matrix.distro }}-${{ matrix.arch }}
+        path: ~/rpmbuild/RPMS/**/*.rpm
+        retention-days: 5
+
+    - name: Upload as release assets
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ~/rpmbuild/RPMS/**/*.rpm
+
+  smoke-test-packages:
+    needs: build-rpm
+    # Only smoke test on master/main push or release (not on PRs)
+    if: github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # x86_64 tests
+          - distro: el8
+            image: rockylinux:8
+            arch: x86_64
+            runner: ubuntu-latest
+          - distro: el9
+            image: rockylinux:9
+            arch: x86_64
+            runner: ubuntu-latest
+          - distro: el10
+            image: rockylinux/rockylinux:10
+            arch: x86_64
+            runner: ubuntu-latest
+          - distro: amzn2023
+            image: amazonlinux:2023
+            arch: x86_64
+            runner: ubuntu-latest
+          # arm64 tests
+          - distro: el8
+            image: rockylinux:8
+            arch: aarch64
+            runner: ubuntu24-arm64-2-8
+          - distro: el9
+            image: rockylinux:9
+            arch: aarch64
+            runner: ubuntu24-arm64-2-8
+          - distro: el10
+            image: rockylinux/rockylinux:10
+            arch: aarch64
+            runner: ubuntu24-arm64-2-8
+          - distro: amzn2023
+            image: amazonlinux:2023
+            arch: aarch64
+            runner: ubuntu24-arm64-2-8
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.image }}
+    name: Smoke test (${{ matrix.distro }}-${{ matrix.arch }})
+    steps:
+    - name: Download RPM
+      uses: actions/download-artifact@v4
+      with:
+        name: rpm-${{ matrix.distro }}-${{ matrix.arch }}
+        path: rpms
+
+    - name: Install dependencies and RPM
+      run: |
+        if command -v dnf &> /dev/null; then
+          dnf install -y libevent openssl
+          dnf install -y ./rpms/**/*.rpm || dnf install -y ./rpms/*.rpm
+        else
+          yum install -y libevent openssl
+          yum install -y ./rpms/**/*.rpm || yum install -y ./rpms/*.rpm
+        fi
+
+    - name: Verify installation
+      run: |
+        memtier_benchmark --version
+        echo "✓ memtier_benchmark (${{ matrix.distro }}-${{ matrix.arch }}) installed and runs successfully"
+
+  publish-to-yum:
+    runs-on: ubuntu-latest
+    needs: smoke-test-packages
+    environment: build
+    # Only publish on actual releases (not prereleases or workflow_dispatch)
+    if: github.event_name == 'release' && github.event.release.prerelease == false
+    steps:
+    - name: Setup RPM Signing key
+      run: |
+        mkdir -m 0700 -p ~/.gnupg
+        echo "$APT_SIGNING_KEY" | gpg --import
+      env:
+        APT_SIGNING_KEY: ${{ secrets.APT_SIGNING_KEY }}
+
+    - name: Download all RPM artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: rpm-*
+        path: rpms
+        merge-multiple: false
+
+    - name: Install createrepo and AWS CLI
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y createrepo-c awscli rpm
+
+    - name: Sign RPMs
+      run: |
+        echo "%_gpg_name oss@redis.com" >> ~/.rpmmacros
+        for rpm in rpms/**/*.rpm; do
+          rpm --addsign "$rpm"
+        done
+
+    - name: Sync existing repo from S3
+      run: |
+        aws s3 sync s3://${{ secrets.APT_S3_BUCKET }}/rpm ./repo --delete || mkdir -p ./repo
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.APT_S3_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.APT_S3_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.APT_S3_REGION }}
+
+    - name: Organize RPMs by distro and architecture
+      run: |
+        # Artifact names are rpm-{distro}-{arch}, e.g., rpm-el9-x86_64
+        for artifact_dir in rpms/rpm-*; do
+          artifact_name=$(basename "$artifact_dir")
+          # Extract distro and arch from artifact name (rpm-el9-x86_64 -> el9, x86_64)
+          distro=$(echo "$artifact_name" | sed 's/rpm-//' | rev | cut -d'-' -f2- | rev)
+          arch=$(echo "$artifact_name" | rev | cut -d'-' -f1 | rev)
+
+          mkdir -p "repo/$distro/$arch"
+          cp "$artifact_dir"/**/*.rpm "repo/$distro/$arch/" 2>/dev/null || \
+          cp "$artifact_dir"/*.rpm "repo/$distro/$arch/" 2>/dev/null || true
+
+          echo "Organized: $artifact_name -> repo/$distro/$arch/"
+        done
+
+    - name: Create/Update YUM repository metadata
+      run: |
+        for distro_dir in repo/*/; do
+          for arch_dir in "$distro_dir"*/; do
+            if [ -d "$arch_dir" ] && ls "$arch_dir"/*.rpm 1>/dev/null 2>&1; then
+              echo "Creating repo metadata for: $arch_dir"
+              createrepo_c --update "$arch_dir"
+            fi
+          done
+        done
+
+    - name: Upload repo to S3
+      run: |
+        aws s3 sync ./repo s3://${{ secrets.APT_S3_BUCKET }}/rpm --delete
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.APT_S3_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.APT_S3_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.APT_S3_REGION }}
+
+    - name: List uploaded packages
+      run: |
+        echo "📦 Packages uploaded to YUM repository:"
+        find repo -name "*.rpm" -type f
+

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -46,16 +46,25 @@ jobs:
     - name: Get version
       id: version
       run: |
-        # Use tag if available, otherwise extract from configure.ac
+        # Extract version from configure.ac (source of truth)
+        SOURCE_VERSION=$(awk -F'[(),]' '/AC_INIT/ {gsub(/ /, "", $3); print $3}' configure.ac)
+
+        # Use tag if available, otherwise use source version
         if [ -n "${{ github.event.inputs.tag_name }}" ]; then
           VERSION="${{ github.event.inputs.tag_name }}"
         elif [ -n "${{ github.event.release.tag_name }}" ]; then
           VERSION="${{ github.event.release.tag_name }}"
         else
-          VERSION=$(awk -F'[(),]' '/AC_INIT/ {gsub(/ /, "", $3); print $3}' configure.ac)
+          VERSION="$SOURCE_VERSION"
         fi
+
+        # Validate tag matches source version on releases
+        if [ -n "${{ github.event.release.tag_name }}" ] && [ "$VERSION" != "$SOURCE_VERSION" ]; then
+          echo "::warning::Release tag ($VERSION) does not match configure.ac version ($SOURCE_VERSION)"
+        fi
+
         echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "Building version: $VERSION"
+        echo "Building version: $VERSION (source: $SOURCE_VERSION)"
 
     - name: Create source tarball
       run: |
@@ -256,13 +265,18 @@ jobs:
     - name: Sign RPMs
       run: |
         echo "%_gpg_name oss@redis.com" >> ~/.rpmmacros
-        for rpm in rpms/**/*.rpm; do
-          rpm --addsign "$rpm"
+        # Use find instead of globstar (not enabled by default in bash)
+        find rpms -name "*.rpm" -type f | while read -r rpm_file; do
+          echo "Signing: $rpm_file"
+          rpm --addsign "$rpm_file"
         done
 
     - name: Sync existing repo from S3
       run: |
-        aws s3 sync s3://${{ secrets.APT_S3_BUCKET }}/rpm ./repo --delete || mkdir -p ./repo
+        # Create repo dir first, then sync (don't use || to avoid masking errors)
+        mkdir -p ./repo
+        # Sync existing repo; if bucket path doesn't exist yet, this is a no-op
+        aws s3 sync "s3://${{ secrets.APT_S3_BUCKET }}/rpm" ./repo || echo "No existing repo found, starting fresh"
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.APT_S3_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.APT_S3_SECRET_ACCESS_KEY }}
@@ -278,11 +292,20 @@ jobs:
           arch=$(echo "$artifact_name" | rev | cut -d'-' -f1 | rev)
 
           mkdir -p "repo/$distro/$arch"
-          cp "$artifact_dir"/**/*.rpm "repo/$distro/$arch/" 2>/dev/null || \
-          cp "$artifact_dir"/*.rpm "repo/$distro/$arch/" 2>/dev/null || true
+          # Use find instead of globstar
+          find "$artifact_dir" -name "*.rpm" -type f -exec cp {} "repo/$distro/$arch/" \;
 
           echo "Organized: $artifact_name -> repo/$distro/$arch/"
         done
+
+    - name: Verify RPMs were organized
+      run: |
+        RPM_COUNT=$(find repo -name "*.rpm" -type f | wc -l)
+        if [ "$RPM_COUNT" -eq 0 ]; then
+          echo "::error::No RPMs found in repo directory. Aborting to prevent wiping S3."
+          exit 1
+        fi
+        echo "Found $RPM_COUNT RPMs to publish"
 
     - name: Create/Update YUM repository metadata
       run: |
@@ -297,7 +320,8 @@ jobs:
 
     - name: Upload repo to S3
       run: |
-        aws s3 sync ./repo s3://${{ secrets.APT_S3_BUCKET }}/rpm --delete
+        # Use --delete to keep repo clean, but we verified RPMs exist above
+        aws s3 sync ./repo "s3://${{ secrets.APT_S3_BUCKET }}/rpm" --delete
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.APT_S3_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.APT_S3_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -195,8 +195,9 @@ jobs:
 
   smoke-test-packages:
     needs: build-rpm
-    # Only smoke test on master/main push or release (not on PRs)
-    if: github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    # Run on PRs too: the smoke test exercises install + repo-resolved install,
+    # which is exactly the user-facing path we want to protect against
+    # regressions before merging.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -240,6 +240,17 @@ jobs:
     container: ${{ matrix.image }}
     name: Smoke test (${{ matrix.distro }}-${{ matrix.arch }})
     steps:
+    - name: Install minimal shell tools
+      # Minimal Rocky 8/10 and AL2023 base images ship without findutils
+      # (and sometimes without diff/which). Install up-front so the rest of
+      # the job can use `find` etc.
+      run: |
+        if command -v dnf >/dev/null 2>&1; then
+          dnf install -y findutils
+        else
+          yum install -y findutils
+        fi
+
     - name: Download RPM
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       with:

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -46,40 +46,60 @@ jobs:
 
     - name: Get version
       id: version
+      # Pass user-controlled inputs through env: rather than ${{ }} expansion
+      # so they cannot inject shell syntax. configure.ac is editable by
+      # forked-PR authors; AC_INIT() containing backticks or $() would
+      # otherwise be evaluated when the version flows back through
+      # `${{ steps.version.outputs.version }}` in later steps.
+      env:
+        INPUT_TAG: ${{ github.event.inputs.tag_name }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
       run: |
+        set -eu
         # Extract version from configure.ac (source of truth)
         SOURCE_VERSION=$(awk -F'[(),]' '/AC_INIT/ {gsub(/ /, "", $3); print $3}' configure.ac)
 
-        # Use tag if available, otherwise use source version
-        if [ -n "${{ github.event.inputs.tag_name }}" ]; then
-          VERSION="${{ github.event.inputs.tag_name }}"
-        elif [ -n "${{ github.event.release.tag_name }}" ]; then
-          VERSION="${{ github.event.release.tag_name }}"
+        if [ -n "$INPUT_TAG" ]; then
+          VERSION="$INPUT_TAG"
+        elif [ -n "$RELEASE_TAG" ]; then
+          VERSION="$RELEASE_TAG"
         else
           VERSION="$SOURCE_VERSION"
         fi
 
+        # Defense in depth: reject anything that is not a simple semver-ish
+        # token. Blocks backticks, $(...), /, &, spaces, etc. before the
+        # value is reused in sed replacements or file paths.
+        case "$VERSION" in
+          ""|*[!A-Za-z0-9._-]*)
+            echo "::error::Invalid version string: $VERSION"
+            exit 1
+            ;;
+        esac
+
         # Hard-fail on releases if the tag and configure.ac drift apart —
         # publishing RPMs labeled with a tag that doesn't match the source
         # version is worse than failing the build.
-        if [ -n "${{ github.event.release.tag_name }}" ] && [ "$VERSION" != "$SOURCE_VERSION" ]; then
+        if [ -n "$RELEASE_TAG" ] && [ "$VERSION" != "$SOURCE_VERSION" ]; then
           echo "::error::Release tag ($VERSION) does not match configure.ac version ($SOURCE_VERSION). Update configure.ac or retag the release."
           exit 1
         fi
 
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         echo "Building version: $VERSION (source: $SOURCE_VERSION)"
 
     - name: Create source tarball
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
       run: |
-        VERSION=${{ steps.version.outputs.version }}
-        mkdir -p memtier-benchmark-$VERSION
-        rsync -a --exclude='.git' --exclude='memtier-benchmark-*' . memtier-benchmark-$VERSION/
-        tar czf ~/rpmbuild/SOURCES/memtier-benchmark-$VERSION.tar.gz memtier-benchmark-$VERSION
+        mkdir -p "memtier-benchmark-$VERSION"
+        rsync -a --exclude='.git' --exclude='memtier-benchmark-*' . "memtier-benchmark-$VERSION/"
+        tar czf "$HOME/rpmbuild/SOURCES/memtier-benchmark-$VERSION.tar.gz" "memtier-benchmark-$VERSION"
 
     - name: Update spec file version
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
       run: |
-        VERSION=${{ steps.version.outputs.version }}
         sed -i "s/^Version:.*/Version:        $VERSION/" rpm/memtier-benchmark.spec
         cp rpm/memtier-benchmark.spec ~/rpmbuild/SPECS/
 

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -24,8 +24,9 @@ on:
         required: false
         default: ""
 
+# Default to least-privilege; jobs that need write opt in below.
 permissions:
-  contents: write
+  contents: read
   actions: read
 
 jobs:
@@ -38,7 +39,7 @@ jobs:
         dnf install -y git rpm-build rpmdevtools rsync
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Setup RPM build tree
       run: rpmdev-setuptree
@@ -84,7 +85,7 @@ jobs:
         rpmbuild -bs ~/rpmbuild/SPECS/memtier-benchmark.spec
 
     - name: Upload SRPM artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: srpm
         path: ~/rpmbuild/SRPMS/*.src.rpm
@@ -92,6 +93,9 @@ jobs:
 
   build-rpm:
     needs: build-srpm
+    # Needs contents: write only to attach RPMs as release assets (release event).
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -145,19 +149,36 @@ jobs:
         fi
 
     - name: Download SRPM
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       with:
         name: srpm
 
     - name: Install SRPM
+      # SRPM is produced by the prior job from this repo's own spec;
+      # re-installing it here unpacks sources and the spec into ~/rpmbuild/.
       run: rpm -ivh *.src.rpm
 
     - name: Build RPM
       run: |
         rpmbuild -bb ~/rpmbuild/SPECS/memtier-benchmark.spec
 
+    - name: Static check with rpmlint (advisory)
+      continue-on-error: true
+      run: |
+        # rpmlint lives in different repos across distros; try a few then skip if unavailable.
+        if command -v dnf &>/dev/null; then
+          dnf install -y rpmlint \
+            || dnf install -y --enablerepo=crb rpmlint \
+            || dnf install -y --enablerepo=powertools rpmlint \
+            || dnf install -y --enablerepo=epel rpmlint \
+            || echo "rpmlint unavailable on ${{ matrix.distro }}"
+        fi
+        if command -v rpmlint &>/dev/null; then
+          find ~/rpmbuild/RPMS -name '*.rpm' -type f -print0 | xargs -0 rpmlint || true
+        fi
+
     - name: Upload RPM artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: rpm-${{ matrix.distro }}-${{ matrix.arch }}
         path: ~/rpmbuild/RPMS/**/*.rpm
@@ -165,7 +186,7 @@ jobs:
 
     - name: Upload as release assets
       if: github.event_name == 'release'
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
       with:
         files: ~/rpmbuild/RPMS/**/*.rpm
 
@@ -216,14 +237,14 @@ jobs:
     name: Smoke test (${{ matrix.distro }}-${{ matrix.arch }})
     steps:
     - name: Download RPM
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       with:
         name: rpm-${{ matrix.distro }}-${{ matrix.arch }}
         path: rpms
 
-    - name: Install dependencies and RPM
+    - name: Install RPM directly (sanity check)
       run: |
-        # Find RPM file (globstar not enabled by default)
+        # First pass: install the file directly to confirm the RPM itself is sound.
         RPM_FILE=$(find ./rpms -name "*.rpm" -type f ! -name "*debug*" | head -1)
         if [ -z "$RPM_FILE" ]; then
           echo "::error::No RPM file found in ./rpms"
@@ -231,36 +252,98 @@ jobs:
           exit 1
         fi
         echo "Installing: $RPM_FILE"
-
+        # Rely on the package's auto-deps to pull libevent/openssl — manually
+        # pre-installing them would mask a missing Requires:.
         if command -v dnf &> /dev/null; then
-          dnf install -y libevent openssl
           dnf install -y "$RPM_FILE"
         else
-          yum install -y libevent openssl
           yum install -y "$RPM_FILE"
         fi
 
-    - name: Verify installation
+    - name: Verify direct install
       run: |
         memtier_benchmark --version
-        echo "✓ memtier_benchmark (${{ matrix.distro }}-${{ matrix.arch }}) installed and runs successfully"
+        memtier_benchmark --help > /dev/null
+        # Man page is referenced from the spec %files; assert it actually shipped.
+        test -f /usr/share/man/man1/memtier_benchmark.1.gz \
+          || test -f /usr/share/man/man1/memtier_benchmark.1
+        # Bash completion file must be syntactically loadable.
+        bash -n /usr/share/bash-completion/completions/memtier_benchmark
+        echo "✓ direct install (${{ matrix.distro }}-${{ matrix.arch }}) verified"
+
+    - name: Test install via local YUM repo (mirrors README path layout)
+      run: |
+        # This step mirrors what users actually do: install via repo metadata
+        # using the same baseurl pattern documented in README.md. It catches
+        # createrepo / Requires / baseurl bugs that direct-file install misses,
+        # including $releasever-vs-distro mismatches like the AL2023 case.
+        set -euo pipefail
+        if command -v dnf &>/dev/null; then
+          dnf remove -y memtier-benchmark
+          dnf install -y createrepo_c || dnf install -y createrepo
+        else
+          yum remove -y memtier-benchmark
+          yum install -y createrepo_c || yum install -y createrepo
+        fi
+
+        DISTRO="${{ matrix.distro }}"
+        ARCH="${{ matrix.arch }}"
+        REPO_ROOT=/tmp/localrepo
+        mkdir -p "$REPO_ROOT/$DISTRO/$ARCH"
+        find ./rpms -name '*.rpm' -type f ! -name '*debug*' \
+          -exec cp {} "$REPO_ROOT/$DISTRO/$ARCH/" \;
+
+        if command -v createrepo_c &>/dev/null; then
+          createrepo_c "$REPO_ROOT/$DISTRO/$ARCH"
+        else
+          createrepo "$REPO_ROOT/$DISTRO/$ARCH"
+        fi
+
+        # Match the README baseurl pattern. \$releasever and \$basearch are
+        # passed through to dnf; only $REPO_ROOT is shell-expanded here.
+        if [ "$DISTRO" = "amzn2023" ]; then
+          BASEURL="file://$REPO_ROOT/amzn2023/\$basearch"
+        else
+          BASEURL="file://$REPO_ROOT/el\$releasever/\$basearch"
+        fi
+
+        cat > /etc/yum.repos.d/local-test.repo <<EOF
+        [local-test]
+        name=Local Test
+        baseurl=$BASEURL
+        enabled=1
+        gpgcheck=0
+        EOF
+
+        if command -v dnf &>/dev/null; then
+          dnf install -y memtier-benchmark
+        else
+          yum install -y memtier-benchmark
+        fi
+
+        memtier_benchmark --version
+        echo "✓ repo install (${{ matrix.distro }}-${{ matrix.arch }}) verified via $BASEURL"
 
   publish-to-yum:
     runs-on: ubuntu-latest
     needs: smoke-test-packages
     environment: build
+    permissions:
+      contents: read
     # Only publish on actual releases (not prereleases or workflow_dispatch)
     if: github.event_name == 'release' && github.event.release.prerelease == false
     steps:
     - name: Setup RPM Signing key
+      # Same key used for the DEB pipeline (APT_SIGNING_KEY); name retained
+      # for parity with existing secret naming.
       run: |
         mkdir -m 0700 -p ~/.gnupg
-        echo "$APT_SIGNING_KEY" | gpg --import
+        echo "$APT_SIGNING_KEY" | gpg --batch --import
       env:
         APT_SIGNING_KEY: ${{ secrets.APT_SIGNING_KEY }}
 
     - name: Download all RPM artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       with:
         pattern: rpm-*
         path: rpms
@@ -280,12 +363,52 @@ jobs:
           rpm --addsign "$rpm_file"
         done
 
+    - name: Verify RPM signatures
+      # Fail fast if signing silently produced unsigned/invalid RPMs.
+      run: |
+        set -euo pipefail
+        # Import the public half of the signing key into rpm's keyring so
+        # `rpm -K` can verify, not just check the digest.
+        gpg --export --armor oss@redis.com > /tmp/redis-pub.asc
+        sudo rpm --import /tmp/redis-pub.asc
+
+        bad=0
+        while read -r rpm_file; do
+          # Two checks because `rpm -K` exits 0 on unsigned packages (digest OK).
+          # 1. Header field must contain a PGP signature, not "(none)".
+          sig=$(rpm -qp --queryformat '%{SIGPGP:pgpsig}\n' "$rpm_file")
+          if [ "$sig" = "(none)" ] || [ -z "$sig" ]; then
+            echo "::error::RPM unsigned: $rpm_file (SIGPGP=$sig)"
+            bad=$((bad + 1))
+            continue
+          fi
+          # 2. The signature must verify against the imported key.
+          if ! rpm -K "$rpm_file"; then
+            echo "::error::RPM signature does not verify: $rpm_file"
+            bad=$((bad + 1))
+            continue
+          fi
+          echo "✓ signed: $rpm_file ($sig)"
+        done < <(find rpms -name "*.rpm" -type f)
+
+        if [ "$bad" -gt 0 ]; then
+          echo "::error::$bad RPM(s) failed signature verification"
+          exit 1
+        fi
+
     - name: Sync existing repo from S3
       run: |
-        # Create repo dir first, then sync (don't use || to avoid masking errors)
+        set -euo pipefail
         mkdir -p ./repo
-        # Sync existing repo; if bucket path doesn't exist yet, this is a no-op
-        aws s3 sync "s3://${{ secrets.APT_S3_BUCKET }}/rpm" ./repo || echo "No existing repo found, starting fresh"
+        # Distinguish "bucket path is empty (first-ever publish)" from "sync
+        # failed for any other reason". A blanket `|| echo` masks transient
+        # errors and lets the later `--delete` upload wipe prior releases.
+        if aws s3 ls "s3://${{ secrets.APT_S3_BUCKET }}/rpm/" >/dev/null 2>&1; then
+          # Path exists with at least one object — a sync failure now is real.
+          aws s3 sync "s3://${{ secrets.APT_S3_BUCKET }}/rpm" ./repo
+        else
+          echo "No existing rpm/ prefix in s3://${{ secrets.APT_S3_BUCKET }}, starting fresh"
+        fi
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.APT_S3_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.APT_S3_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -59,9 +59,12 @@ jobs:
           VERSION="$SOURCE_VERSION"
         fi
 
-        # Validate tag matches source version on releases
+        # Hard-fail on releases if the tag and configure.ac drift apart —
+        # publishing RPMs labeled with a tag that doesn't match the source
+        # version is worse than failing the build.
         if [ -n "${{ github.event.release.tag_name }}" ] && [ "$VERSION" != "$SOURCE_VERSION" ]; then
-          echo "::warning::Release tag ($VERSION) does not match configure.ac version ($SOURCE_VERSION)"
+          echo "::error::Release tag ($VERSION) does not match configure.ac version ($SOURCE_VERSION). Update configure.ac or retag the release."
+          exit 1
         fi
 
         echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -367,9 +370,14 @@ jobs:
       # Fail fast if signing silently produced unsigned/invalid RPMs.
       run: |
         set -euo pipefail
-        # Import the public half of the signing key into rpm's keyring so
-        # `rpm -K` can verify, not just check the digest.
-        gpg --export --armor oss@redis.com > /tmp/redis-pub.asc
+        # Import the public half of whatever key is in the keyring (avoids
+        # coupling to a specific UID). Empty output here means the earlier
+        # APT_SIGNING_KEY import didn't actually populate the keyring.
+        gpg --export --armor > /tmp/redis-pub.asc
+        if [ ! -s /tmp/redis-pub.asc ]; then
+          echo "::error::Public key export is empty — APT_SIGNING_KEY import likely failed"
+          exit 1
+        fi
         sudo rpm --import /tmp/redis-pub.asc
 
         bad=0

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -359,7 +359,21 @@ jobs:
 
     - name: Sign RPMs
       run: |
-        echo "%_gpg_name oss@redis.com" >> ~/.rpmmacros
+        set -euo pipefail
+        # Derive the signing identifier from the imported key rather than
+        # hard-coding a UID. The DEB pipeline relies on "first key in the
+        # keyring" semantics; we mirror that by selecting the first secret
+        # key's fingerprint, which works regardless of which UID(s) the
+        # APT_SIGNING_KEY secret happens to carry.
+        SIGN_FPR=$(gpg --list-secret-keys --with-colons \
+          | awk -F: '/^fpr:/{print $10; exit}')
+        if [ -z "$SIGN_FPR" ]; then
+          echo "::error::No secret key found in keyring; APT_SIGNING_KEY import failed?"
+          exit 1
+        fi
+        echo "Signing with key: $SIGN_FPR"
+        echo "%_gpg_name $SIGN_FPR" >> ~/.rpmmacros
+
         # Use find instead of globstar (not enabled by default in bash)
         find rpms -name "*.rpm" -type f | while read -r rpm_file; do
           echo "Signing: $rpm_file"

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -124,19 +124,19 @@ jobs:
           - distro: el8
             image: rockylinux:8
             arch: aarch64
-            runner: ubuntu24-arm64-2-8
+            runner: ubuntu-24.04-arm
           - distro: el9
             image: rockylinux:9
             arch: aarch64
-            runner: ubuntu24-arm64-2-8
+            runner: ubuntu-24.04-arm
           - distro: el10
             image: rockylinux/rockylinux:10
             arch: aarch64
-            runner: ubuntu24-arm64-2-8
+            runner: ubuntu-24.04-arm
           - distro: amzn2023
             image: amazonlinux:2023
             arch: aarch64
-            runner: ubuntu24-arm64-2-8
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.image }}
     name: Build RPM (${{ matrix.distro }}-${{ matrix.arch }})
@@ -223,19 +223,19 @@ jobs:
           - distro: el8
             image: rockylinux:8
             arch: aarch64
-            runner: ubuntu24-arm64-2-8
+            runner: ubuntu-24.04-arm
           - distro: el9
             image: rockylinux:9
             arch: aarch64
-            runner: ubuntu24-arm64-2-8
+            runner: ubuntu-24.04-arm
           - distro: el10
             image: rockylinux/rockylinux:10
             arch: aarch64
-            runner: ubuntu24-arm64-2-8
+            runner: ubuntu-24.04-arm
           - distro: amzn2023
             image: amazonlinux:2023
             arch: aarch64
-            runner: ubuntu24-arm64-2-8
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.image }}
     name: Smoke test (${{ matrix.distro }}-${{ matrix.arch }})

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -280,9 +280,10 @@ jobs:
         # --version is the binary-loads check. Don't run --help here:
         # memtier_benchmark exits non-zero on --help, which aborts `sh -e`.
         memtier_benchmark --version
-        # Man page is referenced from the spec %files; assert it actually shipped.
-        test -f /usr/share/man/man1/memtier_benchmark.1.gz \
-          || test -f /usr/share/man/man1/memtier_benchmark.1
+        # Man page is referenced from the spec %files. Query the RPM
+        # rather than testing fixed paths — el10 uses zstd (.zst) instead
+        # of gzip (.gz), and other distros may diverge again later.
+        rpm -ql memtier-benchmark | grep -qE "/man1/memtier_benchmark\.1(\..+)?$"
         # Bash completion file must be syntactically loadable.
         bash -n /usr/share/bash-completion/completions/memtier_benchmark
         echo "✓ direct install (${{ matrix.distro }}-${{ matrix.arch }}) verified"

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -266,8 +266,9 @@ jobs:
 
     - name: Verify direct install
       run: |
+        # --version is the binary-loads check. Don't run --help here:
+        # memtier_benchmark exits non-zero on --help, which aborts `sh -e`.
         memtier_benchmark --version
-        memtier_benchmark --help > /dev/null
         # Man page is referenced from the spec %files; assert it actually shipped.
         test -f /usr/share/man/man1/memtier_benchmark.1.gz \
           || test -f /usr/share/man/man1/memtier_benchmark.1

--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ Once configured, to install memtier_benchmark use:
 sudo apt-get install memtier-benchmark
 ```
 
+### Installing on RHEL, Rocky Linux, AlmaLinux, and Amazon Linux
+
+Pre-compiled binaries are available for RHEL 8/9/10 compatible distributions and Amazon Linux 2023
+from the packages.redis.io YUM repository. To configure this repository, use the following steps:
+
+```
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /etc/pki/rpm-gpg/redis-archive-keyring.gpg
+
+sudo tee /etc/yum.repos.d/redis.repo <<'EOF'
+[redis]
+name=Redis
+baseurl=https://packages.redis.io/rpm/el$releasever/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/redis-archive-keyring.gpg
+EOF
+```
+
+Once configured, to install memtier_benchmark use:
+
+```
+sudo dnf install -y memtier-benchmark
+```
+
 ### Installing on MacOS
 
 To install memtier_benchmark on MacOS, use Homebrew:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Pre-compiled binaries are available for RHEL 8/9/10 compatible distributions
 from the packages.redis.io YUM repository. To configure this repository, use the following steps:
 
 ```
-curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /etc/pki/rpm-gpg/redis-archive-keyring.gpg
+sudo curl -fsSL https://packages.redis.io/gpg -o /etc/pki/rpm-gpg/redis-archive-keyring.gpg
 
 sudo tee /etc/yum.repos.d/redis.repo <<'EOF'
 [redis]
@@ -75,7 +75,7 @@ Amazon Linux 2023 uses a separate repository path because `$releasever` on AL202
 not an `el<n>` value:
 
 ```
-curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /etc/pki/rpm-gpg/redis-archive-keyring.gpg
+sudo curl -fsSL https://packages.redis.io/gpg -o /etc/pki/rpm-gpg/redis-archive-keyring.gpg
 
 sudo tee /etc/yum.repos.d/redis.repo <<'EOF'
 [redis]

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Once configured, to install memtier_benchmark use:
 sudo apt-get install memtier-benchmark
 ```
 
-### Installing on RHEL, Rocky Linux, AlmaLinux, and Amazon Linux
+### Installing on RHEL, Rocky Linux, and AlmaLinux
 
-Pre-compiled binaries are available for RHEL 8/9/10 compatible distributions and Amazon Linux 2023
+Pre-compiled binaries are available for RHEL 8/9/10 compatible distributions
 from the packages.redis.io YUM repository. To configure this repository, use the following steps:
 
 ```
@@ -57,6 +57,30 @@ sudo tee /etc/yum.repos.d/redis.repo <<'EOF'
 [redis]
 name=Redis
 baseurl=https://packages.redis.io/rpm/el$releasever/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/redis-archive-keyring.gpg
+EOF
+```
+
+Once configured, to install memtier_benchmark use:
+
+```
+sudo dnf install -y memtier-benchmark
+```
+
+### Installing on Amazon Linux 2023
+
+Amazon Linux 2023 uses a separate repository path because `$releasever` on AL2023 is `2023`,
+not an `el<n>` value:
+
+```
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /etc/pki/rpm-gpg/redis-archive-keyring.gpg
+
+sudo tee /etc/yum.repos.d/redis.repo <<'EOF'
+[redis]
+name=Redis
+baseurl=https://packages.redis.io/rpm/amzn2023/$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/redis-archive-keyring.gpg

--- a/rpm/memtier-benchmark.spec
+++ b/rpm/memtier-benchmark.spec
@@ -1,0 +1,59 @@
+# RPM spec file for memtier_benchmark
+# Copyright (C) 2011-2026 Redis Labs Ltd.
+
+%define version_from_configure %(awk -F'[(),]' '/AC_INIT/ {gsub(/ /, "", $3); print $3}' %{_sourcedir}/../configure.ac 2>/dev/null || echo "0.0.0")
+
+Name:           memtier-benchmark
+Version:        %{version_from_configure}
+Release:        1%{?dist}
+Summary:        NoSQL Redis and Memcache traffic generation and benchmarking tool
+
+License:        GPLv2
+URL:            https://github.com/RedisLabs/memtier_benchmark
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  gcc-c++
+BuildRequires:  make
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  libtool
+BuildRequires:  libevent-devel
+BuildRequires:  openssl-devel
+BuildRequires:  zlib-devel
+BuildRequires:  pkgconfig
+
+%description
+memtier_benchmark is a command line utility developed by Redis Labs
+for load generation and benchmarking NoSQL key-value databases.
+
+It offers the following features:
+  * Support for both Redis and Memcache protocols (text and binary)
+  * Multi-threaded multi-client execution
+  * Multiple configuration options, including:
+    - Read:Write ratio
+    - Random and sequential key name pattern policies
+    - Random or ranged key expiration
+    - Redis cluster support
+    - TLS connections support
+
+%prep
+%setup -q
+
+%build
+autoreconf -ivf
+%configure
+%make_build
+
+%install
+%make_install
+
+%files
+%license COPYING
+%doc README.md
+%{_bindir}/memtier_benchmark
+%{_mandir}/man1/memtier_benchmark.1*
+
+%changelog
+* %(date "+%a %b %d %Y") Redis Team <oss@redis.com> - %{version}-%{release}
+- See https://github.com/RedisLabs/memtier_benchmark/releases
+

--- a/rpm/memtier-benchmark.spec
+++ b/rpm/memtier-benchmark.spec
@@ -1,10 +1,9 @@
 # RPM spec file for memtier_benchmark
-# Copyright (C) 2011-2026 Redis Labs Ltd.
+# Copyright (C) 2011-2026 Redis Ltd.
 
-%define version_from_configure %(awk -F'[(),]' '/AC_INIT/ {gsub(/ /, "", $3); print $3}' %{_sourcedir}/../configure.ac 2>/dev/null || echo "0.0.0")
-
+# Version is set by the workflow via sed before building
 Name:           memtier-benchmark
-Version:        %{version_from_configure}
+Version:        0.0.0
 Release:        1%{?dist}
 Summary:        NoSQL Redis and Memcache traffic generation and benchmarking tool
 

--- a/rpm/memtier-benchmark.spec
+++ b/rpm/memtier-benchmark.spec
@@ -42,7 +42,8 @@ It offers the following features:
 %build
 autoreconf -ivf
 %configure
-%make_build
+# Use distribution flags + fPIC for PIE support (required on el10+)
+%make_build CXXFLAGS="%{optflags} -fPIC"
 
 %install
 %make_install

--- a/rpm/memtier-benchmark.spec
+++ b/rpm/memtier-benchmark.spec
@@ -9,7 +9,7 @@ Release:        1%{?dist}
 Summary:        NoSQL Redis and Memcache traffic generation and benchmarking tool
 
 License:        GPLv2
-URL:            https://github.com/RedisLabs/memtier_benchmark
+URL:            https://github.com/redis/memtier_benchmark
 Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  gcc-c++
@@ -55,5 +55,5 @@ autoreconf -ivf
 
 %changelog
 * %(date "+%a %b %d %Y") Redis Team <oss@redis.com> - %{version}-%{release}
-- See https://github.com/RedisLabs/memtier_benchmark/releases
+- See https://github.com/redis/memtier_benchmark/releases
 

--- a/rpm/memtier-benchmark.spec
+++ b/rpm/memtier-benchmark.spec
@@ -52,6 +52,7 @@ autoreconf -ivf
 %doc README.md
 %{_bindir}/memtier_benchmark
 %{_mandir}/man1/memtier_benchmark.1*
+%{_datadir}/bash-completion/completions/memtier_benchmark
 
 %changelog
 * %(date "+%a %b %d %Y") Redis Team <oss@redis.com> - %{version}-%{release}

--- a/rpm/memtier-benchmark.spec
+++ b/rpm/memtier-benchmark.spec
@@ -55,6 +55,6 @@ autoreconf -ivf
 %{_datadir}/bash-completion/completions/memtier_benchmark
 
 %changelog
-* %(date "+%a %b %d %Y") Redis Team <oss@redis.com> - %{version}-%{release}
-- See https://github.com/redis/memtier_benchmark/releases
+* Thu Apr 30 2026 Redis Team <oss@redis.com> - 0.0.0-1
+- See https://github.com/redis/memtier_benchmark/releases for per-release notes.
 

--- a/scripts/test-rpm-locally.sh
+++ b/scripts/test-rpm-locally.sh
@@ -94,7 +94,7 @@ RPM_FILE=$(find ~/rpmbuild/RPMS -name "*.rpm" -type f ! -name "*debug*" | head -
 $PKG install -y "$RPM_FILE"
 
 memtier_benchmark --version
-memtier_benchmark --help > /dev/null
+# memtier_benchmark exits non-zero on --help; do not gate on its rc.
 test -f /usr/share/man/man1/memtier_benchmark.1.gz \
   || test -f /usr/share/man/man1/memtier_benchmark.1
 bash -n /usr/share/bash-completion/completions/memtier_benchmark

--- a/scripts/test-rpm-locally.sh
+++ b/scripts/test-rpm-locally.sh
@@ -95,8 +95,8 @@ $PKG install -y "$RPM_FILE"
 
 memtier_benchmark --version
 # memtier_benchmark exits non-zero on --help; do not gate on its rc.
-test -f /usr/share/man/man1/memtier_benchmark.1.gz \
-  || test -f /usr/share/man/man1/memtier_benchmark.1
+# Query the RPM for the man page: el10 ships .zst, others ship .gz.
+rpm -ql memtier-benchmark | grep -qE "/man1/memtier_benchmark\.1(\..+)?$"
 bash -n /usr/share/bash-completion/completions/memtier_benchmark
 
 # Repo-install verification (mirrors smoke-test local-YUM-repo step).

--- a/scripts/test-rpm-locally.sh
+++ b/scripts/test-rpm-locally.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Reproduce the RPM build + smoke test from .github/workflows/release-rpm.yml
+# inside a single container. Useful for validating spec/workflow changes
+# before pushing to CI.
+#
+# Usage:
+#   scripts/test-rpm-locally.sh                  # default: el9 x86_64
+#   scripts/test-rpm-locally.sh el8
+#   scripts/test-rpm-locally.sh amzn2023
+#   scripts/test-rpm-locally.sh el10 aarch64    # cross-arch (needs qemu-user-static)
+#
+# Requirements: docker or podman.
+
+set -euo pipefail
+
+DISTRO="${1:-el9}"
+ARCH="${2:-x86_64}"
+
+case "$DISTRO" in
+  el8)       IMAGE="rockylinux:8" ;;
+  el9)       IMAGE="rockylinux:9" ;;
+  el10)      IMAGE="rockylinux/rockylinux:10" ;;
+  amzn2023)  IMAGE="amazonlinux:2023" ;;
+  *)
+    echo "Unknown distro: $DISTRO (expected: el8, el9, el10, amzn2023)" >&2
+    exit 2
+    ;;
+esac
+
+if command -v docker >/dev/null 2>&1; then
+  ENGINE=docker
+elif command -v podman >/dev/null 2>&1; then
+  ENGINE=podman
+else
+  echo "Need docker or podman in PATH" >&2
+  exit 2
+fi
+
+PLATFORM_ARG=()
+if [ "$ARCH" != "x86_64" ]; then
+  case "$ARCH" in
+    aarch64) PLATFORM_ARG=(--platform linux/arm64) ;;
+    *) echo "Unknown arch: $ARCH" >&2; exit 2 ;;
+  esac
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo ">>> Engine:   $ENGINE"
+echo ">>> Distro:   $DISTRO ($IMAGE)"
+echo ">>> Arch:     $ARCH"
+echo ">>> Repo:     $REPO_ROOT"
+echo
+
+"$ENGINE" run --rm "${PLATFORM_ARG[@]}" \
+  -v "$REPO_ROOT:/src:ro" \
+  -e DISTRO="$DISTRO" \
+  -e ARCH="$ARCH" \
+  "$IMAGE" bash -euo pipefail -c '
+set -x
+
+# Install build deps (mirrors release-rpm.yml build-rpm step).
+if command -v dnf >/dev/null 2>&1; then
+  PKG=dnf
+else
+  PKG=yum
+fi
+$PKG install -y rpm-build rpmdevtools rsync gcc-c++ make autoconf automake \
+  libtool libevent-devel openssl-devel zlib-devel pkgconfig
+
+# Stage a writable copy of the source tree.
+cp -r /src /work
+cd /work
+
+VERSION=$(awk -F"[(),]" "/AC_INIT/ {gsub(/ /, \"\", \$3); print \$3}" configure.ac)
+echo "Building memtier-benchmark version: $VERSION"
+
+rpmdev-setuptree
+
+# Tarball matches what build-srpm produces in CI.
+mkdir -p memtier-benchmark-$VERSION
+rsync -a --exclude=".git" --exclude="memtier-benchmark-*" . memtier-benchmark-$VERSION/
+tar czf ~/rpmbuild/SOURCES/memtier-benchmark-$VERSION.tar.gz memtier-benchmark-$VERSION
+
+sed "s/^Version:.*/Version:        $VERSION/" rpm/memtier-benchmark.spec \
+  > ~/rpmbuild/SPECS/memtier-benchmark.spec
+
+# -ba builds both SRPM and binary RPM in one shot.
+rpmbuild -ba ~/rpmbuild/SPECS/memtier-benchmark.spec
+
+# Direct-install verification (mirrors smoke-test "Verify direct install").
+RPM_FILE=$(find ~/rpmbuild/RPMS -name "*.rpm" -type f ! -name "*debug*" | head -1)
+[ -n "$RPM_FILE" ] || { echo "No RPM produced"; exit 1; }
+$PKG install -y "$RPM_FILE"
+
+memtier_benchmark --version
+memtier_benchmark --help > /dev/null
+test -f /usr/share/man/man1/memtier_benchmark.1.gz \
+  || test -f /usr/share/man/man1/memtier_benchmark.1
+bash -n /usr/share/bash-completion/completions/memtier_benchmark
+
+# Repo-install verification (mirrors smoke-test local-YUM-repo step).
+$PKG install -y createrepo_c || $PKG install -y createrepo
+$PKG remove -y memtier-benchmark
+
+REPO_ROOT=/tmp/localrepo
+mkdir -p "$REPO_ROOT/$DISTRO/$ARCH"
+find ~/rpmbuild/RPMS -name "*.rpm" -type f ! -name "*debug*" \
+  -exec cp {} "$REPO_ROOT/$DISTRO/$ARCH/" \;
+if command -v createrepo_c >/dev/null 2>&1; then
+  createrepo_c "$REPO_ROOT/$DISTRO/$ARCH"
+else
+  createrepo "$REPO_ROOT/$DISTRO/$ARCH"
+fi
+
+if [ "$DISTRO" = "amzn2023" ]; then
+  BASEURL="file://$REPO_ROOT/amzn2023/\$basearch"
+else
+  BASEURL="file://$REPO_ROOT/el\$releasever/\$basearch"
+fi
+
+cat > /etc/yum.repos.d/local-test.repo <<EOF
+[local-test]
+name=Local Test
+baseurl=$BASEURL
+enabled=1
+gpgcheck=0
+EOF
+
+$PKG install -y memtier-benchmark
+memtier_benchmark --version
+
+echo
+echo "================================================"
+echo "OK: $DISTRO $ARCH built, signed-not-verified, and repo-installed"
+echo "================================================"
+'


### PR DESCRIPTION
Add RPM packaging and YUM repository publishing for Red Hat-based distributions with multi-architecture support.

## Changes

### New Files
- `rpm/memtier-benchmark.spec` — RPM spec file for building memtier_benchmark
- `.github/workflows/release-rpm.yml` — GitHub Actions workflow for RPM builds and publishing
- `scripts/test-rpm-locally.sh` — local one-shot reproduction of the build + smoke test inside a single container (any matrix entry)

### Supported Distributions

| Distribution | x86_64 | aarch64 |
|--------------|--------|---------|
| Rocky Linux 8 (el8) | ✅ | ✅ |
| Rocky Linux 9 (el9) | ✅ | ✅ |
| Rocky Linux 10 (el10) | ✅ | ✅ |
| Amazon Linux 2023 | ✅ | ✅ |

> Compatible with RHEL 8/9/10 and AlmaLinux 8/9/10

### Workflow Behavior

| Event | Build RPMs | Smoke Test | Publish to YUM |
|-------|------------|------------|----------------|
| PR to master/main | ✅ | ✅ | ❌ |
| Push to master/main | ✅ | ✅ | ❌ |
| Release published | ✅ | ✅ | ✅ |
| Manual dispatch | ✅ | ✅ | ❌ |

### Repository Structure

Packages will be published to `https://packages.redis.io/rpm/`:
```
https://packages.redis.io/rpm/
├── el8/
│   ├── x86_64/
│   │   ├── repodata/
│   │   └── memtier-benchmark-*.el8.x86_64.rpm
│   └── aarch64/
│       ├── repodata/
│       └── memtier-benchmark-*.el8.aarch64.rpm
├── el9/
│   ├── x86_64/
│   └── aarch64/
├── el10/
│   ├── x86_64/
│   └── aarch64/
└── amzn2023/
    ├── x86_64/
    └── aarch64/
```

which aligns with what we already have in DEB Repository Structure:
```
https://packages.redis.io/deb/
├── dists/
│   ├── focal/           # Ubuntu 20.04
│   │   ├── Release
│   │   ├── Release.gpg
│   │   └── main/
│   │       └── binary-amd64/
│   │           └── Packages
│   ├── jammy/           # Ubuntu 22.04
│   ├── noble/           # Ubuntu 24.04
│   ├── bullseye/        # Debian 11
│   └── bookworm/        # Debian 12
└── pool/
    └── main/
        └── m/
            └── memtier-benchmark/
                ├── memtier-benchmark_*_amd64.deb
                └── memtier-benchmark_*_arm64.deb
```

## Hardening since initial review

See [this comment](https://github.com/redis/memtier_benchmark/pull/338#issuecomment-4351685783) for a per-area summary. Key items:

- **Publish path safety** — explicit `aws s3 ls` precheck so a transient sync failure can't trigger `--delete` against prior releases; `rpm -qp %{SIGPGP:pgpsig}` + `rpm -K` post-sign verification; signing identity derived from the imported key's fingerprint instead of a hard-coded UID; non-empty public-key export sanity check.
- **Workflow security** — least-privilege `permissions:` (workflow `contents: read`, write only on the jobs that need it); third-party actions pinned to commit SHAs; user-controlled values (release tag, workflow_dispatch input, version output) routed through `env:` rather than `${{ … }}` shell interpolation; version validated against `[A-Za-z0-9._-]` whitelist before reuse.
- **Test coverage** — smoke test runs on PRs; new local-YUM-repo install test mirrors the README's `el$releasever/$basearch` (and `amzn2023/$basearch`) baseurl pattern, so README config drift fails CI; man-page check uses `rpm -ql` (distro-agnostic re: gz/zst); advisory `rpmlint` step.
- **Release-tag invariant** — tag/source-version mismatch on `release` events is now a hard fail (was a warning).
- **Docs** — separate AL2023 install section (the prior `el$releasever` block expanded to a 404 there); RPM install no longer pipes the key through `gpg --dearmor` (RPM expects ASCII armor).
- **CI infra** — aarch64 jobs migrated from a never-available self-hosted label to GitHub-hosted `ubuntu-24.04-arm`. **First time the aarch64 matrix has actually executed end-to-end on this repo.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new release automation that signs artifacts and syncs a YUM repo to S3 with `--delete`, so misconfiguration could affect published packages despite guardrails (version/tag validation, signature verification, non-empty checks).
> 
> **Overview**
> Adds first-class RPM packaging and distribution for `memtier-benchmark`, including a new `rpm/memtier-benchmark.spec` and a GitHub Actions workflow that builds SRPMs/RPMs for EL8/9/10 and Amazon Linux 2023 across `x86_64` and `aarch64`.
> 
> The workflow now **smoke-tests installs** (direct RPM and via a generated local YUM repo matching the documented baseurl layout), and on published non-prerelease releases it **signs RPMs, verifies signatures, generates `createrepo` metadata, and syncs the repo to S3** (plus optionally attaches RPMs to the GitHub release). README is updated with YUM repo install instructions, and `scripts/test-rpm-locally.sh` is added to reproduce the build/smoke test in a container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06de47069c374e845aae3db219c2a6fe5bea68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
