### PR TITLE
feat: --latency-window sliding-window tail latency for --realtime-latencies

### DIFF
--- a/bash-completion/memtier_benchmark
+++ b/bash-completion/memtier_benchmark
@@ -31,7 +31,7 @@ _memtier_completions()
                    "--max-retries" "--retry-backoff-ms" "--retry-backoff-factor" "--retry-on"\
                    "--max-retry-queue" "--failed-keys-file"\
                    "--thread-conn-start-min-jitter-micros" "--thread-conn-start-max-jitter-micros"\
-                   "--print-percentiles" "--uri" "--sni"\
+                   "--print-percentiles" "--latency-window" "--uri" "--sni"\
                    "--cert" "--key" "--cacert" "--tls-protocols"\
                    "-s" "-p" "-S" "-o" "-x" "-c" "-n" "-t" "-d" "-a" "-u")
 

--- a/memtier_benchmark.1
+++ b/memtier_benchmark.1
@@ -106,7 +106,10 @@ Specify which percentiles info to print on the results table (by default prints 
 When performing multiple test iterations, print and save results for all iterations
 .TP
 \fB\-\-realtime\-latencies\fR
-Replace the periodic single\-line progress output with a per\-tick block: line 1 = throughput + miss ratio, then one or more latency lines carrying the percentiles configured by \fB\-\-print\-percentiles\fR (immediate and overall, side\-by\-side). Redraws in place on a TTY; appends cleanly when stderr is redirected to a file.
+Replace the periodic single\-line progress output with a per\-tick block: line 1 = throughput + miss ratio, then three labeled latency rows per percentile \- inst (last tick), win<N>s (sliding window, see \fB\-\-latency\-window\fR) and overall (full run). Redraws in place on a TTY; appends cleanly when stderr is redirected to a file.
+.TP
+\fB\-\-latency\-window\fR=\fI\,SECS\/\fR
+Sliding\-window size for the win<N>s tail\-latency row in \fB\-\-realtime\-latencies\fR output. Acts like load1/5/15 for tail latency: each tick the per\-second histogram is pushed into a ring of N snapshots and percentiles are computed over the live ring. Default: 60. Set to 0 to disable the windowed row. Max: 3600.
 .TP
 \fB\-\-command\-stats\-breakdown\fR=\fI\,command\/\fR|line
 How to group command statistics in the output (default: command)

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -583,6 +583,7 @@ static void config_init_defaults(struct benchmark_config *cfg)
     if (!cfg->requests && !cfg->test_time) cfg->requests = 10000;
     if (!cfg->hdr_prefix) cfg->hdr_prefix = "";
     if (!cfg->print_percentiles.is_defined()) cfg->print_percentiles = config_quantiles("50,99,99.9");
+    // latency_window_secs default is set pre-parse so 0 stays a valid user "disabled" value.
     if (!cfg->monitor_pattern) cfg->monitor_pattern = 'S';
 
     // StatsD defaults - port only matters if host is set
@@ -686,6 +687,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_print_percentiles,
         o_print_all_runs,
         o_realtime_latencies,
+        o_latency_window,
         o_distinct_client_seed,
         o_randomize,
         o_client_stats,
@@ -768,6 +770,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         {"print-percentiles", 1, 0, o_print_percentiles},
         {"print-all-runs", 0, 0, o_print_all_runs},
         {"realtime-latencies", 0, 0, o_realtime_latencies},
+        {"latency-window", 1, 0, o_latency_window},
         {"distinct-client-seed", 0, 0, o_distinct_client_seed},
         {"randomize", 0, 0, o_randomize},
         {"requests", 1, 0, 'n'},
@@ -954,6 +957,21 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
             break;
         case o_realtime_latencies:
             cfg->realtime_latencies = true;
+            break;
+        case o_latency_window:
+            endptr = NULL;
+            cfg->latency_window_secs = (unsigned int) strtoul(optarg, &endptr, 10);
+            if (!endptr || *endptr != '\0') {
+                fprintf(stderr, "error: latency-window must be a non-negative integer (seconds).\n");
+                return -1;
+            }
+            // Cap the ring size to avoid runaway memory: each snapshot is a full
+            // hdr_histogram (~tens of KB). 3600 lets you express a 1-hour
+            // tail-latency window, well past load1/5/15 territory.
+            if (cfg->latency_window_secs > 3600) {
+                fprintf(stderr, "error: latency-window must be <= 3600 seconds.\n");
+                return -1;
+            }
             break;
         case o_distinct_client_seed:
             cfg->distinct_client_seed++;
@@ -1588,9 +1606,13 @@ void usage()
         "      --print-all-runs           When performing multiple test iterations, print and save results for all "
         "iterations\n"
         "      --realtime-latencies       Replace the periodic single-line progress output with a per-tick block: "
-        "line 1 = throughput + miss ratio, then one or more latency lines carrying the percentiles configured by "
-        "--print-percentiles (immediate and overall, side-by-side). Redraws in place on a TTY; appends cleanly when "
-        "stderr is redirected to a file.\n"
+        "line 1 = throughput + miss ratio, then three labeled latency rows per percentile - inst (last tick), "
+        "win<N>s (sliding window, see --latency-window) and overall (full run). Redraws in place on a TTY; "
+        "appends cleanly when stderr is redirected to a file.\n"
+        "      --latency-window=SECS      Sliding-window size for the win<N>s tail-latency row in "
+        "--realtime-latencies output. Acts like load1/5/15 for tail latency: each tick the per-second histogram "
+        "is pushed into a ring of N snapshots and percentiles are computed over the live ring. Default: 60. "
+        "Set to 0 to disable the windowed row. Max: 3600.\n"
         "      --command-stats-breakdown=command|line\n"
         "                                 How to group command statistics in the output (default: command)\n"
         "                                 command: aggregate by command name (first word, e.g., SET, GET)\n"
@@ -2094,10 +2116,25 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
 
     // Cumulative latency histogram for --realtime-latencies "overall" percentiles.
     // We hdr_add each tick's aggregated inst histogram into this so the percentiles
-    // shown in '(avg: X.XXX)' reflect the whole run, not just the last second.
+    // shown for the 'overall' row reflect the whole run, not just the last second.
     hdr_histogram *rtl_totals_hist = NULL;
     if (cfg->realtime_latencies) {
         hdr_init(LATENCY_HDR_MIN_VALUE, LATENCY_HDR_SEC_MAX_VALUE, LATENCY_HDR_SEC_SIGDIGTS, &rtl_totals_hist);
+    }
+
+    // Sliding-window ring of per-second snapshots. Each tick we clone
+    // inst_hist_agg into rtl_window_ring[next_slot]; the displaced snapshot is
+    // freed before being overwritten. We compute the windowed percentile by
+    // hdr_reset-ing a scratch histogram, hdr_add-ing every live slot, and
+    // querying. O(W) per tick (microseconds for W<=3600); see --latency-window.
+    const unsigned int win_secs =
+        (cfg->realtime_latencies && cfg->latency_window_secs > 0) ? cfg->latency_window_secs : 0;
+    std::vector<hdr_histogram *> rtl_window_ring(win_secs, NULL);
+    unsigned int rtl_window_next = 0;         // index of the next slot to write into
+    unsigned int rtl_window_filled = 0;       // count of live slots (caps at win_secs)
+    hdr_histogram *rtl_window_scratch = NULL; // reused materialized window histogram
+    if (win_secs > 0) {
+        hdr_init(LATENCY_HDR_MIN_VALUE, LATENCY_HDR_SEC_MAX_VALUE, LATENCY_HDR_SEC_SIGDIGTS, &rtl_window_scratch);
     }
 
     // provide some feedback...
@@ -2296,64 +2333,136 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
             }
 
             // Accumulate this tick's instantaneous percentile samples into the
