### PR TITLE
ci(release-rpm): accept V4 header signatures in verify step (2.3)

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -436,21 +436,32 @@ jobs:
 
         bad=0
         while read -r rpm_file; do
-          # Two checks because `rpm -K` exits 0 on unsigned packages (digest OK).
-          # 1. Header field must contain a PGP signature, not "(none)".
-          sig=$(rpm -qp --queryformat '%{SIGPGP:pgpsig}\n' "$rpm_file")
-          if [ "$sig" = "(none)" ] || [ -z "$sig" ]; then
-            echo "::error::RPM unsigned: $rpm_file (SIGPGP=$sig)"
+          # `rpm --addsign` on rpm >= 4.13 produces a V4 header signature,
+          # stored in `%{RSAHEADER}` / `%{DSAHEADER}`. The legacy `%{SIGPGP}`
+          # tag is `(none)` on V4-signed packages, so querying it falsely
+          # reports modern RPMs as unsigned. Use `rpm -Kv` instead — it
+          # prints a per-component verification line (`Header V4 RSA/SHA512
+          # Signature, key ID xxxx: OK`) and exits 0 only when every
+          # component checks out against the imported key, covering both
+          # V3 (legacy SIGPGP) and V4 (RSAHEADER/DSAHEADER) signatures.
+          # `|| true` so a non-zero rpm exit (unsigned / NOKEY / BAD) does
+          # not abort the script under `set -e` before our grep-based
+          # diagnostics can run. We classify the result via the captured
+          # output below, not via the exit code.
+          verify_output=$(rpm -Kv "$rpm_file" 2>&1 || true)
+          if ! echo "$verify_output" | grep -qE 'Header V[34] (RSA|DSA)/.*: OK'; then
+            echo "::error::RPM unsigned or signature does not verify: $rpm_file"
+            echo "$verify_output"
             bad=$((bad + 1))
             continue
           fi
-          # 2. The signature must verify against the imported key.
-          if ! rpm -K "$rpm_file"; then
-            echo "::error::RPM signature does not verify: $rpm_file"
+          if echo "$verify_output" | grep -qE 'NOKEY|NOTTRUSTED|BAD'; then
+            echo "::error::RPM signature problem: $rpm_file"
+            echo "$verify_output"
             bad=$((bad + 1))
             continue
           fi
-          echo "✓ signed: $rpm_file ($sig)"
+          echo "✓ signed: $rpm_file"
         done < <(find rpms -name "*.rpm" -type f)
 
         if [ "$bad" -gt 0 ]; then


### PR DESCRIPTION
Backport of #370 to the `2.3` release branch.

The 2.3.1 `publish-to-yum` step 6 has been failing because the verify script queries the legacy `%{SIGPGP}` tag, which is `(none)` on V4-signed RPMs. `rpm --addsign` on rpm >= 4.13 produces V4 header signatures (`%{RSAHEADER}`); the SIGPGP-only check rejects them as unsigned even though `rpm -K` confirms the signature is valid.

Failed run: https://github.com/redis/memtier_benchmark/actions/runs/25388333208/job/74456580707

Replace the SIGPGP query with `rpm -Kv` parsing — accepts V3 and V4 signatures, rejects `NOKEY / NOTTRUSTED / BAD` outcomes.

Once this lands, re-tag `2.3.1` to the new `2.3` tip (so the release event picks up the fixed workflow file), delete + recreate the GitHub Release, and the workflow will publish to YUM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow’s RPM signature verification logic, which can block or allow YUM publication if the parsing is wrong. Risk is moderate because it affects the CI/release gate but does not change product runtime code.
> 
> **Overview**
> Fixes the `publish-to-yum` workflow’s RPM signature verification to **accept modern V4 header signatures** produced by `rpm --addsign` on newer RPM versions.
> 
> Replaces the legacy `%{SIGPGP}` tag check (which reports `(none)` for V4-signed RPMs) with captured `rpm -Kv` output parsing, failing the job on missing `Header V3/V4 ...: OK` lines and explicitly flagging `NOKEY`/`NOTTRUSTED`/`BAD` signature states while printing diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec9365553f729f5294fe736b09b8a160585c128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->