### PR TITLE
ci(release-rpm): drop apt awscli, use runner's pre-installed AWS CLI v2 (2.3)

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -388,10 +388,14 @@ jobs:
         path: rpms
         merge-multiple: false
 
-    - name: Install createrepo and AWS CLI
+    - name: Install createrepo and verify AWS CLI
       run: |
         sudo apt-get update
-        sudo apt-get install -y createrepo-c awscli rpm
+        # awscli is no longer in apt on Ubuntu 24.04 (noble); the GitHub-hosted
+        # ubuntu-latest runner ships AWS CLI v2 pre-installed at
+        # /usr/local/bin/aws, so we only need to install the rpm tooling here.
+        sudo apt-get install -y createrepo-c rpm
+        aws --version
 
     - name: Sign RPMs
       run: |


### PR DESCRIPTION
## Summary

Backport of #368 to the `2.3` release branch.

The 2.3.1 release's `publish-to-yum` job failed in step 4 with:

\`\`\`
E: Package 'awscli' has no installation candidate
\`\`\`

Failed run: https://github.com/redis/memtier_benchmark/actions/runs/25385139928/job/74444847195

Ubuntu **dropped the `awscli` apt package in 24.04 (noble)**. GitHub's `ubuntu-latest` now resolves to noble. The `ubuntu-24.04` runner image **ships AWS CLI v2 pre-installed** at `/usr/local/bin/aws`, so the apt install was both redundant and broken.

This PR drops `awscli` from the apt list and adds `aws --version` as a sanity check on `2.3`, so 2.3.x patch releases keep publishing to YUM.

Once this lands we can re-trigger `publish-to-yum` against the 2.3.1 release via `workflow_dispatch` to backfill the YUM repo with the 2.3.1 RPMs (which already exist as release assets but are not yet served from the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only affects the `publish-to-yum` GitHub Actions job by changing how AWS CLI is obtained; main risk is unexpected runner image differences causing publish failures.
> 
> **Overview**
> Fixes the RPM release workflow on Ubuntu 24.04 runners by **dropping `awscli` from the apt install** in `publish-to-yum` and instead relying on the GitHub-hosted runner’s pre-installed AWS CLI v2.
> 
> Adds an `aws --version` sanity check while still installing only the required RPM repo tooling (`createrepo-c`, `rpm`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be2f77ff60a891e5d0d9e67a9a32191bf9289c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->