### PR TITLE
fix(tls): gate pre-1.1.0 OpenSSL deprecated APIs for OpenSSL 4.0 readiness

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -2489,8 +2489,11 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
 
 #ifdef USE_TLS
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+// OpenSSL < 1.1.0 requires the application to register its own locking
+// callbacks for thread safety. Since 1.1.0 the library handles its own
+// internal locking and these APIs are no-ops; they are slated for removal
+// in OpenSSL 4.0 (see issue #387).
 static pthread_mutex_t *__openssl_locks;
 
 static void __openssl_locking_callback(int mode, int type, const char *file, int line)
@@ -2509,7 +2512,6 @@ static unsigned long __openssl_thread_id(void)
     id = (unsigned long) pthread_self();
     return id;
 }
-#pragma GCC diagnostic pop
 
 static void init_openssl_threads(void)
 {
@@ -2536,30 +2538,32 @@ static void cleanup_openssl_threads(void)
     }
     OPENSSL_free(__openssl_locks);
 }
+#endif
 
 static void init_openssl(void)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     SSL_library_init();
     SSL_load_error_strings();
+#endif
     if (!RAND_poll()) {
         fprintf(stderr, "Failed to initialize OpenSSL random entropy.\n");
         exit(1);
     }
 
-// Enable memtier benchmark to load an OpenSSL config file.
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     OPENSSL_config(NULL);
+    init_openssl_threads();
 #else
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
 #endif
-
-
-    init_openssl_threads();
 }
 
 static void cleanup_openssl(void)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     cleanup_openssl_threads();
+#endif
 }
 
 #endif
@@ -2943,7 +2947,11 @@ int main(int argc, char *argv[])
     if (cfg.tls) {
         init_openssl();
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         cfg.openssl_ctx = SSL_CTX_new(SSLv23_client_method());
+#else
+        cfg.openssl_ctx = SSL_CTX_new(TLS_client_method());
+#endif
         SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
         if (!(cfg.tls_protocols & REDIS_TLS_PROTO_TLSv1)) SSL_CTX_set_options(cfg.openssl_ctx, SSL_OP_NO_TLSv1);


### PR DESCRIPTION
## Summary

Closes #387.

OpenSSL 4.0 is on track to remove a number of APIs that were deprecated back in 1.1.0. memtier still called six of them unconditionally — `SSLv23_client_method()`, `SSL_library_init()`, `SSL_load_error_strings()`, `CRYPTO_set_id_callback()`, `CRYPTO_set_locking_callback()`, `CRYPTO_num_locks()`. Against modern OpenSSL these emit deprecation warnings; against OpenSSL 4.0 (or any distro that adds `-Werror=deprecated-declarations` downstream, as Redis does — see redis/redis#15221) the build will fail outright.

Gate the legacy locking-callback and init paths behind `OPENSSL_VERSION_NUMBER < 0x10100000L` — matching the existing `OPENSSL_config` / `OPENSSL_init_crypto` gate that was already in this file — and switch `SSLv23_client_method` → `TLS_client_method` on 1.1.0+.

The library has handled internal locking automatically since 1.1.0, and `SSL_library_init` / `SSL_load_error_strings` are no-ops since the same release, so dropping them on the modern path is a true no-op functionally.

## Why this matters

- **OpenSSL 4.0 with `-Werror=deprecated-declarations`**: hard build failure.
- **OpenSSL 4.0 that fully removes the symbols**: link failure even without `-Werror`.
- **OpenSSL 3.x today**: ~6 deprecation warnings on every TLS build.

## Verification

Built locally with stricter flags to confirm the deprecation surface is gone:

```sh
make clean
CXXFLAGS="-O2 -g -Wall -Werror=deprecated-declarations" make -j4
```

→ build succeeds (only the pre-existing unrelated `statsd.cpp` `-Wformat-truncation` warning remains).

## Test plan

- [x] Local build clean with `-Werror=deprecated-declarations`
- [ ] Existing TLS test matrix (Single Endpoint TCP TLS, OSS TCP TLS v1.2 / v1.3, OSS-CLUSTER TCP TLS) under ASAN / UBSan / TSAN
- [ ] No behavior change on OpenSSL 1.0.x (legacy path preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are compile-time gated and primarily affect build compatibility with OpenSSL 1.1.0+ / 4.0 deprecations, with minimal runtime behavior impact beyond TLS context method selection.
> 
> **Overview**
> **Improves OpenSSL 1.1.0+ / 4.0 build compatibility for TLS builds.** The legacy OpenSSL thread-locking callbacks and deprecated init calls are now compiled only for `OPENSSL_VERSION_NUMBER < 0x10100000L`, while newer versions use `OPENSSL_init_crypto`.
> 
> For TLS context creation, OpenSSL 1.1.0+ switches from `SSLv23_client_method()` to `TLS_client_method()`, keeping the older method on pre-1.1.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3178a693822c2eac45c9ec186548723030892f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->