### PR TITLE
fix: ignore SIGPIPE so peer-close mid-write returns EPIPE (PERF-501, #382)

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -2569,6 +2569,16 @@ int main(int argc, char *argv[])
     // Install signal handler for Ctrl+C
     signal(SIGINT, sigint_handler);
 
+    // Ignore SIGPIPE so a peer-initiated TCP/TLS close mid-write returns
+    // EPIPE from send()/SSL_write() instead of killing the process. Without
+    // this, a single half-closed socket among hundreds can tear down the
+    // entire run with exit 141 before --reconnect-on-error / --retry-on-error
+    // get a chance to handle EPIPE. libevent's bufferevent uses MSG_NOSIGNAL
+    // on plain-TCP send(), but TLS writes via OpenSSL's SSL_write() do not
+    // (and ARM Linux ignores MSG_NOSIGNAL on writev in some configurations),
+    // so a process-wide SIG_IGN is the robust fix. See PERF-501 / GH #382.
+    signal(SIGPIPE, SIG_IGN);
+
     // Install crash handlers for debugging
     setup_crash_handlers();
 

--- a/tests/test_sigpipe_immunity.py
+++ b/tests/test_sigpipe_immunity.py
@@ -1,0 +1,87 @@
+"""
+Regression test for PERF-501 / GH #382:
+memtier_benchmark must ignore SIGPIPE so that a peer-initiated TCP/TLS close
+mid-write returns EPIPE to the existing --reconnect-on-error path instead of
+killing the process with exit 141.
+
+Sending SIGPIPE directly to the running process is the cleanest black-box
+check for the SIG_IGN install — independent of which protocol the writer is
+using (plain TCP vs OpenSSL SSL_write) and independent of the timing race
+that triggers it in production.
+
+Run subset:
+  TEST=test_sigpipe_immunity.py ./tests/run_tests.sh
+"""
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+
+from include import MEMTIER_BINARY, addTLSArgs
+
+
+def test_sigpipe_ignored(env):
+    """Process must remain alive after receiving SIGPIPE."""
+    if env.isUnixSocket():
+        env.skip()
+        return
+
+    master_nodes_list = env.getMasterNodesList()
+    port = master_nodes_list[0]["port"]
+
+    args = [
+        MEMTIER_BINARY,
+        "-s",
+        "127.0.0.1",
+        "-p",
+        str(port),
+        "-t",
+        "1",
+        "-c",
+        "1",
+        "--test-time=10",
+        "--ratio=1:0",
+        "--hide-histogram",
+    ]
+    if env.isCluster():
+        args.append("--cluster-mode")
+    # Forward TLS flags using the same helper as other tests.
+    benchmark_specs = {"args": []}
+    addTLSArgs(benchmark_specs, env)
+    args.extend(benchmark_specs["args"])
+
+    with tempfile.TemporaryDirectory() as td:
+        stdout_path = os.path.join(td, "mb.stdout")
+        stderr_path = os.path.join(td, "mb.stderr")
+        with open(stdout_path, "w") as out, open(stderr_path, "w") as err:
+            proc = subprocess.Popen(args, stdout=out, stderr=err)
+        try:
+            # Wait for memtier to fully start its event loop.
+            time.sleep(1.5)
+            env.assertIsNone(proc.poll(),
+                             "memtier exited before SIGPIPE was sent (startup failure?)")
+
+            # First SIGPIPE — without SIG_IGN this delivers SIG_DFL and exits 141.
+            os.kill(proc.pid, signal.SIGPIPE)
+            time.sleep(0.5)
+            env.assertIsNone(proc.poll(),
+                             "memtier died from SIGPIPE — SIG_IGN regression")
+
+            # Second SIGPIPE — just to prove SIG_IGN persists, not a fluke.
+            os.kill(proc.pid, signal.SIGPIPE)
+            time.sleep(0.5)
+            env.assertIsNone(proc.poll(),
+                             "memtier died from a second SIGPIPE — SIG_IGN regression")
+
+            # Clean shutdown via SIGINT (which IS handled separately).
+            proc.send_signal(signal.SIGINT)
+            rc = proc.wait(timeout=10)
+            # Either 0 (clean) or 130 (SIGINT-driven shutdown after wrap-up).
+            env.assertTrue(rc in (0, 130, -signal.SIGINT),
+                           "unexpected exit code after SIGINT: {}".format(rc))
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()

--- a/tests/test_sigpipe_immunity.py
+++ b/tests/test_sigpipe_immunity.py
@@ -60,27 +60,38 @@ def test_sigpipe_ignored(env):
         try:
             # Wait for memtier to fully start its event loop.
             time.sleep(1.5)
-            env.assertIsNone(proc.poll(),
-                             "memtier exited before SIGPIPE was sent (startup failure?)")
+            # NB: RLTest's assertion methods take (value, depth=0, message=None);
+            # the message MUST be passed as a keyword arg or RLTest treats it as
+            # `depth` and crashes with TypeError when it does `1 + depth`.
+            env.assertIsNone(
+                proc.poll(),
+                message="memtier exited before SIGPIPE was sent (startup failure?)",
+            )
 
             # First SIGPIPE — without SIG_IGN this delivers SIG_DFL and exits 141.
             os.kill(proc.pid, signal.SIGPIPE)
             time.sleep(0.5)
-            env.assertIsNone(proc.poll(),
-                             "memtier died from SIGPIPE — SIG_IGN regression")
+            env.assertIsNone(
+                proc.poll(),
+                message="memtier died from SIGPIPE — SIG_IGN regression",
+            )
 
             # Second SIGPIPE — just to prove SIG_IGN persists, not a fluke.
             os.kill(proc.pid, signal.SIGPIPE)
             time.sleep(0.5)
-            env.assertIsNone(proc.poll(),
-                             "memtier died from a second SIGPIPE — SIG_IGN regression")
+            env.assertIsNone(
+                proc.poll(),
+                message="memtier died from a second SIGPIPE — SIG_IGN regression",
+            )
 
             # Clean shutdown via SIGINT (which IS handled separately).
             proc.send_signal(signal.SIGINT)
             rc = proc.wait(timeout=10)
             # Either 0 (clean) or 130 (SIGINT-driven shutdown after wrap-up).
-            env.assertTrue(rc in (0, 130, -signal.SIGINT),
-                           "unexpected exit code after SIGINT: {}".format(rc))
+            env.assertTrue(
+                rc in (0, 130, -signal.SIGINT),
+                message="unexpected exit code after SIGINT: {}".format(rc),
+            )
         finally:
             if proc.poll() is None:
                 proc.kill()

--- a/tests/test_sigpipe_tls_rst.py
+++ b/tests/test_sigpipe_tls_rst.py
@@ -210,17 +210,26 @@ def test_sigpipe_tls_rst_does_not_kill_process(env):
             # exit 141 = 128 + SIGPIPE; on Python's wait(), this is reported
             # as either 141 (positive) or -signal.SIGPIPE (negative, if it
             # was killed by signal). Either form indicates the regression.
+            #
+            # NB: RLTest's assertion methods take (value, depth=0, message=None);
+            # the message MUST be passed as a keyword arg or RLTest treats it
+            # as `depth` and crashes with TypeError when it does `1 + depth`.
+            # RLTest also doesn't expose `assertNotIn`, so we use `assertTrue`
+            # over a `not in` expression.
             sigpipe_codes = {141, -signal.SIGPIPE}
-            env.assertNotIn(
-                rc, sigpipe_codes,
-                "memtier died from SIGPIPE (rc={}); SIG_IGN regression. "
-                "stderr at {}".format(rc, stderr_path),
+            env.assertTrue(
+                rc not in sigpipe_codes,
+                message=(
+                    "memtier died from SIGPIPE (rc={}); SIG_IGN regression. "
+                    "stderr at {}".format(rc, stderr_path)
+                ),
             )
 
             # The tarpit should have torn down at least one TLS session.
             env.assertGreater(
-                tarpit.reset_count, 0,
-                "TLS tarpit never accepted a memtier session — test harness broken",
+                tarpit.reset_count,
+                0,
+                message="TLS tarpit never accepted a memtier session — test harness broken",
             )
 
             # And the runtime error path should have logged at least one
@@ -229,10 +238,13 @@ def test_sigpipe_tls_rst_does_not_kill_process(env):
             with open(stderr_path) as f:
                 stderr = f.read()
             env.assertTrue(
-                "Connection error" in stderr or "TLS connection error" in stderr
+                "Connection error" in stderr
+                or "TLS connection error" in stderr
                 or "connection dropped" in stderr,
-                "memtier never logged a connection error despite many TLS RSTs "
-                "(stderr at {})".format(stderr_path),
+                message=(
+                    "memtier never logged a connection error despite many TLS RSTs "
+                    "(stderr at {})".format(stderr_path)
+                ),
             )
         finally:
             tarpit.stop()

--- a/tests/test_sigpipe_tls_rst.py
+++ b/tests/test_sigpipe_tls_rst.py
@@ -29,7 +29,6 @@ import shutil
 import signal
 import socket
 import ssl
-import struct
 import subprocess
 import tempfile
 import threading
@@ -118,21 +117,37 @@ class _TlsRstTarpit:
             except socket.timeout:
                 continue
             try:
-                tls = ctx.wrap_socket(raw, server_side=True, do_handshake_on_connect=True)
+                tls = ctx.wrap_socket(
+                    raw, server_side=True, do_handshake_on_connect=True
+                )
                 try:
-                    tls.settimeout(0.05)
-                    tls.recv(8192)
+                    tls.settimeout(0.3)
+                    tls.recv(65536)  # let memtier pipeline several writes
                 except Exception:
                     pass
-                # Force RST on close: SO_LINGER {l_onoff=1, l_linger=0}.
+                # SIGPIPE-triggering close sequence:
+                #
+                # Skip TLS close_notify and skip SO_LINGER. Just close the
+                # underlying fd. The kernel sends a graceful FIN. memtier
+                # has --pipeline=N writes queued; libevent's openssl
+                # bufferevent flushes them via SSL_write. The first writes
+                # after FIN succeed locally (data goes into the wire), but
+                # the peer kernel sees them on a fully-closed socket and
+                # responds with RST. memtier's NEXT SSL_write (still
+                # pipelined) then hits an RST-marked fd: write() returns
+                # EPIPE AND the kernel raises SIGPIPE in the writer thread
+                # (SSL_write doesn't pass MSG_NOSIGNAL). Without
+                # signal(SIGPIPE, SIG_IGN), SIG_DFL kills the process with
+                # exit 141 before EPIPE is observed.
+                #
+                # Forcing RST directly via SO_LINGER (pre-wrap on raw, or
+                # post-wrap on a re-wrapped fd via tls.detach()) RSTs
+                # *during* handshake completion, which never gives memtier
+                # a chance to build up a pipeline -- the natural close
+                # path above is the one that exercises the production
+                # race.
                 try:
-                    raw.setsockopt(
-                        socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
-                    )
-                except Exception:
-                    pass
-                try:
-                    raw.close()
+                    tls.close()
                 except Exception:
                     pass
                 self.reset_count += 1

--- a/tests/test_sigpipe_tls_rst.py
+++ b/tests/test_sigpipe_tls_rst.py
@@ -1,0 +1,225 @@
+"""
+Regression test for PERF-501 / GH #382 — production-shaped reproduction.
+
+Spins up an in-process TLS server that:
+  1. completes the TLS handshake with memtier
+  2. reads the first client write (a HELLO / SELECT / SET)
+  3. forces a TCP RST via SO_LINGER {l_onoff=1, l_linger=0}
+
+memtier's next SSL_write into that session calls write() on a RST-marked
+fd; the kernel both returns EPIPE *and* raises SIGPIPE. OpenSSL's
+SSL_write() does NOT pass MSG_NOSIGNAL, so without signal(SIGPIPE,
+SIG_IGN) in main(), the process is killed before --reconnect-on-error
+can observe the error and the entire benchmark dies with exit 141.
+
+This complements test_sigpipe_immunity.py (which just SIG_IGN-tests the
+binary directly) by exercising the actual production failure mode end
+to end: openssl write -> kernel RST -> SIGPIPE -> recovery via the
+existing reconnect path.
+
+Skips when the build was configured --disable-tls (no TLS support in
+the memtier binary).
+
+Run subset:
+  TEST=test_sigpipe_tls_rst.py ./tests/run_tests.sh
+"""
+
+import os
+import shutil
+import signal
+import socket
+import ssl
+import struct
+import subprocess
+import tempfile
+import threading
+import time
+
+from include import MEMTIER_BINARY
+
+
+def _have_tls_support():
+    """Check whether MEMTIER_BINARY was built with TLS support."""
+    out = subprocess.run([MEMTIER_BINARY, "--help"], capture_output=True, text=True)
+    return "--tls " in out.stdout or "--tls\n" in out.stdout
+
+
+def _gen_cert(workdir):
+    """Generate a self-signed RSA cert/key pair in workdir. Returns (cert, key)."""
+    cert = os.path.join(workdir, "tls.crt")
+    key = os.path.join(workdir, "tls.key")
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-nodes",
+            "-newkey",
+            "rsa:2048",
+            "-days",
+            "1",
+            "-subj",
+            "/CN=localhost",
+            "-keyout",
+            key,
+            "-out",
+            cert,
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert, key
+
+
+def _pick_free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _TlsRstTarpit:
+    """TLS server that RSTs each session right after the first client write."""
+
+    def __init__(self, cert, key):
+        self.cert = cert
+        self.key = key
+        self.port = _pick_free_port()
+        self._stop = threading.Event()
+        self._thread = None
+        self.reset_count = 0
+
+    def start(self):
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        # Connect to ourselves to unblock the accept() so the thread can exit.
+        try:
+            socket.create_connection(("127.0.0.1", self.port), timeout=0.2).close()
+        except Exception:
+            pass
+        if self._thread:
+            self._thread.join(timeout=2)
+
+    def _serve(self):
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile=self.cert, keyfile=self.key)
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", self.port))
+        srv.listen(1024)
+        srv.settimeout(0.2)
+        while not self._stop.is_set():
+            try:
+                raw, _ = srv.accept()
+            except socket.timeout:
+                continue
+            try:
+                tls = ctx.wrap_socket(raw, server_side=True, do_handshake_on_connect=True)
+                try:
+                    tls.settimeout(0.05)
+                    tls.recv(8192)
+                except Exception:
+                    pass
+                # Force RST on close: SO_LINGER {l_onoff=1, l_linger=0}.
+                try:
+                    raw.setsockopt(
+                        socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0)
+                    )
+                except Exception:
+                    pass
+                try:
+                    raw.close()
+                except Exception:
+                    pass
+                self.reset_count += 1
+            except Exception:
+                try:
+                    raw.close()
+                except Exception:
+                    pass
+        try:
+            srv.close()
+        except Exception:
+            pass
+
+
+def test_sigpipe_tls_rst_does_not_kill_process(env):
+    """memtier must survive a TLS peer that RSTs the connection mid-write."""
+    if not _have_tls_support():
+        env.skip()
+        return
+    if shutil.which("openssl") is None:
+        env.skip()
+        return
+
+    workdir = tempfile.mkdtemp()
+    try:
+        cert, key = _gen_cert(workdir)
+        tarpit = _TlsRstTarpit(cert, key)
+        tarpit.start()
+        try:
+            args = [
+                MEMTIER_BINARY,
+                "-s",
+                "127.0.0.1",
+                "-p",
+                str(tarpit.port),
+                "--tls",
+                "--tls-skip-verify",
+                "-t",
+                "2",
+                "-c",
+                "2",
+                "--pipeline=16",
+                "--test-time=4",
+                "--ratio=1:0",
+                "--hide-histogram",
+                "--reconnect-on-error",
+                "--max-reconnect-attempts=100",
+            ]
+            stdout_path = os.path.join(workdir, "mb.stdout")
+            stderr_path = os.path.join(workdir, "mb.stderr")
+            with open(stdout_path, "w") as out, open(stderr_path, "w") as err:
+                proc = subprocess.Popen(args, stdout=out, stderr=err)
+            try:
+                rc = proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                rc = proc.wait()
+
+            # The key assertion: process must NOT have died from SIGPIPE.
+            # exit 141 = 128 + SIGPIPE; on Python's wait(), this is reported
+            # as either 141 (positive) or -signal.SIGPIPE (negative, if it
+            # was killed by signal). Either form indicates the regression.
+            sigpipe_codes = {141, -signal.SIGPIPE}
+            env.assertNotIn(
+                rc, sigpipe_codes,
+                "memtier died from SIGPIPE (rc={}); SIG_IGN regression. "
+                "stderr at {}".format(rc, stderr_path),
+            )
+
+            # The tarpit should have torn down at least one TLS session.
+            env.assertGreater(
+                tarpit.reset_count, 0,
+                "TLS tarpit never accepted a memtier session — test harness broken",
+            )
+
+            # And the runtime error path should have logged at least one
+            # connection-error line, proving the EPIPE was routed through
+            # attempt_reconnect rather than silently swallowed.
+            with open(stderr_path) as f:
+                stderr = f.read()
+            env.assertTrue(
+                "Connection error" in stderr or "TLS connection error" in stderr
+                or "connection dropped" in stderr,
+                "memtier never logged a connection error despite many TLS RSTs "
+                "(stderr at {})".format(stderr_path),
+            )
+        finally:
+            tarpit.stop()
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- Closes #382 / PERF-501. memtier_benchmark exited `141 (= 128 + SIGPIPE)` mid-run when a backend closed a TCP/TLS connection while a writer thread was sending. Default SIGPIPE disposition (`SIG_DFL`) terminated the process before `--reconnect-on-error` / `--retry-on-error` could observe `EPIPE`.
- One-liner fix: `signal(SIGPIPE, SIG_IGN)` in `main()` before threads launch. After this, `send()` / `SSL_write()` return `-1` with `errno = EPIPE`, which the existing reconnect / retry paths already handle.