-            // run-lifetime histogram so '(avg: X.XXX)' on the latency line covers
-            // the whole run so far, not just the last second.
-            if (rtl_totals_hist != NULL && inst_hist_agg != NULL && hdr_total_count(inst_hist_agg) > 0) {
+            // run-lifetime histogram so the 'overall' row covers the whole run
+            // so far, not just the last second.
+            bool inst_has_data = (inst_hist_agg != NULL && hdr_total_count(inst_hist_agg) > 0);
+            if (rtl_totals_hist != NULL && inst_has_data) {
                 hdr_add(rtl_totals_hist, inst_hist_agg);
             }
 
-            // Latency lines: per-configured-percentile "cur (avg: avg)", chunked
-            // to at most kPctPerLine entries per line so a long --print-percentiles
-            // list (e.g. 50,99,99.9,99.99,99.99999,99.999999) doesn't blow out the
-            // terminal. Line count is deterministic given the configured list,
-            // which keeps the in-place cursor-up redraw stable across ticks.
+            // Push this tick's snapshot into the sliding-window ring. We clone
+            // the per-tick aggregate so the ring owns its memory independent of
+            // inst_hist_agg's lifetime. Empty ticks still consume a slot so the
+            // window measures wall-clock seconds, not "seconds with traffic".
+            if (win_secs > 0 && inst_hist_agg != NULL) {
+                hdr_histogram *snap = NULL;
+                if (hdr_init(LATENCY_HDR_MIN_VALUE, LATENCY_HDR_SEC_MAX_VALUE, LATENCY_HDR_SEC_SIGDIGTS, &snap) == 0) {
+                    if (inst_has_data) hdr_add(snap, inst_hist_agg);
+                    if (rtl_window_ring[rtl_window_next] != NULL) hdr_close(rtl_window_ring[rtl_window_next]);
+                    rtl_window_ring[rtl_window_next] = snap;
+                    rtl_window_next = (rtl_window_next + 1) % win_secs;
+                    if (rtl_window_filled < win_secs) rtl_window_filled++;
+                }
+            }
+
+            // Materialize the windowed histogram by hdr_add-ing every live slot
+            // into a reused scratch. Cost O(W) per tick. Skipped when window is
+            // disabled or no slot has data yet.
+            bool win_has_data = false;
+            if (win_secs > 0 && rtl_window_scratch != NULL) {
+                hdr_reset(rtl_window_scratch);
+                for (unsigned int s = 0; s < rtl_window_filled; s++) {
+                    if (rtl_window_ring[s] != NULL && hdr_total_count(rtl_window_ring[s]) > 0) {
+                        hdr_add(rtl_window_scratch, rtl_window_ring[s]);
+                    }
+                }
+                win_has_data = (hdr_total_count(rtl_window_scratch) > 0);
+            }
+
+            // Latency lines: emit three labeled rows per percentile group -
+            //   inst   : last-tick percentiles (from inst_hist_agg)
+            //   winNs  : sliding-window percentiles (from rtl_window_scratch)
+            //   overall: full-run percentiles (from rtl_totals_hist)
+            // Each row's percentile values are chunked at kPctPerLine to keep
+            // line width bounded for long --print-percentiles lists. Line count
+            // per row is deterministic given the configured list, which keeps
+            // the in-place cursor-up redraw stable across ticks.
             const std::vector<double> &quantiles = cfg->print_percentiles.quantile_list;
             const size_t kPctPerLine = 3;
-            size_t num_latency_lines = quantiles.empty() ? 1 : ((quantiles.size() + kPctPerLine - 1) / kPctPerLine);
-            std::vector<std::string> lat_chunks(num_latency_lines);
-            bool any_samples = (rtl_totals_hist != NULL && hdr_total_count(rtl_totals_hist) > 0);
-            bool cur_samples = (inst_hist_agg != NULL && hdr_total_count(inst_hist_agg) > 0);
-            for (std::size_t i = 0; i < quantiles.size(); i++) {
-                char cur_p[16], avg_p[16];
-                if (cur_samples) {
-                    double ms =
-                        hdr_value_at_percentile(inst_hist_agg, quantiles[i]) / (double) LATENCY_HDR_RESULTS_MULTIPLIER;
-                    snprintf(cur_p, sizeof(cur_p), "%6.3f", ms);
-                } else {
-                    snprintf(cur_p, sizeof(cur_p), "   -  ");
-                }
-                if (any_samples) {
-                    double ms = hdr_value_at_percentile(rtl_totals_hist, quantiles[i]) /
-                                (double) LATENCY_HDR_RESULTS_MULTIPLIER;
-                    snprintf(avg_p, sizeof(avg_p), "%6.3f", ms);
-                } else {
-                    snprintf(avg_p, sizeof(avg_p), "   -  ");
-                }
-                char entry[96];
-                snprintf(entry, sizeof(entry), "  p%.10g %s (avg: %s)", quantiles[i], cur_p, avg_p);
-                lat_chunks[i / kPctPerLine] += entry;
+            size_t chunks_per_row = quantiles.empty() ? 1 : ((quantiles.size() + kPctPerLine - 1) / kPctPerLine);
+            // Three rows when window is enabled, otherwise two (inst + overall).
+            const size_t num_rows = (win_secs > 0) ? 3 : 2;
+            // Row label width 8 chars accommodates "win3600s" and keeps
+            // p-columns vertically aligned across rows.
+            const char *row_label_inst = "inst    ";
+            char row_label_win[16];
+            {
+                char tmp[16];
+                snprintf(tmp, sizeof(tmp), "win%us", win_secs);
+                snprintf(row_label_win, sizeof(row_label_win), "%-8s", tmp);
             }
-            if (quantiles.empty()) lat_chunks[0] = "  (no samples this tick)";
+            const char *row_label_overall = "overall ";
+            bool overall_has_data = (rtl_totals_hist != NULL && hdr_total_count(rtl_totals_hist) > 0);
+            struct
+            {
+                const char *label;
+                hdr_histogram *hist;
+                bool has_data;
+            } rows[3];
+            size_t row_idx = 0;
+            rows[row_idx].label = row_label_inst;
+            rows[row_idx].hist = inst_hist_agg;
+            rows[row_idx].has_data = inst_has_data;
+            row_idx++;
+            if (win_secs > 0) {
+                rows[row_idx].label = row_label_win;
+                rows[row_idx].hist = rtl_window_scratch;
+                rows[row_idx].has_data = win_has_data;
+                row_idx++;
+            }
+            rows[row_idx].label = row_label_overall;
+            rows[row_idx].hist = rtl_totals_hist;
+            rows[row_idx].has_data = overall_has_data;
 
-            size_t total_lines = 1 + num_latency_lines;
-            // The ms unit applies to every value on the latency lines (both cur
-            // and avg are in milliseconds), so we always append it to the last
-            // chunk — even when the last tick had no fresh samples.
-            bool show_ms = cur_samples || any_samples;
+            // Build chunked strings for every row.
+            std::vector<std::vector<std::string>> row_chunks(num_rows, std::vector<std::string>(chunks_per_row));
+            bool any_row_has_data = false;
+            for (size_t r = 0; r < num_rows; r++) {
+                if (rows[r].has_data) any_row_has_data = true;
+                for (std::size_t i = 0; i < quantiles.size(); i++) {
+                    char val_p[16];
+                    if (rows[r].has_data && rows[r].hist != NULL) {
+                        double ms = hdr_value_at_percentile(rows[r].hist, quantiles[i]) /
+                                    (double) LATENCY_HDR_RESULTS_MULTIPLIER;
+                        snprintf(val_p, sizeof(val_p), "%6.3f", ms);
+                    } else {
+                        snprintf(val_p, sizeof(val_p), "   -  ");
+                    }
+                    char entry[64];
+                    snprintf(entry, sizeof(entry), "  p%.10g %s", quantiles[i], val_p);
+                    row_chunks[r][i / kPctPerLine] += entry;
+                }
+                if (quantiles.empty()) row_chunks[r][0] = "  (no samples this tick)";
+            }
+
+            size_t total_latency_lines = num_rows * chunks_per_row;
+            size_t total_lines = 1 + total_latency_lines;
+            // The ms unit applies to every value on the latency lines, so we
+            // always append it to the very last chunk of the last row - even
+            // when the tick had no fresh samples.
+            bool show_ms = any_row_has_data;
             if (stderr_is_tty && !first_rtl_frame) {
                 // Move cursor up the number of lines we last emitted, then
                 // overwrite each with \033[K to wipe residue from a wider frame.
                 fprintf(stderr, "\033[%zuA\r", total_lines);
                 fprintf(stderr, "%s\033[K\n", line1);
-                for (size_t k = 0; k < num_latency_lines; k++) {
-                    const char *unit_suffix = (k + 1 == num_latency_lines && show_ms) ? " ms" : "";
-                    fprintf(stderr, "%s latency%s%s\033[K\n", tag, lat_chunks[k].c_str(), unit_suffix);
+                for (size_t r = 0; r < num_rows; r++) {
+                    for (size_t k = 0; k < chunks_per_row; k++) {
+                        bool last = (r + 1 == num_rows) && (k + 1 == chunks_per_row);
+                        const char *unit_suffix = (last && show_ms) ? " ms" : "";
+                        fprintf(stderr, "%s latency [%s]%s%s\033[K\n", tag, rows[r].label, row_chunks[r][k].c_str(),
+                                unit_suffix);
+                    }
                 }
             } else {
                 fprintf(stderr, "%s\n", line1);
-                for (size_t k = 0; k < num_latency_lines; k++) {
-                    const char *unit_suffix = (k + 1 == num_latency_lines && show_ms) ? " ms" : "";
-                    fprintf(stderr, "%s latency%s%s\n", tag, lat_chunks[k].c_str(), unit_suffix);
+                for (size_t r = 0; r < num_rows; r++) {
+                    for (size_t k = 0; k < chunks_per_row; k++) {
+                        bool last = (r + 1 == num_rows) && (k + 1 == chunks_per_row);
+                        const char *unit_suffix = (last && show_ms) ? " ms" : "";
+                        fprintf(stderr, "%s latency [%s]%s%s\n", tag, rows[r].label, row_chunks[r][k].c_str(),
+                                unit_suffix);
+                    }
                 }
             }
             first_rtl_frame = false;
@@ -2437,6 +2546,10 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     } while (active_threads > 0);
 
     if (rtl_totals_hist != NULL) hdr_close(rtl_totals_hist);
+    if (rtl_window_scratch != NULL) hdr_close(rtl_window_scratch);
+    for (size_t s = 0; s < rtl_window_ring.size(); s++) {
+        if (rtl_window_ring[s] != NULL) hdr_close(rtl_window_ring[s]);
+    }
 
     // Send "run completed" annotation and zero out gauges so graphs drop to 0
     if (cfg->statsd != NULL && cfg->statsd->is_enabled()) {
@@ -2599,6 +2712,9 @@ int main(int argc, char *argv[])
     // 0 must remain a valid user-specified "disabled" value, so initialize the
     // sentinel before parsing args.
     cfg.max_retries = -1;
+    // Sliding-window default: 60s. Initialize before parsing so an explicit
+    // --latency-window=0 (disabled) survives config_init_defaults.
+    cfg.latency_window_secs = 60;
 
     if (config_parse_args(argc, argv, &cfg) < 0) {
         usage();

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -2414,8 +2414,11 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
             rows[row_idx].hist = rtl_totals_hist;
             rows[row_idx].has_data = overall_has_data;
 
-            // Build chunked strings for every row.
-            std::vector<std::vector<std::string>> row_chunks(num_rows, std::vector<std::string>(chunks_per_row));
+            // Build chunked strings for every row. typedef avoids the nested
+            // '>>' template-close token so legacy macOS openssl-1.0.2 / 1.1
+            // builds (which don't pick up -std=c++11) still parse this.
+            typedef std::vector<std::string> row_chunks_t;
+            std::vector<row_chunks_t> row_chunks(num_rows, row_chunks_t(chunks_per_row));
             bool any_row_has_data = false;
             for (size_t r = 0; r < num_rows; r++) {
                 if (rows[r].has_data) any_row_has_data = true;

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -70,6 +70,11 @@ struct benchmark_config
     config_quantiles print_percentiles;
     bool print_all_runs;
     bool realtime_latencies;
+    // Sliding-window tail latency for --realtime-latencies output. Each tick the
+    // per-second aggregated inst histogram is pushed into a ring of N snapshots
+    // (N = latency_window_secs) and percentiles are computed over the live ring,
+    // mirroring load1/5/15 semantics for tail latency. 0 disables the column.
+    unsigned int latency_window_secs;
     int distinct_client_seed;
     int randomize;
     int next_client_idx;

--- a/tests/test_realtime_latencies.py
+++ b/tests/test_realtime_latencies.py
@@ -5,8 +5,14 @@ When the flag is set, memtier_benchmark replaces the per-second
 '[RUN #N ...] ops/sec' progress line with a per-tick block:
 
   [RUN #N  P%  Ts] throughput <cur> (avg: <avg>) ops/sec   <cur>/sec (avg: <avg>/sec)   miss X.XX% (avg: Y.YY%)
-  [RUN #N  P%  Ts] latency  p50  cur (avg: avg)  p99  cur (avg: avg)  p99.9  cur (avg: avg) ms
-  [RUN #N  P%  Ts] latency  p99.99  cur (avg: avg)  ...                                                          (if >3 percentiles)
+  [RUN #N  P%  Ts] latency [inst    ]  p50 X.XXX  p99 X.XXX  p99.9 X.XXX
+  [RUN #N  P%  Ts] latency [winNs   ]  p50 X.XXX  p99 X.XXX  p99.9 X.XXX
+  [RUN #N  P%  Ts] latency [overall ]  p50 X.XXX  p99 X.XXX  p99.9 X.XXX ms
+
+The three latency rows are:
+  - inst   : last-tick percentiles
+  - winNs  : sliding window (size = --latency-window, default 60s; 0 disables)
+  - overall: full-run percentiles
 
 The block redraws in place on a TTY (cursor-up + erase-EOL); on non-TTY
 stderr (file capture / pipe) each tick is just appended, producing a clean
@@ -40,11 +46,10 @@ def _read_json(config):
         return json.load(fh)
 
 
-def test_realtime_latencies_emits_two_line_block(env):
-    """Per tick we get one 'throughput' line and one 'latency' line (when
-    the configured percentile list fits on one wrapped line). Each line
-    carries an immediate value plus '(avg: X)' for the overall counterpart,
-    miss% is present, and the legacy absolute ops counter is gone."""
+def test_realtime_latencies_emits_three_row_block(env):
+    """Per tick we get one 'throughput' line plus three labeled latency rows
+    (inst, winNs, overall). The throughput line still carries cur+avg ops and
+    miss%; each latency row exposes every configured percentile."""
     benchmark_specs = {
         "name": env.testName,
         "args": [
@@ -53,6 +58,7 @@ def test_realtime_latencies_emits_two_line_block(env):
             "--key-minimum=1",
             "--key-maximum=10000",
             "--realtime-latencies",
+            "--latency-window=60",
             "--print-percentiles=50,99,99.9",
         ],
     }
@@ -72,9 +78,7 @@ def test_realtime_latencies_emits_two_line_block(env):
         stderr = _read_stderr(config)
 
         thr_lines = [ln for ln in stderr.splitlines() if re.search(r"\[RUN #\d+ +\d+%.*\] throughput ", ln)]
-        lat_lines = [ln for ln in stderr.splitlines() if re.search(r"\[RUN #\d+ +\d+%.*\] latency ", ln)]
         env.assertTrue(len(thr_lines) >= 1, message="expected at least one 'throughput' line; stderr=\n%s" % stderr[:2000])
-        env.assertTrue(len(lat_lines) >= 1, message="expected at least one 'latency' line; stderr=\n%s" % stderr[:2000])
 
         # Throughput line must carry both immediate ops/sec and a parenthesized
         # avg, plus a miss% with its own avg (e.g. "miss 99.50% (avg: 99.40%)").
@@ -83,20 +87,29 @@ def test_realtime_latencies_emits_two_line_block(env):
         miss_ok = any(re.search(r"miss\s+\d+\.\d+%\s+\(avg:\s*\d+\.\d+%\)", ln) for ln in thr_lines)
         env.assertTrue(miss_ok, message="no 'miss X (avg: Y)' found on any throughput line; got:\n%s" % "\n".join(thr_lines[:5]))
 
-        # Every configured percentile must appear on at least one latency line
-        # together with its '(avg: X.XXX)' overall counterpart.
-        for label in ("p50", "p99", "p99.9"):
-            pat = re.escape(label) + r"\s+\d+\.\d+\s+\(avg:\s*\d+\.\d+\)"
-            hit = any(re.search(pat, ln) for ln in lat_lines)
-            env.assertTrue(
-                hit,
-                message="percentile %s missing immediate+avg on latency lines; got:\n%s"
-                % (label, "\n".join(lat_lines[:5])),
-            )
+        # Each tick must emit all three labeled latency rows.
+        inst_lines = [ln for ln in stderr.splitlines() if re.search(r"\] latency \[inst", ln)]
+        win_lines = [ln for ln in stderr.splitlines() if re.search(r"\] latency \[win60s", ln)]
+        overall_lines = [ln for ln in stderr.splitlines() if re.search(r"\] latency \[overall", ln)]
+        env.assertTrue(len(inst_lines) >= 1, message="no [inst] latency row found; stderr=\n%s" % stderr[:2000])
+        env.assertTrue(len(win_lines) >= 1, message="no [win60s] latency row found; stderr=\n%s" % stderr[:2000])
+        env.assertTrue(len(overall_lines) >= 1, message="no [overall] latency row found; stderr=\n%s" % stderr[:2000])
+
+        # Every configured percentile must appear on each row at least once
+        # with a numeric value (or '-' on the very first tick before samples arrive).
+        for row_name, lines in (("inst", inst_lines), ("win60s", win_lines), ("overall", overall_lines)):
+            for label in ("p50", "p99", "p99.9"):
+                pat = re.escape(label) + r"\s+(?:\d+\.\d+|-)"
+                hit = any(re.search(pat, ln) for ln in lines)
+                env.assertTrue(
+                    hit,
+                    message="percentile %s missing on [%s] row; got:\n%s"
+                    % (label, row_name, "\n".join(lines[:5])),
+                )
 
         # The legacy absolute ops counter ("NNNN ops,") must NOT appear under --realtime-latencies.
         env.assertFalse(
-            any(re.search(r"\d+ ops,", ln) for ln in thr_lines + lat_lines),
+            any(re.search(r"\d+ ops,", ln) for ln in thr_lines + inst_lines + win_lines + overall_lines),
             message="--realtime-latencies must not show absolute ops count; got:\n%s" % stderr[:2000],
         )
 
@@ -109,11 +122,10 @@ def test_realtime_latencies_emits_two_line_block(env):
 
 
 def test_realtime_latencies_wraps_and_handles_deep_tail(env):
-    """When --print-percentiles lists more than 3 entries, the latency block
-    wraps across multiple `[RUN ...] latency ...` lines (3 per line). Also
-    asserts that deep-tail percentiles like 99.99999 don't round to "p100":
-    the legacy `p%.*f` formatter (capped at 3 fractional digits) used to
-    print both 99.99999 and 99.999999 as `p100`, colliding in the table.
+    """When --print-percentiles lists more than 3 entries, each row wraps
+    across multiple `[RUN ...] latency [label] ...` lines (3 percentiles per
+    line). Also asserts that deep-tail percentiles like 99.99999 don't round
+    to "p100" (regression: legacy formatter capped at 3 fractional digits).
     """
     benchmark_specs = {
         "name": env.testName,
@@ -123,6 +135,7 @@ def test_realtime_latencies_wraps_and_handles_deep_tail(env):
             "--key-minimum=1",
             "--key-maximum=10000",
             "--realtime-latencies",
+            "--latency-window=5",
             "--print-percentiles=50,99,99.9,99.99,99.99999,99.999999",
         ],
     }
@@ -143,23 +156,21 @@ def test_realtime_latencies_wraps_and_handles_deep_tail(env):
         stdout_path = os.path.join(config.results_dir, "mb.stdout")
         stdout = open(stdout_path).read() if os.path.exists(stdout_path) else ""
 
-        # 6 percentiles → ceil(6/3) = 2 latency lines per tick. Group lines by
-        # their [RUN ... Ts] tag, since the tag changes each tick.
-        lat_lines = [ln for ln in stderr.splitlines() if "] latency " in ln]
-        env.assertTrue(len(lat_lines) >= 2, message="expected wrapped latency lines (>=2); got:\n%s" % stderr[:2000])
+        # 6 percentiles → ceil(6/3) = 2 chunks per row. With three rows (inst,
+        # win, overall) that's 6 latency lines per tick. Group by tick tag.
+        lat_lines = [ln for ln in stderr.splitlines() if "] latency [" in ln]
+        env.assertTrue(len(lat_lines) >= 6, message="expected wrapped latency lines (>=6); got:\n%s" % stderr[:2000])
 
-        # Group consecutive latency lines that share a tick tag; each tick
-        # should produce exactly 2 latency lines for 6 percentiles.
         tag_re = re.compile(r"(\[RUN #\d+ +\d+% +\d+s\]) latency")
         per_tick = {}
         for ln in lat_lines:
             m = tag_re.match(ln)
             if m:
                 per_tick.setdefault(m.group(1), []).append(ln)
-        full_ticks = [v for v in per_tick.values() if len(v) == 2]
+        full_ticks = [v for v in per_tick.values() if len(v) == 6]
         env.assertTrue(
             len(full_ticks) >= 1,
-            message="expected at least one tick with exactly 2 latency lines; got:\n%s" % stderr[:2000],
+            message="expected at least one tick with 6 latency lines (3 rows x 2 chunks); got:\n%s" % stderr[:2000],
         )
 
         # Deep-tail percentile labels must use enough precision that they
@@ -186,6 +197,46 @@ def test_realtime_latencies_wraps_and_handles_deep_tail(env):
             re.search(r"\bp100(\.\d+)?\s+Latency", stdout) is not None,
             message="'p100 Latency' column in stdout indicates header-formatter rounding bug",
         )
+    finally:
+        if not memtier_ok:
+            debugPrintMemtierOnError(config, env)
+
+
+def test_latency_window_zero_drops_window_row(env):
+    """`--latency-window=0` must suppress the [winNs] row entirely, leaving
+    just inst + overall. Validates the user-facing 'disable' contract."""
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--ratio=1:1",
+            "--key-pattern=R:R",
+            "--key-minimum=1",
+            "--key-maximum=10000",
+            "--realtime-latencies",
+            "--latency-window=0",
+            "--print-percentiles=50,99",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=1, clients=2, requests=None, test_time=2)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+    try:
+        env.assertTrue(memtier_ok)
+        stderr = _read_stderr(config)
+        inst_lines = [ln for ln in stderr.splitlines() if re.search(r"\] latency \[inst", ln)]
+        overall_lines = [ln for ln in stderr.splitlines() if re.search(r"\] latency \[overall", ln)]
+        win_lines = [ln for ln in stderr.splitlines() if re.search(r"\] latency \[win", ln)]
+        env.assertTrue(len(inst_lines) >= 1, message="[inst] row missing with window disabled")
+        env.assertTrue(len(overall_lines) >= 1, message="[overall] row missing with window disabled")
+        env.assertEqual(len(win_lines), 0, message="[win*] row must be suppressed when --latency-window=0")
     finally:
         if not memtier_ok:
             debugPrintMemtierOnError(config, env)
@@ -227,6 +278,54 @@ def test_default_progress_line_unchanged(env):
             "\033[K" in stderr,
             message="legacy mode must not emit ANSI erase-EOL on the progress line",
         )
+    finally:
+        if not memtier_ok:
+            debugPrintMemtierOnError(config, env)
+
+
+def test_latency_window_ring_smooths_spikes(env):
+    """A short window (2s) plus a long-enough run must produce a [win2s] row
+    whose p99 falls into the same numeric range as the inst row over time
+    (smoothed but not zero). Sanity check that the ring is actually populated
+    and computed, not silently empty."""
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--ratio=1:1",
+            "--key-pattern=R:R",
+            "--key-minimum=1",
+            "--key-maximum=10000",
+            "--realtime-latencies",
+            "--latency-window=2",
+            "--print-percentiles=50,99",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=2, clients=4, requests=None, test_time=5)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+    try:
+        env.assertTrue(memtier_ok)
+        stderr = _read_stderr(config)
+        win_lines = [ln for ln in stderr.splitlines() if re.search(r"\] latency \[win2s", ln)]
+        env.assertTrue(len(win_lines) >= 2, message="expected multiple [win2s] rows; stderr=\n%s" % stderr[:2000])
+
+        # Extract numeric p99 values from each [win2s] row and require at
+        # least one positive reading once the ring has data.
+        p99_re = re.compile(r"\bp99\s+(\d+\.\d+)")
+        win_p99 = []
+        for ln in win_lines:
+            m = p99_re.search(ln)
+            if m:
+                win_p99.append(float(m.group(1)))
+        env.assertTrue(any(v > 0.0 for v in win_p99), message="[win2s] p99 never produced a positive value; got %r" % win_p99)
     finally:
         if not memtier_ok:
             debugPrintMemtierOnError(config, env)


### PR DESCRIPTION
## Summary

Adds a **load1/5/15-style sliding window** to the live latency block under `--realtime-latencies`. The per-tick output now emits **three labeled rows per configured percentile**:

- **inst**    — last tick only
- **win\<N\>s** — sliding window (default 60s, configurable via `--latency-window=SECS`, set to 0 to disable, max 3600)
- **overall** — full run

Example with `--latency-window=60 --print-percentiles=50,99,99.9`:

```
[RUN #1 50%  2s] throughput 178,155 (avg: 172,043) ops/sec   …   miss 49.88% (avg: 49.87%)
[RUN #1 50%  2s] latency [inst    ]  p50 0.111  p99 0.223  p99.9 0.367
[RUN #1 50%  2s] latency [win60s  ]  p50 0.119  p99 0.239  p99.9 0.479
[RUN #1 50%  2s] latency [overall ]  p50 0.119  p99 0.239  p99.9 0.479 ms
```

## Implementation

- Ring buffer of cloned `hdr_histogram` snapshots, one per second (memtier_benchmark.cpp:2125-2143).
- Per tick: clone `inst_hist_agg` into the next slot, freeing the displaced snapshot. O(W) per tick (microseconds for W ≤ 3600).
- To render: `hdr_reset` a reused scratch histogram, `hdr_add` every live slot, then `hdr_value_at_percentile`.
- Empty ticks still consume a slot, so the window measures wall-clock seconds, not "seconds with traffic".
- Long `--print-percentiles` lists wrap to multiple lines per row with deterministic line count, so the TTY cursor-up redraw stays stable.

## Memory / CPU

- Each snapshot is one `hdr_histogram` (~tens of KB at default precision). Default 60s window ≈ 1-2 MB; capped at 3600s.
- O(W) `hdr_add` per tick, once per second. Negligible.
- No effect when `--realtime-latencies` is off or `--latency-window=0`.

## Test plan

- [x] `make format-check` clean
- [x] Builds cleanly (release + `--enable-sanitizers`)
- [x] ASAN smoke run with deep-tail percentiles: exit 0, no leaks, no errors
- [x] RLTest `test_realtime_latencies.py`: 5/5 PASS (incl. 2 new tests: `test_latency_window_zero_drops_window_row`, `test_latency_window_ring_smooths_spikes`)
- [x] Existing `--realtime-latencies` tests updated for new label-row layout and still pass
- [x] `--help` and man page show `--latency-window`
- [x] bash-completion lists `--latency-window` under `options_no_comp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `--realtime-latencies` progress output format and adds a per-second histogram ring buffer, which could affect log parsers and introduce memory/CPU overhead if misconfigured (bounded to 3600s).
> 
> **Overview**
> Adds a new `--latency-window=SECS` option that computes *sliding-window tail latency* for `--realtime-latencies` by keeping a ring of per-second HDR histogram snapshots (default 60s, `0` disables, max 3600).
> 
> Updates the live progress block to emit **labeled latency rows** per tick (always `inst` + `overall`, plus `win<N>s` when enabled) and adjusts TTY redraw/wrapping logic accordingly.
> 
> Wires the flag through CLI parsing/help/man page and bash completion, extends `benchmark_config` with `latency_window_secs`, and updates/adds RLTest coverage to validate the new rows, wrapping behavior, and the `--latency-window=0` disable contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10285ab6d064b65c73749874c0c6de695dc59b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->