### PR TITLE
ci(release-rpm): accept V4 header signatures in verify step

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -430,21 +430,32 @@ jobs:
 
         bad=0
         while read -r rpm_file; do
-          # Two checks because `rpm -K` exits 0 on unsigned packages (digest OK).
-          # 1. Header field must contain a PGP signature, not "(none)".
-          sig=$(rpm -qp --queryformat '%{SIGPGP:pgpsig}\n' "$rpm_file")
-          if [ "$sig" = "(none)" ] || [ -z "$sig" ]; then
-            echo "::error::RPM unsigned: $rpm_file (SIGPGP=$sig)"
+          # `rpm --addsign` on rpm >= 4.13 produces a V4 header signature,
+          # stored in `%{RSAHEADER}` / `%{DSAHEADER}`. The legacy `%{SIGPGP}`
+          # tag is `(none)` on V4-signed packages, so querying it falsely
+          # reports modern RPMs as unsigned. Use `rpm -Kv` instead — it
+          # prints a per-component verification line (`Header V4 RSA/SHA512
+          # Signature, key ID xxxx: OK`) and exits 0 only when every
+          # component checks out against the imported key, covering both
+          # V3 (legacy SIGPGP) and V4 (RSAHEADER/DSAHEADER) signatures.
+          # `|| true` so a non-zero rpm exit (unsigned / NOKEY / BAD) does
+          # not abort the script under `set -e` before our grep-based
+          # diagnostics can run. We classify the result via the captured
+          # output below, not via the exit code.
+          verify_output=$(rpm -Kv "$rpm_file" 2>&1 || true)
+          if ! echo "$verify_output" | grep -qE 'Header V[34] (RSA|DSA)/.*: OK'; then
+            echo "::error::RPM unsigned or signature does not verify: $rpm_file"
+            echo "$verify_output"
             bad=$((bad + 1))
             continue
           fi
-          # 2. The signature must verify against the imported key.
-          if ! rpm -K "$rpm_file"; then
-            echo "::error::RPM signature does not verify: $rpm_file"
+          if echo "$verify_output" | grep -qE 'NOKEY|NOTTRUSTED|BAD'; then
+            echo "::error::RPM signature problem: $rpm_file"
+            echo "$verify_output"
             bad=$((bad + 1))
             continue
           fi
-          echo "✓ signed: $rpm_file ($sig)"
+          echo "✓ signed: $rpm_file"
         done < <(find rpms -name "*.rpm" -type f)
 
         if [ "$bad" -gt 0 ]; then


### PR DESCRIPTION
## Summary

The 2.3.1 release's \`publish-to-yum\` job kept failing at step 6 ("Verify RPM signatures") with:

\`\`\`
##[error]RPM unsigned: rpms/.../memtier-benchmark-2.3.1-...rpm (SIGPGP=(none))
\`\`\`

Failed run: https://github.com/redis/memtier_benchmark/actions/runs/25388333208/job/74456580707

The build matrix actually signs the RPMs correctly — the verify step's check is what's broken:

\`\`\`bash
sig=\$(rpm -qp --queryformat '%{SIGPGP:pgpsig}\n' "\$rpm_file")
if [ "\$sig" = "(none)" ] || [ -z "\$sig" ]; then
    echo "::error::RPM unsigned: \$rpm_file (SIGPGP=\$sig)"
\`\`\`

\`rpm --addsign\` on rpm >= 4.13 produces a **V4 header signature** stored in \`%{RSAHEADER}\` / \`%{DSAHEADER}\`. The legacy \`%{SIGPGP}\` tag stays \`(none)\` on V4-signed packages, so this query falsely reports modern RPMs as unsigned. \`rpm -K\` confirms the actual signature is fine: \`Header V4 RSA/SHA512 Signature, key ID bf53aa0c: OK\` (after the public key is imported, which step 6 does).

This bug was never tripped before because PR #338 added \`release-rpm.yml\` but its \`publish-to-yum\` job is gated on \`event_name == 'release'\` — it only runs when an actual release is published, and 2.3.0 predated this workflow. The 2.3.1 release was the first end-to-end exercise.

## Change

Replace the \`SIGPGP\` query with \`rpm -Kv\` parsing. \`rpm -Kv\` prints a per-component verification line and exits 0 only when every component verifies. Match against \`'Header V[34] (RSA|DSA)/.*: OK'\` to accept both V3 (legacy SIGPGP) and V4 (RSAHEADER/DSAHEADER) signatures, and explicitly reject \`NOKEY / NOTTRUSTED / BAD\` outcomes to preserve the safety net the original script intended.

## Test plan

- [x] Verified the regex matches the actual \`rpm -Kv\` output captured from the failing run for el8/el9/el10/amzn2023 × x86_64/aarch64.
- After merge, re-fire the 2.3.1 publish path and confirm \`publish-to-yum\` step 6 passes and steps 7-12 actually run.

## Sibling PR

Same fix needs to land on the \`2.3\` release branch so 2.3.1 (and future 2.3.x patches) can publish to YUM. I'll open the cherry-pick after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release publishing workflow’s RPM signature verification logic; a regex/command mismatch could either fail legitimate releases or (less likely) allow a bad signature to slip through.
> 
> **Overview**
> Fixes the `publish-to-yum` workflow’s RPM signature verification to handle modern *V4 header signatures* produced by `rpm --addsign`.
> 
> The verify step now captures `rpm -Kv` output per RPM and greps for an `Header V3/V4 RSA/DSA ...: OK` line, while explicitly flagging `NOKEY/NOTTRUSTED/BAD` cases, instead of relying on the legacy `%{SIGPGP}` tag which reports `(none)` for V4-signed packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13983e6c7a1e674516668ead0dbf36b66e36b0a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->