### PR TITLE
fix(cluster): prevent assertion abort on reconnect with --cluster-mode --reconnect-on-error (#377)

### DIFF
--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -115,9 +115,14 @@ int cluster_client::connect(void)
     // set main connection to send 'CLUSTER SLOTS' command
     sc->set_cluster_slots();
 
-    // create key index pool for main connection
-    key_index_pool *key_idx_pool = new key_index_pool;
-    m_key_index_pools.push_back(key_idx_pool);
+    // create key index pool for main connection only on the first connect.
+    // On reconnects (e.g. via --reconnect-on-error), the main connection's
+    // key_index_pool already exists and m_connections is unchanged, so
+    // pushing again would break the invariant the assertion enforces.
+    if (m_key_index_pools.empty()) {
+        key_index_pool *key_idx_pool = new key_index_pool;
+        m_key_index_pools.push_back(key_idx_pool);
+    }
     assert(m_connections.size() == m_key_index_pools.size());
 
     // continue with base class

--- a/tests/test_reconnections.py
+++ b/tests/test_reconnections.py
@@ -167,6 +167,121 @@ def test_reconnect_on_connection_kill(env):
         killer_thread.join(timeout=5)
 
 
+def test_reconnect_cluster_mode_no_assertion(env):
+    """
+    Regression test for https://github.com/redis/memtier_benchmark/issues/377
+
+    When --cluster-mode and --reconnect-on-error are combined and a connection
+    drops mid-run, cluster_client::connect() used to fire
+    `assert(m_connections.size() == m_key_index_pools.size())` and SIGABRT the
+    process. This test runs that exact combination, kills connections during
+    the run, and verifies that:
+      - memtier never aborts (no SIGABRT, no "Assertion" line in stderr)
+      - the process exits with a normal status code (no signal death)
+    """
+    if not env.isCluster():
+        env.skip()
+
+    key_max = 100000
+    key_min = 1
+
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--pipeline=1",
+            "--ratio=1:0",
+            "--key-pattern=P:P",
+            "--key-minimum={}".format(key_min),
+            "--key-maximum={}".format(key_max),
+            "--data-size=512",
+            "--random-data",
+            "--reconnect-on-error",
+            "--max-reconnect-attempts=20",
+            "--reconnect-backoff-factor=1.0",
+            "--connection-timeout=5",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+
+    config = get_default_memtier_config(threads=4, clients=2, requests=None, test_time=10)
+    master_nodes_list = env.getMasterNodesList()
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+
+    import subprocess
+
+    stdout_path = "{0}/mb.stdout".format(config.results_dir)
+    stderr_path = "{0}/mb.stderr".format(config.results_dir)
+    with open(stdout_path, "w") as stdout_f, open(stderr_path, "w") as stderr_f:
+        proc = subprocess.Popen(
+            benchmark.args,
+            stdout=stdout_f,
+            stderr=stderr_f,
+            cwd=config.results_dir,
+        )
+
+        # Let connections fully establish before kicking them over.
+        time.sleep(2)
+
+        kill_count = 0
+        # Two waves of CLIENT KILL to ensure the reconnect path is exercised
+        # at least once per shard.
+        for _wave in range(2):
+            for master_connection in master_nodes_connections:
+                try:
+                    killed = master_connection.execute_command(
+                        "CLIENT", "KILL", "TYPE", "normal"
+                    )
+                    if isinstance(killed, int):
+                        kill_count += killed
+                except Exception as e:
+                    env.debugPrint(
+                        "CLIENT KILL failed: {}".format(str(e)), True
+                    )
+            time.sleep(2)
+
+        # Generous timeout: --test-time=10 + reconnect backoff + summary flush.
+        try:
+            return_code = proc.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            # If memtier is wedged post-kill that is a separate concern;
+            # the bug under test is the SIGABRT, so we kill the process and
+            # still verify no assertion fired.
+            proc.kill()
+            try:
+                return_code = proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                return_code = -9
+
+    env.debugPrint("Total clients killed (CLIENT KILL count): {}".format(kill_count), True)
+    env.debugPrint("memtier exit code: {}".format(return_code), True)
+
+    with open(stderr_path) as f:
+        stderr_content = f.read()
+
+    # The core regression assertion: no abort from the parallel-vector invariant.
+    has_assertion_abort = "Assertion `m_connections.size() == m_key_index_pools.size()'" in stderr_content
+    if has_assertion_abort:
+        env.debugPrint("STDERR:\n{}".format(stderr_content), True)
+    env.assertFalse(has_assertion_abort)
+
+    # We must have actually killed at least one connection or this test is meaningless.
+    env.assertTrue(kill_count > 0)
+
+    # SIGABRT == -6 (negative-signal form from Popen.wait()).
+    # 134 (128+6) can also surface from shells; guard against both.
+    env.assertNotEqual(return_code, -6)
+    env.assertNotEqual(return_code, 134)
+
+
 def test_reconnect_disabled_by_default(env):
     """
     Test that reconnection is disabled by default and memtier fails when connections are killed.


### PR DESCRIPTION
## Summary
- Make `cluster_client::connect()` idempotent so the reconnect path doesn't grow `m_key_index_pools` out of sync with `m_connections` and fire `Assertion \`m_connections.size() == m_key_index_pools.size()'`, which previously SIGABRT'd the whole `memtier_benchmark` process the first time any worker thread had to reconnect under `--cluster-mode --reconnect-on-error`.
- Adds a regression test (`tests/test_reconnections.py::test_reconnect_cluster_mode_no_assertion`) that runs the bug-triggering workload, kills connections mid-run via `CLIENT KILL TYPE normal`, and asserts memtier never aborts.

## Root cause
`cluster_client::connect()` (cluster_client.cpp:109) unconditionally did:
```cpp
key_index_pool *key_idx_pool = new key_index_pool;
m_key_index_pools.push_back(key_idx_pool);
assert(m_connections.size() == m_key_index_pools.size());
```
On the first call this matched the single main connection in `m_connections` (assertion holds). But `shard_connection::handle_reconnect_timer_event` re-enters `connect()` on every reconnect attempt **without** clearing either vector — so `m_key_index_pools` grew by one each time while `m_connections` stayed the same, and the next reconnect tripped the assertion.

## Fix
Only push the main connection's `key_index_pool` on the first connect; reuse it on subsequent reconnects. Per-shard pools added later via `create_shard_connection()` are unchanged.

## Verification

**Repro (before fix):**
```bash
./memtier_benchmark -s 127.0.0.1 -p 7000 --cluster-mode \
  -t 4 -c 2 --ratio=1:0 --key-pattern=P:P --random-data \
  --data-size=512 --reconnect-on-error --test-time=20
# in another shell: redis-cli -p 7000 CLIENT KILL TYPE normal
# -> memtier_benchmark: cluster_client.cpp:121: virtual int cluster_client::connect(): Assertion \`m_connections.size() == m_key_index_pools.size()' failed.
# -> SIGABRT
```

**After fix:** same workload + repeated kills runs to completion, all worker threads reconnect, no aborts.

**Regression test:** stashed the fix, rebuilt, ran the new test → fails with `exit_code == -6 (SIGABRT)`. Restored the fix, rebuilt, ran the new test → passes.

## Test plan
- [x] Reproduced original assertion failure on master
- [x] Verified fix eliminates the assertion under repeated `CLIENT KILL TYPE normal`
- [x] New test `test_reconnect_cluster_mode_no_assertion` passes against fixed binary
- [x] New test fails against unfixed binary (regression coverage confirmed)
- [x] `clang-format --dry-run --Werror cluster_client.cpp` clean

Fixes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cluster reconnect bookkeeping; while small, mistakes could cause crashes or incorrect request routing during reconnect scenarios.
> 
> **Overview**
> Prevents `memtier_benchmark` from aborting under `--cluster-mode --reconnect-on-error` by making `cluster_client::connect()` only create/push the main connection’s `key_index_pool` on the first connect, keeping `m_key_index_pools` aligned with `m_connections` across reconnects.
> 
> Adds a cluster-only regression test (`test_reconnect_cluster_mode_no_assertion`) that runs memtier with reconnect enabled, forcibly drops connections via `CLIENT KILL TYPE normal`, and asserts the process exits without the `m_connections.size() == m_key_index_pools.size()` assertion or SIGABRT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b4f034f16c34bdb47faded9d6cc37e35fe315c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->