### PR TITLE
Add per-thread CPU stats reporting in JSON output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,16 @@ All C++ source files must include this header:
  */
 ```
 
+## CPU Stats Testing
+
+Per-thread CPU measurement is implemented using native OS APIs (Mach `thread_info` on macOS, `pthread_getcpuclockid` on Linux). Tests live in `tests/test_cpu_stats.py`:
+
+- **`test_cpu_stats_in_json`**: Verifies CPU stats appear in JSON output with valid structure (per-second, per-thread entries with values in [0, 100))
+- **`test_cpu_stats_high_load`**: Stresses a single thread with 500 clients to drive high CPU; verifies non-trivial usage and the >95% warning
+- **`test_cpu_stats_external_validation`**: Cross-validates memtier's reported CPU percentages against `psutil.Process.threads()` as an independent oracle. Launches memtier via `subprocess.Popen`, polls psutil every ~1s, then compares aggregate average worker CPU% from both sources (±15pp tolerance). Requires `psutil` (listed in `tests/test_requirements.txt`); skips gracefully if unavailable.
+
+All CPU stats tests assert that no individual thread reports exactly 100% CPU usage (values must be strictly less than 100%).
+
 ## Important Notes
 
 - Default build includes debug symbols (`-g`) for crash analysis

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -101,6 +101,11 @@ The project includes a basic set of integration tests.
 Integration tests are based on [RLTest](https://github.com/RedisLabsModules/RLTest), and specific setup parameters can be provided
 to configure tests and topologies (OSS standalone and OSS cluster). By default the tests will be ran for all common commands, and with OSS standalone setup.
 
+Test dependencies (installed via `tests/test_requirements.txt`):
+- **redis** — Python Redis client
+- **RLTest** — Redis Labs test framework
+- **psutil** — Cross-platform process/thread CPU monitoring (used by `test_cpu_stats.py` for external validation of per-thread CPU measurements)
+
 To run all integration tests in a Python virtualenv, follow these steps:
 
     $ mkdir -p .env

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -1369,6 +1369,11 @@ void run_stats::print_kb_sec_column(output_table &table, const std::vector<aggre
     table.add_column(column);
 }
 
+void run_stats::set_cpu_stats(std::vector<per_second_cpu_stats> cpu_stats)
+{
+    m_cpu_stats = std::move(cpu_stats);
+}
+
 void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &command_list, bool cluster_mode,
                            const std::vector<aggregated_command_type_stats> *aggregated)
 {
@@ -1460,6 +1465,24 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
                          m_totals.m_total_latency, m_totals.m_ops, m_totals.m_connection_errors_sec,
                          m_totals.m_connection_errors, quantiles_list, m_totals.latency_histogram, timestamps,
                          total_stats);
+
+    if (jsonhandler != NULL && !m_cpu_stats.empty()) {
+        jsonhandler->open_nesting("CPU Stats");
+        for (size_t i = 0; i < m_cpu_stats.size(); i++) {
+            const per_second_cpu_stats &cs = m_cpu_stats[i];
+            char sec_str[32];
+            snprintf(sec_str, sizeof(sec_str), "%u", cs.m_second);
+            jsonhandler->open_nesting(sec_str);
+            jsonhandler->write_obj("Main Thread", "%.2f", cs.m_main_thread_cpu_pct);
+            for (size_t t = 0; t < cs.m_thread_cpu_pct.size(); t++) {
+                char thread_name[32];
+                snprintf(thread_name, sizeof(thread_name), "Thread %zu", t);
+                jsonhandler->write_obj(thread_name, "%.2f", cs.m_thread_cpu_pct[t]);
+            }
+            jsonhandler->close_nesting();
+        }
+        jsonhandler->close_nesting();
+    }
 }
 
 void run_stats::print_histogram(FILE *out, json_handler *jsonhandler, arbitrary_command_list &command_list,

--- a/run_stats.h
+++ b/run_stats.h
@@ -142,6 +142,9 @@ public:
     void set_interrupted(bool interrupted) { m_interrupted = interrupted; }
     bool get_interrupted() const { return m_interrupted; }
 
+    std::vector<per_second_cpu_stats> m_cpu_stats;
+    void set_cpu_stats(std::vector<per_second_cpu_stats> cpu_stats);
+
     void update_get_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency,
                        unsigned int hits, unsigned int misses);
     void update_set_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency);

--- a/run_stats_types.h
+++ b/run_stats_types.h
@@ -147,6 +147,12 @@ public:
     void merge(const one_second_stats &other);
 };
 
+struct per_second_cpu_stats {
+    unsigned int m_second;
+    double m_main_thread_cpu_pct;
+    std::vector<double> m_thread_cpu_pct;
+};
+
 class totals_cmd
 {
 public:

--- a/tests/test_cpu_stats.py
+++ b/tests/test_cpu_stats.py
@@ -1,0 +1,245 @@
+import tempfile
+import json
+import subprocess
+import time
+from include import *
+from mb import Benchmark, RunConfig
+
+
+def test_cpu_stats_in_json(env):
+    """Verify CPU stats appear in JSON output with valid structure."""
+    benchmark_specs = {"name": env.testName, "args": []}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=2, clients=5, requests=1000)
+    master_nodes_list = env.getMasterNodesList()
+    overall_expected_request_count = get_expected_request_count(config)
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(config, env)
+
+    env.assertTrue(memtier_ok == True)
+    env.assertTrue(os.path.isfile('{0}/mb.json'.format(config.results_dir)))
+
+    json_filename = '{0}/mb.json'.format(config.results_dir)
+    with open(json_filename) as results_json:
+        results_dict = json.load(results_json)
+
+        # CPU Stats should be present under ALL STATS
+        env.assertTrue('ALL STATS' in results_dict)
+        all_stats = results_dict['ALL STATS']
+        env.assertTrue('CPU Stats' in all_stats)
+
+        cpu_stats = all_stats['CPU Stats']
+        env.assertTrue(len(cpu_stats) > 0)
+
+        for second_key, second_data in cpu_stats.items():
+            # Each second should have Main Thread
+            env.assertTrue('Main Thread' in second_data)
+            main_cpu = second_data['Main Thread']
+            env.assertTrue(main_cpu >= 0)
+            env.assertTrue(main_cpu < 100)
+
+            # Each second should have Thread N entries matching thread count (2)
+            for t in range(2):
+                thread_key = 'Thread {}'.format(t)
+                env.assertTrue(thread_key in second_data)
+                thread_cpu = second_data[thread_key]
+                env.assertTrue(thread_cpu >= 0)
+                env.assertTrue(thread_cpu < 100)
+
+
+def test_cpu_stats_high_load(env):
+    """Stress a single thread with many clients to drive high CPU and verify warning."""
+    env.skipOnCluster()
+
+    # 1 thread, 500 clients, deep pipeline, small data, time-based run
+    # This should saturate the single worker thread and trigger the >95% CPU warning
+    benchmark_specs = {"name": env.testName, "args": [
+        '--pipeline=100',
+        '--data-size=1',
+        '--ratio=1:1',
+        '--key-pattern=R:R',
+        '--key-maximum=100',
+    ]}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=1, clients=500, requests=None, test_time=5)
+    master_nodes_list = env.getMasterNodesList()
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(config, env)
+
+    env.assertTrue(memtier_ok == True)
+    env.assertTrue(os.path.isfile('{0}/mb.json'.format(config.results_dir)))
+
+    # Verify JSON CPU stats exist and show non-trivial CPU usage
+    json_filename = '{0}/mb.json'.format(config.results_dir)
+    with open(json_filename) as results_json:
+        results_dict = json.load(results_json)
+        all_stats = results_dict['ALL STATS']
+        env.assertTrue('CPU Stats' in all_stats)
+
+        cpu_stats = all_stats['CPU Stats']
+        env.assertTrue(len(cpu_stats) >= 2)
+
+        # With 500 clients on 1 thread, the worker should be using significant CPU
+        max_thread_cpu = 0
+        for second_key, second_data in cpu_stats.items():
+            env.assertTrue('Thread 0' in second_data)
+            thread_cpu = second_data['Thread 0']
+            env.assertTrue(thread_cpu >= 0)
+            env.assertTrue(thread_cpu < 100)
+            if thread_cpu > max_thread_cpu:
+                max_thread_cpu = thread_cpu
+
+        # The single worker thread should be using meaningful CPU (> 10%)
+        env.debugPrint("Max worker thread CPU observed: {:.1f}%".format(max_thread_cpu), True)
+        env.assertTrue(max_thread_cpu > 10.0)
+
+    # Check stderr for the high CPU warning
+    stderr_filename = '{0}/mb.stderr'.format(config.results_dir)
+    if os.path.isfile(stderr_filename):
+        with open(stderr_filename) as stderr_file:
+            stderr_content = stderr_file.read()
+            has_warning = 'WARNING: High CPU on thread' in stderr_content
+            env.debugPrint("High CPU warning present in stderr: {}".format(has_warning), True)
+            if max_thread_cpu > 95.0:
+                # If we observed >95% CPU, the warning must have fired
+                env.assertTrue(has_warning)
+
+
+def test_cpu_stats_external_validation(env):
+    """Cross-validate memtier CPU stats against psutil external measurements."""
+    try:
+        import psutil
+    except ImportError:
+        env.debugPrint("psutil not available, skipping external CPU validation", True)
+        return
+
+    env.skipOnCluster()
+
+    num_threads = 1
+    test_time = 5
+
+    benchmark_specs = {"name": env.testName, "args": [
+        '--pipeline=100',
+        '--data-size=1',
+        '--ratio=1:1',
+        '--key-pattern=R:R',
+        '--key-maximum=100',
+    ]}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=num_threads, clients=500,
+                                        requests=None, test_time=test_time)
+    master_nodes_list = env.getMasterNodesList()
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+
+    # Launch as subprocess (non-blocking) so we can sample CPU externally
+    process = subprocess.Popen(
+        benchmark.args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    # Sample external CPU via psutil
+    external_samples = []
+    access_denied = False
+    try:
+        p = psutil.Process(process.pid)
+        prev_threads = {t.id: (t.user_time, t.system_time) for t in p.threads()}
+        prev_time = time.time()
+        time.sleep(1)
+
+        while process.poll() is None:
+            cur_time = time.time()
+            wall_delta = cur_time - prev_time
+            if wall_delta < 0.5:
+                time.sleep(0.5)
+                continue
+
+            cur_threads = {t.id: (t.user_time, t.system_time) for t in p.threads()}
+            sample = {}
+            for tid, (cu, cs) in cur_threads.items():
+                if tid in prev_threads:
+                    pu, ps_time = prev_threads[tid]
+                    delta_cpu = (cu - pu) + (cs - ps_time)
+                    sample[tid] = (delta_cpu / wall_delta) * 100.0
+            external_samples.append(sample)
+
+            prev_threads = cur_threads
+            prev_time = cur_time
+            time.sleep(1)
+    except psutil.NoSuchProcess:
+        pass
+    except psutil.AccessDenied:
+        # macOS task_for_pid restriction — can't read child process threads
+        access_denied = True
+
+    stdout, stderr = process.communicate()
+    if stderr:
+        benchmark.write_file('mb.stderr', stderr)
+
+    env.assertTrue(process.returncode == 0)
+
+    if access_denied:
+        env.debugPrint("psutil.AccessDenied (macOS task_for_pid restriction), skipping", True)
+        return
+
+    env.assertTrue(len(external_samples) >= 2)
+
+    # Read memtier JSON output
+    json_filename = os.path.join(config.results_dir, 'mb.json')
+    env.assertTrue(os.path.isfile(json_filename))
+
+    with open(json_filename) as f:
+        results_dict = json.load(f)
+
+    cpu_stats = results_dict['ALL STATS']['CPU Stats']
+
+    # Compute average total worker CPU% from memtier JSON (exclude Main Thread)
+    internal_worker_cpus = []
+    for sec_key, sec_data in cpu_stats.items():
+        sec_total = sum(v for k, v in sec_data.items() if k != 'Main Thread')
+        internal_worker_cpus.append(sec_total)
+    internal_avg = sum(internal_worker_cpus) / len(internal_worker_cpus)
+
+    # Compute average total worker CPU% from psutil
+    # Identify main thread as lowest TID (main thread has lowest ID on both platforms)
+    all_tids = set()
+    for sample in external_samples:
+        all_tids.update(sample.keys())
+    main_tid = min(all_tids) if all_tids else None
+
+    external_worker_cpus = []
+    for sample in external_samples:
+        sec_total = sum(v for tid, v in sample.items() if tid != main_tid)
+        external_worker_cpus.append(sec_total)
+    external_avg = sum(external_worker_cpus) / len(external_worker_cpus)
+
+    env.debugPrint("Internal avg worker CPU: {:.1f}%".format(internal_avg), True)
+    env.debugPrint("External avg worker CPU: {:.1f}%".format(external_avg), True)
+    env.debugPrint("Delta: {:.1f}pp".format(abs(internal_avg - external_avg)), True)
+
+    # Assert they agree within 15 percentage points
+    env.assertTrue(abs(internal_avg - external_avg) < 15.0)
+
+    # Verify both show significant CPU usage (not both near zero)
+    env.assertTrue(internal_avg > 10.0)
+    env.assertTrue(external_avg > 10.0)

--- a/tests/test_cpu_stats.py
+++ b/tests/test_cpu_stats.py
@@ -22,7 +22,8 @@ def test_cpu_stats_in_json(env):
 
     benchmark = Benchmark.from_json(config, benchmark_specs)
     memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env)
+    if not memtier_ok:
+        debugPrintMemtierOnError(config, env)
 
     env.assertTrue(memtier_ok == True)
     env.assertTrue(os.path.isfile('{0}/mb.json'.format(config.results_dir)))
@@ -80,7 +81,8 @@ def test_cpu_stats_high_load(env):
 
     benchmark = Benchmark.from_json(config, benchmark_specs)
     memtier_ok = benchmark.run()
-    debugPrintMemtierOnError(config, env)
+    if not memtier_ok:
+        debugPrintMemtierOnError(config, env)
 
     env.assertTrue(memtier_ok == True)
     env.assertTrue(os.path.isfile('{0}/mb.json'.format(config.results_dir)))

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,2 +1,3 @@
 redis>=3.0.0
 git+https://github.com/RedisLabsModules/RLTest.git@master
+psutil>=5.9.0


### PR DESCRIPTION
## Summary
- Report per-second, per-thread CPU usage in JSON output using native OS APIs (Mach `thread_info` on macOS, `pthread_getcpuclockid` on Linux)
- Emit a stderr warning when any worker thread exceeds 95% CPU, indicating results may be unreliable
- Add integration tests: JSON structure validation, high-load stress test, and psutil-based external cross-validation

## Details

A new `CPU Stats` section is added to the JSON output under `ALL STATS`, reporting per-second CPU percentages for the main thread and each worker thread. This helps users identify when memtier itself is the bottleneck rather than the server under test.

### Files changed
- **`memtier_benchmark.cpp`** — `get_thread_cpu_usec()` helper + per-second CPU sampling in the benchmark loop
- **`run_stats.cpp` / `run_stats.h` / `run_stats_types.h`** — `per_second_cpu_stats` struct and JSON serialization
- **`tests/test_cpu_stats.py`** — Three integration tests (structure, high-load, external validation)
- **`tests/test_requirements.txt`** — Added `psutil` dependency for external validation test
- **`AGENTS.md` / `DEVELOPMENT.md`** — Documentation updates

## Test plan
- `test_cpu_stats_in_json` — Verifies CPU Stats appear in JSON with correct per-thread structure
- `test_cpu_stats_high_load` — 500 clients on 1 thread; verifies non-trivial CPU and >95% warning
- `test_cpu_stats_external_validation` — Cross-validates against psutil measurements (±15pp tolerance)
- Build on Linux to verify `pthread_getcpuclockid` path compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds per-second CPU sampling in the main benchmark loop and emits new JSON/stderr output; main risk is measurement overhead and potential platform-specific differences (macOS Mach vs Linux pthread clocks) affecting performance and tests.
> 
> **Overview**
> Adds **per-second, per-thread CPU utilization reporting** to the benchmark run and exposes it in JSON output under `ALL STATS` → `CPU Stats` (including main thread and each worker thread).
> 
> Implements OS-specific CPU time sampling (Mach on macOS, `pthread_getcpuclockid` on Linux), stores samples in `run_stats`, and prints a stderr warning when any worker exceeds 95% CPU.
> 
> Introduces new integration coverage in `tests/test_cpu_stats.py` (JSON structure checks, high-load warning/usage assertions, and optional `psutil` cross-validation) and documents the new testing/dependency requirements (adds `psutil` to `tests/test_requirements.txt`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bff2e9c555de33729e3e452fe8a385b008d74e48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->