### PR TITLE
fix(obj_gen): allow --key-prefix larger than 250 bytes (RED-105966)

### DIFF
--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -164,6 +164,10 @@ object_generator::object_generator(size_t n_key_iterators /*= OBJECT_GENERATOR_K
     m_next_key.resize(n_key_iterators, 0);
 
     m_data_size.size_list = NULL;
+
+    // Ensure m_key_buffer is allocated even before set_key_prefix() is called,
+    // since cluster_client::get_key_for_conn invokes generate_key() unconditionally.
+    set_key_prefix(NULL);
 }
 
 object_generator::object_generator(const object_generator &copy) :
@@ -196,9 +200,8 @@ object_generator::object_generator(const object_generator &copy) :
         m_data_size.size_list = new config_weight_list(*m_data_size.size_list);
     }
     alloc_value_buffer();
-    if (m_key_prefix != NULL) {
-        set_key_prefix(m_key_prefix);
-    }
+    // Allocate m_key_buffer unconditionally; NULL prefix is treated as empty.
+    set_key_prefix(m_key_prefix);
 
     m_next_key.resize(copy.m_next_key.size(), 0);
 }
@@ -440,7 +443,8 @@ unsigned long long object_generator::get_key_index(int iter)
 
 void object_generator::generate_key(unsigned long long key_index)
 {
-    m_key_len = snprintf(m_key_buffer, m_key_buffer_size, "%s%llu", m_key_prefix, key_index);
+    const char *prefix = (m_key_prefix != NULL) ? m_key_prefix : "";
+    m_key_len = snprintf(m_key_buffer, m_key_buffer_size, "%s%llu", prefix, key_index);
     m_key = m_key_buffer;
 }
 

--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -303,7 +303,7 @@ void object_generator::set_key_prefix(const char *key_prefix)
     size_t prefix_len = (key_prefix != NULL) ? strlen(key_prefix) : 0;
     size_t required = prefix_len + 21;
     if (required > m_key_buffer_size) {
-        char *new_buf = (char *)realloc(m_key_buffer, required);
+        char *new_buf = (char *) realloc(m_key_buffer, required);
         if (new_buf == NULL) {
             fprintf(stderr, "error: failed to allocate %zu bytes for key buffer\n", required);
             exit(1);

--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -155,6 +155,8 @@ object_generator::object_generator(size_t n_key_iterators /*= OBJECT_GENERATOR_K
         m_key_zipf_Hmin(0),
         m_key_zipf_Hmax(0),
         m_key_zipf_s(0),
+        m_key_buffer(NULL),
+        m_key_buffer_size(0),
         m_value_buffer(NULL),
         m_value_buffer_size(0),
         m_value_buffer_mutation_pos(0)
@@ -184,6 +186,8 @@ object_generator::object_generator(const object_generator &copy) :
         m_key_zipf_Hmin(copy.m_key_zipf_Hmin),
         m_key_zipf_Hmax(copy.m_key_zipf_Hmax),
         m_key_zipf_s(copy.m_key_zipf_s),
+        m_key_buffer(NULL),
+        m_key_buffer_size(0),
         m_value_buffer(NULL),
         m_value_buffer_size(0),
         m_value_buffer_mutation_pos(0)
@@ -192,6 +196,9 @@ object_generator::object_generator(const object_generator &copy) :
         m_data_size.size_list = new config_weight_list(*m_data_size.size_list);
     }
     alloc_value_buffer();
+    if (m_key_prefix != NULL) {
+        set_key_prefix(m_key_prefix);
+    }
 
     m_next_key.resize(copy.m_next_key.size(), 0);
 }
@@ -199,6 +206,7 @@ object_generator::object_generator(const object_generator &copy) :
 object_generator::~object_generator()
 {
     if (m_value_buffer != NULL) free(m_value_buffer);
+    if (m_key_buffer != NULL) free(m_key_buffer);
     if (m_data_size_type == data_size_weighted && m_data_size.size_list != NULL) {
         delete m_data_size.size_list;
     }
@@ -290,6 +298,19 @@ void object_generator::set_expiry_range(unsigned int expiry_min, unsigned int ex
 void object_generator::set_key_prefix(const char *key_prefix)
 {
     m_key_prefix = key_prefix;
+
+    // Ensure m_key_buffer can hold prefix + 20 digits (max for unsigned long long) + NUL.
+    size_t prefix_len = (key_prefix != NULL) ? strlen(key_prefix) : 0;
+    size_t required = prefix_len + 21;
+    if (required > m_key_buffer_size) {
+        char *new_buf = (char *)realloc(m_key_buffer, required);
+        if (new_buf == NULL) {
+            fprintf(stderr, "error: failed to allocate %zu bytes for key buffer\n", required);
+            exit(1);
+        }
+        m_key_buffer = new_buf;
+        m_key_buffer_size = required;
+    }
 }
 
 void object_generator::set_key_range(unsigned long long key_min, unsigned long long key_max)
@@ -419,7 +440,7 @@ unsigned long long object_generator::get_key_index(int iter)
 
 void object_generator::generate_key(unsigned long long key_index)
 {
-    m_key_len = snprintf(m_key_buffer, sizeof(m_key_buffer) - 1, "%s%llu", m_key_prefix, key_index);
+    m_key_len = snprintf(m_key_buffer, m_key_buffer_size, "%s%llu", m_key_prefix, key_index);
     m_key = m_key_buffer;
 }
 

--- a/obj_gen.h
+++ b/obj_gen.h
@@ -110,7 +110,8 @@ protected:
     std::vector<unsigned long long> m_next_key;
 
     unsigned long long m_key_index;
-    char m_key_buffer[250];
+    char *m_key_buffer;
+    size_t m_key_buffer_size;
     const char *m_key;
     int m_key_len;
     char *m_value_buffer;

--- a/tests/test_large_key_prefix.py
+++ b/tests/test_large_key_prefix.py
@@ -1,0 +1,143 @@
+"""
+Regression tests for keys whose prefix exceeds the legacy 250-byte
+m_key_buffer cap (see JIRA RED-105966).
+
+Before the fix:
+  * object_generator::m_key_buffer was a fixed 250-byte stack array, and
+    generate_key() called snprintf(buf, sizeof(buf)-1, "%s%llu", ...).
+  * With a >=250-byte prefix, snprintf truncated the prefix and never
+    appended the key index, so every iteration produced the same content
+    and only one unique key was written to Redis (per the ticket).
+  * snprintf still returned the un-truncated length, so memtier sent
+    that many bytes from the 250-byte buffer, exposing adjacent heap
+    bytes as part of the key.
+
+These tests verify the fix by running memtier against a real Redis with
+a large --key-prefix and asserting on the actual key set in the server.
+
+  TEST=test_large_key_prefix.py OSS_STANDALONE=1 ./tests/run_tests.sh
+"""
+
+import os
+import tempfile
+
+from include import (
+    add_required_env_arguments,
+    addTLSArgs,
+    debugPrintMemtierOnError,
+    ensure_clean_benchmark_folder,
+    get_default_memtier_config,
+)
+from mb import Benchmark, RunConfig
+
+
+def _run_set_workload(env, prefix, key_maximum=200, requests=400,
+                      threads=1, clients=1):
+    """Run a SET-only workload with the given prefix and return run_config."""
+    test_dir = tempfile.mkdtemp()
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--ratio=1:0",
+            "--key-prefix={}".format(prefix),
+            "--key-minimum=1",
+            "--key-maximum={}".format(key_maximum),
+            "--key-pattern=P:P",
+            "--data-size=8",
+            "--pipeline=10",
+            "--hide-histogram",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+
+    config = get_default_memtier_config(threads=threads, clients=clients,
+                                        requests=requests)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    run_config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(run_config.results_dir)
+
+    benchmark = Benchmark.from_json(run_config, benchmark_specs)
+    ok = benchmark.run()
+    if not ok:
+        debugPrintMemtierOnError(run_config, env)
+    env.assertTrue(ok)
+    return run_config
+
+
+def _assert_key_set_well_formed(env, conn, prefix, expected_unique):
+    """All keys in the DB start with `prefix` and decode as prefix+<index>."""
+    db_keys = conn.keys("*")
+    env.assertEqual(len(db_keys), expected_unique,
+                    message="expected {} keys, got {}".format(
+                        expected_unique, len(db_keys)))
+
+    prefix_bytes = prefix.encode() if isinstance(prefix, str) else prefix
+    prefix_len = len(prefix_bytes)
+
+    seen_indices = set()
+    for k in db_keys:
+        kb = k if isinstance(k, (bytes, bytearray)) else k.encode()
+        # Every key must start with the exact, un-truncated prefix.
+        env.assertEqual(kb[:prefix_len], prefix_bytes,
+                        message="key does not start with full prefix; "
+                                "len(key)={}, expected prefix length {}".format(
+                                    len(kb), prefix_len))
+        suffix = kb[prefix_len:]
+        env.assertTrue(len(suffix) > 0 and suffix.isdigit(),
+                       message="key suffix is not a decimal index: {!r}".format(
+                           suffix[:32]))
+        seen_indices.add(int(suffix))
+
+    # We populate indices 1..key_maximum sequentially. Pattern P:P cycles
+    # through the range, so all of them should be present.
+    env.assertEqual(len(seen_indices), expected_unique,
+                    message="expected {} distinct indices, got {}".format(
+                        expected_unique, len(seen_indices)))
+
+
+def test_prefix_just_above_legacy_cap(env):
+    """251-byte prefix: one byte over the old 250-byte buffer."""
+    env.skipOnCluster()
+    env.flush()
+    prefix = "a" * 251
+    key_maximum = 200
+    _run_set_workload(env, prefix, key_maximum=key_maximum, requests=800)
+    conn = env.getConnection()
+    _assert_key_set_well_formed(env, conn, prefix, expected_unique=key_maximum)
+
+
+def test_prefix_1kib(env):
+    """Reproduces the JIRA RED-105966 case (1003-byte prefix)."""
+    env.skipOnCluster()
+    env.flush()
+    prefix = "x" * 1003
+    key_maximum = 200
+    _run_set_workload(env, prefix, key_maximum=key_maximum, requests=800)
+    conn = env.getConnection()
+    _assert_key_set_well_formed(env, conn, prefix, expected_unique=key_maximum)
+
+
+def test_prefix_4kib(env):
+    """4 KiB prefix exercises a larger realloc; Redis caps keys at 512 MiB."""
+    env.skipOnCluster()
+    env.flush()
+    prefix = "z" * 4096
+    key_maximum = 100
+    _run_set_workload(env, prefix, key_maximum=key_maximum, requests=400)
+    conn = env.getConnection()
+    _assert_key_set_well_formed(env, conn, prefix, expected_unique=key_maximum)
+
+
+def test_default_short_prefix_still_works(env):
+    """Sanity: the common short-prefix path still produces the expected
+    number of distinct memtier-N keys after the buffer became dynamic."""
+    env.skipOnCluster()
+    env.flush()
+    # Default --key-prefix is "memtier-".
+    prefix = "memtier-"
+    key_maximum = 50
+    _run_set_workload(env, prefix, key_maximum=key_maximum, requests=200)
+    conn = env.getConnection()
+    _assert_key_set_well_formed(env, conn, prefix, expected_unique=key_maximum)


### PR DESCRIPTION
## Summary

- `obj_gen` truncated keys silently at 250 bytes and leaked adjacent heap as part of the key (full root-cause in commit body).
- Switches `m_key_buffer` to a heap allocation sized once in `set_key_prefix` to `strlen(prefix) + 21`.
- Adds `tests/test_large_key_prefix.py` covering 251 B (one over the legacy cap), 1003 B (the JIRA repro), 4 KiB, and the default `memtier-` prefix.

## Root cause

`generate_key` called

```cpp
m_key_len = snprintf(m_key_buffer, sizeof(m_key_buffer) - 1, "%s%llu", m_key_prefix, key_index);
```

with `char m_key_buffer[250]`. With a ≥249-byte prefix, `snprintf` truncates the prefix and never appends the index, so every iteration produces the same content and only one unique key reaches Redis. Worse, `snprintf` still returns the un-truncated length, so memtier sends `m_key_len` bytes out of a 250-byte buffer — an out-of-bounds heap read exposed as the key on the wire.

## Fix

`m_key_buffer` becomes `char *` + `size_t m_key_buffer_size`. `set_key_prefix` reallocs once to `strlen(prefix) + 21` (20 = max decimal digits of `unsigned long long`, +1 NUL). The copy constructor re-allocates per clone via `set_key_prefix(m_key_prefix)`. The destructor frees.

## Redis limit confirmation

Confirmed locally that Redis accepts keys up to 512 MiB (`proto-max-bulk-len`); 512 MiB + 1 is rejected at the protocol layer. The 250-byte cap was purely a memtier artifact.

## Resource consumption

Interleaved 10 runs each, 4 threads × 10 conns, SET 1:4, `data-size=32`, pipeline 16 against local Redis:

| Metric | Old (median) | New (median) | Delta |
|---|---|---|---|
| ops/sec | 1 054 197 | 1 063 774 | +0.9 % |
| Peak RSS | 14 560 KB | 14 624 KB | +0.4 % |

Both within stdev (~90 k ops/s, ~150 KB RSS) — no regression. Memory: stack 250 B replaced with heap allocation of `len(prefix) + 21` (29 B for the default `memtier-` prefix), plus glibc allocator overhead — effectively the same footprint.

## Test plan

- [x] `TEST=test_large_key_prefix.py OSS_STANDALONE=1 ./tests/run_tests.sh` → 4/4 PASS on the new binary
- [x] Same suite against the pre-fix binary → 3/4 FAIL (default-prefix case still PASSes), confirming the test catches the bug
- [x] Full `OSS_STANDALONE=1 ./tests/run_tests.sh` → 100/100 PASS
- [x] Resource regression check (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core key-generation memory management to use a dynamically sized heap buffer, which touches performance-critical code and fixes a potential out-of-bounds read/leak if sizing is wrong. New integration tests reduce regression risk but rely on running memtier against a live Redis.
> 
> **Overview**
> Fixes long `--key-prefix` handling by replacing the fixed 250-byte `m_key_buffer` with a dynamically allocated buffer sized in `set_key_prefix()` and used by `generate_key()` (treating `NULL` as empty), plus proper allocation on construction/copy and cleanup in the destructor.
> 
> Adds `tests/test_large_key_prefix.py` to regression-test 251B, ~1KiB, and 4KiB prefixes (and the default prefix) by running a SET-only workload and asserting Redis contains the expected number of distinct, well-formed keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3933ce8b165044ee7103ff5e7e571cc9a77ae590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->