### PR TITLE
Widen get_total_latency() return type to double

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1045,9 +1045,9 @@ unsigned long int client_group::get_total_ops(void)
     return total_ops;
 }
 
-unsigned long int client_group::get_total_latency(void)
+double client_group::get_total_latency(void)
 {
-    unsigned long int total_latency = 0;
+    double total_latency = 0;
     unsigned int count = active_client_count();
     for (unsigned int i = 0; i < count; i++) {
         total_latency += m_clients[i]->get_stats()->get_total_latency();

--- a/client.h
+++ b/client.h
@@ -261,7 +261,7 @@ public:
 
     unsigned long int get_total_bytes(void);
     unsigned long int get_total_ops(void);
-    unsigned long int get_total_latency(void);
+    double get_total_latency(void);
     unsigned long int get_duration_usec(void);
     unsigned long int get_total_connection_errors(void);
 

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1985,7 +1985,7 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
         unsigned long int total_bytes = 0;
         unsigned long int duration = 0;
         unsigned int thread_counter = 0;
-        unsigned long int total_latency = 0;
+        double total_latency = 0;
         unsigned long int total_connection_errors = 0;
 
         for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -376,7 +376,7 @@ unsigned long int run_stats::get_total_ops(void)
     return m_totals.m_ops;
 }
 
-unsigned long int run_stats::get_total_latency(void)
+double run_stats::get_total_latency(void)
 {
     return m_totals.m_latency;
 }

--- a/run_stats.h
+++ b/run_stats.h
@@ -257,7 +257,7 @@ public:
     unsigned long int get_duration_usec(void);
     unsigned long int get_total_bytes(void);
     unsigned long int get_total_ops(void);
-    unsigned long int get_total_latency(void);
+    double get_total_latency(void);
     unsigned long int get_total_connection_errors(void);
 
     // Returns true if set_start_time() was called, indicating the client


### PR DESCRIPTION
## Summary

Follow-up to #364. After that fix, `totals::m_latency` is `double`, but `get_total_latency()` still returned `unsigned long int` and silently narrowed any fractional value to 0 or 1.

The narrowing is currently latent — `get_total_latency()` is only invoked during the live-progress accumulator phase where `m_latency` holds an integer-valued sum of microseconds, so no current caller observes a fractional value. But a future caller running after `summarize()` would re-trigger the same RED-191460 bug class (real avg of 1.291 ms truncated to 1, sub-ms truncated to 0).

Flagged by Cursor Bugbot on the 2.3.1 backport PR (#365).

## Change

Propagate `double` through the chain so the type matches the underlying field at each layer:

- `run_stats::get_total_latency` → returns `double`
- `client_group::get_total_latency` → returns `double`
- `memtier_benchmark.cpp` live-progress local accumulator → `double`

The display arithmetic (`avg_latency`, `cur_latency`) was already done in `double`, so no precision is lost or gained downstream — this is purely a type-system fix that prevents the same class of regression that #364 closed.

## Test plan

- [x] `OSS_STANDALONE=1 TEST=test_json_output_integrity.py ./tests/run_tests.sh` — 4/4 pass.
- [x] `autoreconf -ivf && ./configure && make -j` builds clean.
- [x] `make format` clean (no diff).
- [x] Live-progress display still shows non-zero average latency under a real workload (verified manually with `memtier_benchmark -s 127.0.0.1 -p 6379 --hide-histogram --test-time=4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-widening change limited to latency aggregation, reducing the chance of precision loss without affecting control flow.
> 
> **Overview**
> Prevents silent truncation of latency totals by widening `get_total_latency()` to return `double` throughout the stats chain (`run_stats` and `client_group`).
> 
> Updates the live progress accumulator in `memtier_benchmark.cpp` to use `double` for `total_latency`, keeping latency arithmetic consistent with the underlying `m_latency` type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dbc32191e649f80c5c0ec17d269d9c2aed60d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->