### PR TITLE
chore: add pre-commit hook running 'make format-check'

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,38 @@
+#!/bin/sh
+# memtier_benchmark pre-commit hook.
+#
+# Delegates to `make format-check` so the rule lives in one place
+# (Makefile.am) and matches what CI runs. Runs only when the staged
+# changeset touches C/C++ files, to avoid overhead on doc-only commits.
+#
+# Enable in a fresh clone:
+#     make install-hooks
+#
+# Bypass (don't make a habit of it):
+#     git commit --no-verify
+
+set -e
+
+# Look at staged additions/copies/modifications/renames.
+staged_cxx=$(git diff --cached --name-only --diff-filter=ACMR \
+             | grep -E '\.(cpp|cc|cxx|h|hpp|hxx)$' \
+             | grep -v '^deps/' || true)
+
+if [ -z "$staged_cxx" ]; then
+    exit 0
+fi
+
+echo "[pre-commit] running 'make format-check' on staged C/C++ changes..."
+
+if ! make format-check >/dev/null 2>&1; then
+    echo
+    echo "✗ Code style check failed."
+    echo "  Fix with:"
+    echo "      make format && git add -u && git commit"
+    echo "  Or rerun manually to see which files differ:"
+    echo "      make format-check"
+    echo "  Bypass (not recommended): git commit --no-verify"
+    exit 1
+fi
+
+echo "[pre-commit] format-check passed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,9 +1,10 @@
 #!/bin/sh
 # memtier_benchmark pre-commit hook.
 #
-# Delegates to `make format-check` so the rule lives in one place
-# (Makefile.am) and matches what CI runs. Runs only when the staged
-# changeset touches C/C++ files, to avoid overhead on doc-only commits.
+# Delegates to `make format-check-staged`, which inspects the staged blobs
+# in the git index (not the working tree) so the rule lives in Makefile.am,
+# matches what CI runs, and is immune to the working-tree-vs-index drift
+# (e.g. `make format` without `git add -u`).
 #
 # Enable in a fresh clone:
 #     make install-hooks
@@ -13,26 +14,12 @@
 
 set -e
 
-# Look at staged additions/copies/modifications/renames.
-staged_cxx=$(git diff --cached --name-only --diff-filter=ACMR \
-             | grep -E '\.(cpp|cc|cxx|h|hpp|hxx)$' \
-             | grep -v '^deps/' || true)
-
-if [ -z "$staged_cxx" ]; then
-    exit 0
-fi
-
-echo "[pre-commit] running 'make format-check' on staged C/C++ changes..."
-
-if ! make format-check >/dev/null 2>&1; then
+# format-check-staged is a no-op when no C/C++ file is staged, and emits its
+# own remediation guidance on failure; we only need to translate the exit
+# code into a friendly hook-level message.
+if ! make format-check-staged; then
     echo
-    echo "✗ Code style check failed."
-    echo "  Fix with:"
-    echo "      make format && git add -u && git commit"
-    echo "  Or rerun manually to see which files differ:"
-    echo "      make format-check"
+    echo "✗ Pre-commit format check failed (see remediation above)."
     echo "  Bypass (not recommended): git commit --no-verify"
     exit 1
 fi
-
-echo "[pre-commit] format-check passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ make
 - Run `make format-check` to verify formatting
 - CI enforces formatting on all PRs
 - **Always run `make format` after modifying C++ files and before committing.** Verify with `make format-check` that no formatting issues remain.
+- Run `make install-hooks` once per clone to enable the `.githooks/pre-commit` hook, which runs `make format-check` automatically on staged C/C++ changes.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ make
 - Run `make format-check` to verify formatting
 - CI enforces formatting on all PRs
 - **Always run `make format` after modifying C++ files and before committing.** Verify with `make format-check` that no formatting issues remain.
-- Run `make install-hooks` once per clone to enable the `.githooks/pre-commit` hook, which runs `make format-check` automatically on staged C/C++ changes.
+- Run `make install-hooks` once per clone to enable the `.githooks/pre-commit` hook, which runs `make format-check-staged` automatically on staged C/C++ blobs (the content in the index, not the working tree).
 
 ## Testing
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,8 +95,11 @@ CI will automatically check that all C++ files are properly formatted on every p
 #### Pre-commit hook
 
 The repository ships a `pre-commit` hook under `.githooks/` that runs `make
-format-check` on staged C/C++ files before each commit, so style violations
-are caught locally instead of in CI. Enable it once per clone:
+format-check-staged` before each commit. That target inspects the *staged
+blobs* in the git index (not the working tree), so style violations are
+caught locally instead of in CI and the check is immune to working-tree
+vs. index drift (e.g. running `make format` without `git add -u`). Enable
+it once per clone:
 
 ```
 $ make install-hooks

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,6 +92,23 @@ $ make format-check
 
 CI will automatically check that all C++ files are properly formatted on every push and pull request.
 