## Why a process-wide SIG_IGN (not MSG_NOSIGNAL per call)
- libevent's bufferevent already passes `MSG_NOSIGNAL` on plain-TCP `send()`, but **TLS** writes via OpenSSL's `SSL_write()` do not. PERF-501 was reproduced under `--tls`, which is why the existing reconnect machinery couldn't save it.
- Some `writev` paths on certain kernels ignore `MSG_NOSIGNAL` on the iovec, so even non-TLS writes can theoretically generate SIGPIPE. Process-wide ignore covers both.

## Reproduction (locally verified)
- Built master without the patch → sent the process SIGPIPE → exit `141`. ✓ (bug present)
- Built with the patch → sent SIGPIPE twice → process stays alive, continues its event loop. ✓ (fix works)

## Test plan
- [x] `make` clean, no warnings.
- [x] `make format-check` passes.
- [x] Local reproduction (master vs patched binary) — see commit message.
- [x] New regression test `tests/test_sigpipe_immunity.py` sends `SIGPIPE` twice to a running memtier and asserts the pid is still alive. Independent of the timing race that triggers it in production, so it's deterministic.
- [ ] Full CI matrix (will run on push).

## Out of scope (follow-up)
- Optional diagnostic `SA_SIGINFO` handler logging `si_fd` + `getpeername()` peer for one-shot triage. Kept out of this PR — useful for ad-hoc debugging but not for production behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-wide signal handling by installing `SIGPIPE` ignore, which can affect how broken-pipe conditions surface across all networking writes; behavior should now rely on existing `EPIPE` error paths. Added regression tests reduce the chance of silent behavior changes, but this still touches core runtime behavior.
> 
> **Overview**
> Prevents `memtier_benchmark` from being terminated by `SIGPIPE` when a peer closes a TCP/TLS connection mid-write by installing `signal(SIGPIPE, SIG_IGN)` in `main()` so writes fail with `EPIPE` and existing reconnect/retry logic can run.
> 
> Adds two regression tests: `test_sigpipe_immunity.py` verifies the binary survives injected `SIGPIPE`, and `test_sigpipe_tls_rst.py` reproduces the real TLS failure mode with a local TLS server that triggers RSTs during pipelined `SSL_write()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6106a9df67b1a46696870233d00c6df01d756533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->