### PR TITLE
ci(release-rpm): drop apt awscli, use runner's pre-installed AWS CLI v2

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -386,10 +386,14 @@ jobs:
         path: rpms
         merge-multiple: false
 
-    - name: Install createrepo and AWS CLI
+    - name: Install createrepo and verify AWS CLI
       run: |
         sudo apt-get update
-        sudo apt-get install -y createrepo-c awscli rpm
+        # awscli is no longer in apt on Ubuntu 24.04 (noble); the GitHub-hosted
+        # ubuntu-latest runner ships AWS CLI v2 pre-installed at
+        # /usr/local/bin/aws, so we only need to install the rpm tooling here.
+        sudo apt-get install -y createrepo-c rpm
+        aws --version
 
     - name: Sign RPMs
       run: |


### PR DESCRIPTION
## Summary

The 2.3.1 release's `publish-to-yum` job failed in step 4 with:

\`\`\`
Package awscli is not available, but is referred to by another package.
E: Package 'awscli' has no installation candidate
\`\`\`

Failed run: https://github.com/redis/memtier_benchmark/actions/runs/25385139928/job/74444847195

Ubuntu **dropped the `awscli` apt package in 24.04 (noble)** — the v1 it shipped was years out of date. GitHub Actions' \`ubuntu-latest\` now resolves to noble, so the apt install can never satisfy `awscli` again.

The fix is straightforward: GitHub's `ubuntu-24.04` runner image **ships AWS CLI v2 pre-installed** at `/usr/local/bin/aws`, so the apt install line was both redundant and broken. Drop `awscli` from the apt list, add `aws --version` as a sanity check.

## Effect on the 2.3.1 release

The release tag, RPMs (build + smoke test) and Docker images all completed successfully — `publish-to-yum` is the last step that copies signed RPMs into the public S3-backed YUM repo. **The 2.3.1 RPMs exist as release assets but are not yet served from the YUM repo.** Once this lands, we can re-trigger `publish-to-yum` against the 2.3.1 release via `workflow_dispatch` (or by transient unpublish/republish) to backfill the repo.

## Where this also needs to land

Same fix is needed on the `2.3` branch so 2.3.x patch releases keep publishing. I'll open a sibling PR after this one lands, or feel free to cherry-pick directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that adjusts package installation for the GitHub runner image; main risk is if the runner image no longer includes `aws` or its path/version differs, breaking the publish job.
> 
> **Overview**
> Fixes `publish-to-yum` in `release-rpm.yml` on `ubuntu-latest` (now Ubuntu 24.04) by **removing `awscli` from the apt install** and installing only RPM tooling (`createrepo-c`, `rpm`).
> 
> Adds a small sanity check (`aws --version`) and clarifying comments to ensure the runner’s preinstalled AWS CLI v2 is available before syncing the YUM repo to S3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e2a53becd77efa72afd65df81ed094f63ecb76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->