+#### Pre-commit hook
+
+The repository ships a `pre-commit` hook under `.githooks/` that runs `make
+format-check` on staged C/C++ files before each commit, so style violations
+are caught locally instead of in CI. Enable it once per clone:
+
+```
+$ make install-hooks
+```
+
+This sets `core.hooksPath` to `.githooks` for this repository. To bypass the
+hook for a single commit (avoid making a habit of it):
+
+```
+$ git commit --no-verify
+```
+
 ## Testing
 
 The project includes a basic set of integration tests.

--- a/Makefile.am
+++ b/Makefile.am
@@ -94,3 +94,10 @@ format-check:
 		exit 1; \
 	fi; \
 	echo "All C++ files are properly formatted!"
+
+# Git hooks
+.PHONY: install-hooks
+install-hooks:
+	@git config core.hooksPath .githooks
+	@echo "Git hooks enabled (core.hooksPath = .githooks)."
+	@echo "Pre-commit hook will run 'make format-check' on staged C/C++ changes."

--- a/Makefile.am
+++ b/Makefile.am
@@ -95,9 +95,39 @@ format-check:
 	fi; \
 	echo "All C++ files are properly formatted!"
 
+# Like format-check, but inspects the staged blobs in the git index rather than
+# the working tree. Used by the pre-commit hook so that:
+#  - mis-formatted *staged* content cannot slip past when `make format` was run
+#    against the working tree but the result was never re-staged, and
+#  - unrelated mis-formatted files lying in the working tree do not block an
+#    otherwise-clean commit.
+.PHONY: format-check-staged
+format-check-staged:
+	@STAGED=$$(git diff --cached --name-only --diff-filter=ACMR \
+	            | grep -E '\.(cpp|cc|cxx|h|hpp|hxx)$$' \
+	            | grep -v '^deps/' || true); \
+	if [ -z "$$STAGED" ]; then \
+		exit 0; \
+	fi; \
+	echo "Checking staged C/C++ source file formatting..."; \
+	FAILED=0; \
+	for file in $$STAGED; do \
+		if ! git show ":$$file" | clang-format --assume-filename="$$file" --dry-run --Werror 2>/dev/null; then \
+			echo "Needs formatting (staged): $$file"; \
+			FAILED=1; \
+		fi; \
+	done; \
+	if [ $$FAILED -eq 1 ]; then \
+		echo ""; \
+		echo "Some staged files need formatting. Stage the formatted version:"; \
+		echo "    make format && git add -u"; \
+		exit 1; \
+	fi; \
+	echo "All staged C/C++ files are properly formatted!"
+
 # Git hooks
 .PHONY: install-hooks
 install-hooks:
 	@git config core.hooksPath .githooks
 	@echo "Git hooks enabled (core.hooksPath = .githooks)."
-	@echo "Pre-commit hook will run 'make format-check' on staged C/C++ changes."
+	@echo "Pre-commit hook will run 'make format-check-staged' on staged C/C++ changes."


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-commit` that delegates to `make format-check` on staged C/C++ changes, so style violations are caught locally instead of in the code-style CI job.
- Adds `make install-hooks` to wire `core.hooksPath` to `.githooks` (one-time per clone).
- Documents the workflow in `DEVELOPMENT.md` and `AGENTS.md`.

## Why call `make format-check` instead of `clang-format` directly?

Keeps the formatting rule in one place (`Makefile.am`) — the hook always matches what CI runs. If the project ever changes the include/exclude filter or switches formatters, the hook follows automatically.

## Behavior

- No-op when no C/C++ file is staged (doc-only / test-only commits are unaffected).
- Blocks the commit on violation, with a clear remediation message:
  ```
  ✗ Code style check failed.
    Fix with:
        make format && git add -u && git commit
  ```
- Bypassable via `git commit --no-verify` for emergencies.

## Verification

Tested locally:

| Scenario | Hook exit |
|---|---|
| Stage a mis-formatted C++ change | `1` (blocked, with remediation message) |
| Stage the same file after `make format` | `0` (allowed) |
| Commit doc-only changes | `0` (skipped, no C++ in changeset) |

## Adoption

`make install-hooks` is opt-in per checkout (git deliberately doesn't auto-execute checked-in hooks for security reasons). Documented in `DEVELOPMENT.md` under "Code Style" and called out in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling (git hooks, Make targets, and docs) and do not affect runtime code or build outputs unless a developer opts in.
> 
> **Overview**
> Adds an opt-in local formatting gate for commits: a new `.githooks/pre-commit` hook runs `make format-check-staged` to verify **staged** C/C++ blobs are `clang-format`-clean and provides remediation guidance on failure.
> 
> Introduces `make format-check-staged` (checks only staged `*.{c,cc,cpp,cxx,h,hpp,hxx}` excluding `deps/`) and `make install-hooks` (sets `core.hooksPath` to `.githooks`). Updates `DEVELOPMENT.md` and `AGENTS.md` to document enabling/bypassing the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0855c7894fabf389ffe6440d902e0656eebfd7ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->