### PR TITLE
Fix Alpine build: make execinfo.h optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,38 @@ jobs:
         make code-coverage-capture
         bash <(curl -s https://codecov.io/bash) -f memtier_benchmark-*-coverage.info || echo "Codecov did not collect coverage reports"
 
+  build-alpine:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        alpine_version:
+          - "alpine:3.17"
+          - "alpine:3.18"
+          - "alpine:3.19"
+          - "alpine:3.20"
+          - "alpine:3.21"
+          - "alpine:latest"
+    container: ${{ matrix.alpine_version }}
+    name: Build ${{ matrix.alpine_version }}
+    steps:
+    - name: Install git
+      run: apk add --no-cache git
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: |
+        apk add --no-cache \
+          make g++ autoconf automake libtool pkgconfig \
+          libevent-dev zlib-dev openssl-dev
+
+    - name: Build
+      run: autoreconf -ivf && ./configure && make -j
+
+    - name: Verify version
+      run: ./memtier_benchmark --version
+
   build-macos:
     strategy:
       matrix:

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ AC_HEADER_STDC
 AC_HEADER_DIRENT
 AC_CHECK_HEADERS([stdlib.h string.h sys/time.h getopt.h limits.h malloc.h stdlib.h unistd.h utime.h assert.h sys/socket.h sys/types.h])
 AC_CHECK_HEADERS([fcntl.h netinet/tcp.h])
+AC_CHECK_HEADERS([execinfo.h])
 AC_CHECK_HEADERS([pthread.h])
 AC_CHECK_HEADERS([zlib.h])
 AC_CHECK_HEADERS([event2/event.h])

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -41,7 +41,9 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <signal.h>
+#ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
+#endif
 #include <ucontext.h>
 #include <time.h>
 #include <ctype.h>
@@ -1819,6 +1821,7 @@ static void print_all_threads_stack_trace(FILE *fp, int pid, const char *timestr
     // Print main/crashing thread first
     fprintf(fp, "[%d] %s # Thread %lu (current/crashing thread):\n", pid, timestr, (unsigned long) current_thread);
 
+#ifdef HAVE_EXECINFO_H
     void *trace[100];
     int trace_size = backtrace(trace, 100);
     char **messages = backtrace_symbols(trace, trace_size);
@@ -1826,6 +1829,9 @@ static void print_all_threads_stack_trace(FILE *fp, int pid, const char *timestr
         fprintf(fp, "[%d] %s #   %s\n", pid, timestr, messages[i]);
     }
     free(messages);
+#else
+    fprintf(fp, "[%d] %s #   (backtrace not available on this platform)\n", pid, timestr);
+#endif
 
     // Now print stack traces for worker threads if available
     if (g_threads != NULL) {


### PR DESCRIPTION
## Summary
- `libexecinfo-dev` was removed in Alpine 3.17+, causing `fatal error: execinfo.h: No such file or directory` during build
- Added `AC_CHECK_HEADERS([execinfo.h])` to `configure.ac` so the build system detects availability
- Guarded `#include <execinfo.h>` and `backtrace()`/`backtrace_symbols()` calls behind `#ifdef HAVE_EXECINFO_H` with a graceful fallback message
- Added Alpine CI matrix job (3.17, 3.18, 3.19, 3.20, 3.21, latest) that builds and runs `--version`

Closes https://github.com/redis/memtier_benchmark/issues/358

## Test plan
- [x] Verify all Alpine matrix jobs pass (build + `--version`)
- [x] Verify existing Debian/Ubuntu/macOS CI jobs still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build/CI portability changes only; runtime behavior changes only in crash-reporting paths where stack traces may now be omitted with a fallback message if `execinfo.h` is unavailable.
> 
> **Overview**
> Fixes Alpine (3.17+) build failures by making `execinfo.h` optional: `configure.ac` now probes for it and `memtier_benchmark.cpp` conditionally compiles the `execinfo` include and `backtrace()`/`backtrace_symbols()` usage with a graceful fallback message.
> 
> CI is extended with a new `build-alpine` matrix job that builds and runs `./memtier_benchmark --version` across multiple Alpine versions (`3.17`-`3.21` and `latest`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a871da3502ca4a326c5c99922a043ddbc0e79c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->