### PR TITLE
Bump GitHub Actions ahead of Node 20 deprecation (June 2026)

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build with ASAN
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install build dependencies
       run: |
@@ -42,7 +42,7 @@ jobs:
         echo "✓ AddressSanitizer is linked"
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: memtier-asan-build
         path: |
@@ -76,10 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     name: ASAN ${{ matrix.test-config.name }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: memtier-asan-build
 
@@ -92,7 +92,7 @@ jobs:
         sudo apt-get install -y pkg-config libevent-dev libssl-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         architecture: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Checkout Code for other versions
       if: matrix.image != 'ubuntu:bionic'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install dependencies
       run: |
@@ -73,7 +73,7 @@ jobs:
         apt-get install -y git ca-certificates
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install build dependencies
       run: |
@@ -99,7 +99,7 @@ jobs:
   build-notls:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
@@ -116,7 +116,7 @@ jobs:
   build-ubuntu-latest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
@@ -136,7 +136,7 @@ jobs:
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
@@ -148,7 +148,7 @@ jobs:
       run: autoreconf -ivf && ./configure --enable-code-coverage && make -j
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: memtier-build-${{ matrix.platform }}
         path: |
@@ -190,10 +190,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
     name: Test ${{ matrix.test-config.name }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: memtier-build-${{ matrix.platform }}
 
@@ -206,7 +206,7 @@ jobs:
         sudo apt-get install lcov autoconf automake pkg-config libevent-dev libssl-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         architecture: x64
@@ -244,10 +244,10 @@ jobs:
     runs-on: ubuntu-22.04
     name: "StatsD: docker-compose Integration"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: memtier-build-ubuntu-22.04
 
@@ -263,7 +263,7 @@ jobs:
         sudo apt-get install -y libevent-dev libssl-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         architecture: x64
@@ -307,7 +307,7 @@ jobs:
   coverage-ubuntu:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install dependencies
       run: |
@@ -320,7 +320,7 @@ jobs:
       run: autoreconf -ivf && ./configure --enable-code-coverage && make -j
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         architecture: x64
@@ -376,7 +376,7 @@ jobs:
       run: apk add --no-cache git
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install build dependencies
       run: |
@@ -397,7 +397,7 @@ jobs:
     runs-on: macos-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent openssl@${{ matrix.openssl }}
     - name: Build
@@ -413,7 +413,7 @@ jobs:
   build-macos-openssl-1-1:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent openssl@1.1
     - name: Build
@@ -428,7 +428,7 @@ jobs:
   build-macos-openssl-1-0-2:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent pkg-config
     - name: Install openssl v1.0.2

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -11,7 +11,7 @@ jobs:
     name: C++ Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install clang-format
         run: |

--- a/.github/workflows/dockers.yml
+++ b/.github/workflows/dockers.yml
@@ -20,21 +20,21 @@ jobs:
     if: (github.repository == 'redis/memtier_benchmark')
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
         with:
           install: true
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: build and push in master
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         if: ${{ github.event.release.tag_name == '' }}
         with:
           push: true
@@ -43,7 +43,7 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
 
       - name: build and push on release
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         if: ${{ github.event.release.tag_name != '' }}
         with:
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         path: repo
     - name: Copy source code to build dir
@@ -85,7 +85,7 @@ jobs:
       run: |
           cd sources && dpkg-buildpackage -S
     - name: Upload source package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: source-${{ matrix.dist }}
         path: |
@@ -104,7 +104,7 @@ jobs:
         exclude: ${{ fromJSON(vars.BUILD_EXCLUDE) }}
     needs: build-source-package
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Determine build architecture
       run: |
           if [ ${{ matrix.arch }} = "i386" ]; then
@@ -128,7 +128,7 @@ jobs:
     - name: Prepare sbuild environment
       run: sudo ./debian/setup_sbuild.sh ${{ matrix.dist }} ${{ env.BUILD_ARCH }}
     - name: Get source package
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: source-${{ matrix.dist }}
     - name: Build binary package
@@ -139,7 +139,7 @@ jobs:
             --build ${{ env.BUILD_ARCH }} \
             --dist ${{ matrix.dist }} *.dsc
     - name: Upload binary package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: binary-${{ matrix.dist }}-${{ matrix.arch }}
         path: |
@@ -171,7 +171,7 @@ jobs:
         fi
         echo "BUILD_ARCH=$BUILD_ARCH" >> $GITHUB_ENV
     - name: Get binary packages
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: binary-${{ env.BUILD_ARCH }}-${{ env.ARCH }}
         path: binary-${{ env.BUILD_ARCH }}-${{ env.ARCH }}
@@ -194,7 +194,7 @@ jobs:
       env:
         APT_SIGNING_KEY: ${{ secrets.APT_SIGNING_KEY }}
     - name: Get binary packages
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build with TSAN
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install build dependencies
       run: |
@@ -46,7 +46,7 @@ jobs:
         echo "✓ ThreadSanitizer is linked"
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: memtier-tsan-build
         path: |
@@ -73,10 +73,10 @@ jobs:
     name: TSAN ${{ matrix.test-config.name }}
     continue-on-error: true  # Don't fail build on known races
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: memtier-tsan-build
 
@@ -89,7 +89,7 @@ jobs:
         sudo apt-get install -y pkg-config libevent-dev libssl-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         architecture: x64

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build with UBSan
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install build dependencies
       run: |
@@ -37,7 +37,7 @@ jobs:
         make -j
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: memtier-ubsan-build
         path: |
@@ -71,10 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     name: UBSan ${{ matrix.test-config.name }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: memtier-ubsan-build
 
@@ -87,7 +87,7 @@ jobs:
         sudo apt-get install -y pkg-config libevent-dev libssl-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         architecture: x64


### PR DESCRIPTION
## Summary
GitHub is deprecating Node 20 actions on **June 2, 2026** ([blog post](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), RED-190667). After that date, workflows running Node 20-based actions will fail. This PR bumps every affected action across our 7 workflows so we land before the cutoff. While in here, also bumps a couple of older Node 16 actions that were already deprecated.

### Action bumps
| Action | From | To | Reason |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v5** | Node 20 → Node 24 |
| `actions/upload-artifact` | v4 | **v5** | Node 20 → Node 24 |
| `actions/download-artifact` | v4 | **v5** | Node 20 → Node 24 |
| `actions/setup-python` | v2 | **v6** | Already-deprecated Node 12; v6 is Node 24 (v5 still on Node 20) |
| `docker/setup-qemu-action` | v2 | **v3** | Node 16 → Node 20 (latest stable line) |
| `docker/setup-buildx-action` | v2 | **v3** | Node 16 → Node 20 |
| `docker/login-action` | v2 | **v3** | Node 16 → Node 20 |
| `docker/build-push-action` | v4 | **v6** | Node 16 → Node 20 |

### Intentional non-changes
- `actions/checkout@v3` in `ci.yml:33` is **kept** for the `ubuntu:bionic` smoketest job. Bionic's glibc 2.27 cannot run Node 20+, which is why `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` is already set in that job.
- `ruby/setup-ruby@v1` and `softprops/action-gh-release@v1` use floating major tags and are actively maintained on a non-deprecated Node — no action needed.

## Test plan
- [ ] CI workflow — all matrix jobs green
- [ ] ASAN / TSAN / UBSan workflows pass
- [ ] Code style workflow passes
- [ ] Confirm bionic smoke job still passes via the v3 path
- [ ] `dockers.yml` workflow_dispatch dry-run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to workflow action version bumps, but could cause CI/release/docker pipelines to fail if any updated action has breaking behavior or new runner requirements.
> 
> **Overview**
> Updates GitHub Actions versions across all CI workflows to avoid upcoming Node runtime deprecations.
> 
> This bumps `actions/checkout`, `actions/setup-python`, and artifact upload/download actions to newer major versions in the CI + sanitizer + release pipelines, and updates Docker build workflow actions (`setup-qemu`, `setup-buildx`, `login`, `build-push`) to their latest major versions while preserving the `ubuntu:bionic` job’s pinned `actions/checkout@v3` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67ef024586657e80d90f1813670930b102c391e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->