### PR TITLE
fix(reconnect): don't kill thread on duplicate connection error while a reconnect is already pending

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -119,7 +119,7 @@ jobs:
       run: ./tests/gen-test-certs.sh
 
     - name: Run tests
-      timeout-minutes: 10
+      timeout-minutes: 15
       env: ${{ matrix.test-config.env }}
       run: |
         ./tests/run_tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
           ./tests/gen-test-certs.sh
 
     - name: Run tests
-      timeout-minutes: 10
+      timeout-minutes: 15
       env: ${{ matrix.test-config.env }}
       run: |
         ./tests/run_tests.sh
@@ -343,7 +343,7 @@ jobs:
         ulimit -n 40960
 
     - name: Run tests for coverage
-      timeout-minutes: 10
+      timeout-minutes: 15
       env:
         OSS_STANDALONE: "1"
         OSS_CLUSTER: "0"

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -114,7 +114,7 @@ jobs:
       run: ./tests/gen-test-certs.sh
 
     - name: Run tests
-      timeout-minutes: 10
+      timeout-minutes: 15
       env: ${{ matrix.test-config.env }}
       run: |
         ./tests/run_tests.sh

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -1114,6 +1114,19 @@ void shard_connection::attempt_reconnect(const char *error_context)
         m_reconnect_timer = event_new(m_event_base, -1, 0, cluster_client_reconnect_timer_handler, (void *) this);
         event_add(m_reconnect_timer, &delay);
         m_reconnecting = true;
+    } else if (m_config->reconnect_on_error && m_reconnecting) {
+        // A reconnect is already pending for this connection. The event loop
+        // can deliver multiple connection-error callbacks per dead connection
+        // (e.g. an EOF followed by stray TLS read errors during a node
+        // failover storm), and every one of them lands here while the first
+        // one's reconnect timer is still pending.
+        //
+        // Treat the duplicates as no-ops — the in-flight reconnect will run
+        // and decide what to do. Tearing the thread down here would mean a
+        // single dead connection always kills the whole benchmark thread
+        // under realistic failover conditions, regardless of how high
+        // --max-reconnect-attempts is set.
+        return;
     } else {
         benchmark_error_log("Maximum reconnection attempts (%u) exceeded for %s, triggering thread restart.\n",
                             m_config->max_reconnect_attempts, error_context);

--- a/tests/test_reconnections.py
+++ b/tests/test_reconnections.py
@@ -282,6 +282,108 @@ def test_reconnect_cluster_mode_no_assertion(env):
     env.assertNotEqual(return_code, 134)
 
 
+def test_reconnect_unlimited_no_spurious_thread_restart(env):
+    """
+    Regression test for https://github.com/redis/memtier_benchmark/issues/391.
+
+    With --max-reconnect-attempts=0 (unlimited) and --reconnect-on-error,
+    libevent can deliver a storm of connection-error callbacks per dead
+    connection (EOF + stray read errors). Before the fix, every callback
+    after the first (which set m_reconnecting=true) fell into the terminal
+    else branch and called event_base_loopbreak(), killing the benchmark
+    thread. This produced the misleading log line:
+
+        Maximum reconnection attempts (0) exceeded for ..., triggering thread restart.
+
+    …even though the user had explicitly requested unlimited reconnects.
+
+    This test verifies that:
+    1. The misleading "Maximum reconnection attempts (0) exceeded" message
+       does NOT appear in stderr.
+    2. memtier_benchmark completes successfully (threads survive the kills).
+    """
+    import subprocess
+
+    key_max = 10000
+    key_min = 1
+
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--pipeline=1",
+            "--ratio=1:1",
+            "--key-pattern=R:R",
+            "--key-minimum={}".format(key_min),
+            "--key-maximum={}".format(key_max),
+            "--reconnect-on-error",
+            "--max-reconnect-attempts=0",   # unlimited
+            "--reconnect-backoff-factor=1.0",
+            "--connection-timeout=5",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+
+    config = get_default_memtier_config(threads=2, clients=2, requests=5000)
+    master_nodes_list = env.getMasterNodesList()
+
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+
+    stdout_path = "{0}/mb.stdout".format(config.results_dir)
+    stderr_path = "{0}/mb.stderr".format(config.results_dir)
+    with open(stdout_path, "w") as stdout_f, open(stderr_path, "w") as stderr_f:
+        proc = subprocess.Popen(
+            benchmark.args,
+            stdout=stdout_f,
+            stderr=stderr_f,
+            cwd=config.results_dir,
+        )
+
+        # Let connections establish, then kill them twice in rapid succession
+        # to maximise the chance that libevent delivers multiple error callbacks
+        # per dead connection while a reconnect timer is already pending.
+        time.sleep(1)
+        for _wave in range(3):
+            for conn in master_nodes_connections:
+                try:
+                    conn.execute_command("CLIENT", "KILL", "TYPE", "normal")
+                except Exception:
+                    pass
+            time.sleep(0.5)
+
+        try:
+            return_code = proc.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            return_code = proc.wait(timeout=10)
+
+    with open(stderr_path) as f:
+        stderr_content = f.read()
+
+    env.debugPrint("memtier exit code: {}".format(return_code), True)
+    env.debugPrint("STDERR:\n{}".format(stderr_content[:2000]), True)
+
+    # Core regression assertion: the misleading terminal message must not appear.
+    # Before the fix, duplicate error callbacks while m_reconnecting==True landed
+    # in the terminal else and printed this with the configured cap (0) rather
+    # than the actual attempt count, then killed the thread.
+    env.assertFalse(
+        "Maximum reconnection attempts (0) exceeded" in stderr_content,
+        "Spurious thread-kill message found: duplicate error callback while "
+        "reconnect already pending incorrectly triggered event_base_loopbreak()",
+    )
+
+    # Benchmark must have completed; if threads were killed spuriously it would
+    # exit non-zero or stall.
+    env.assertEqual(return_code, 0)
+
+
 def test_reconnect_disabled_by_default(env):
     """
     Test that reconnection is disabled by default and memtier fails when connections are killed.

--- a/tests/test_reconnections.py
+++ b/tests/test_reconnections.py
@@ -375,7 +375,7 @@ def test_reconnect_unlimited_no_spurious_thread_restart(env):
     # than the actual attempt count, then killed the thread.
     env.assertFalse(
         "Maximum reconnection attempts (0) exceeded" in stderr_content,
-        "Spurious thread-kill message found: duplicate error callback while "
+        message="Spurious thread-kill message found: duplicate error callback while "
         "reconnect already pending incorrectly triggered event_base_loopbreak()",
     )
 


### PR DESCRIPTION
Fixes #391.

## What changed

`shard_connection.cpp::attempt_reconnect()` previously collapsed three semantically distinct conditions into a single terminal `else` branch:

1. `!reconnect_on_error` — caller opted out (terminal: yes)
2. `m_reconnecting == true` — a reconnect is already pending (terminal: **no** — should be a no-op)
3. `m_reconnect_attempts >= max_reconnect_attempts` — configured cap reached (terminal: yes)

Case 2 is the bug. During a real failover, libevent delivers a small storm of connection-error callbacks per dead connection (EOF + stray TLS read errors). The first enters the happy path and schedules a reconnect timer; the rest land in the `else` branch and call `event_base_loopbreak()`, killing the per-thread event loop regardless of `--max-reconnect-attempts` value (including the documented \"`0` = unlimited\" semantic).

## Fix

Add an `else if` for the \"already reconnecting\" case that silently returns. The terminal `else` keeps its existing behaviour for the two cases that *are* terminal.

## Test plan

- [ ] Existing tests pass (`make test`).
- [ ] Manual: trigger a DB-node reboot mid-bench against a Redis Enterprise cluster; confirm threads survive the connection-error storm and throughput recovers after the failover instead of falling to 0 and staying there.

## Issue link

Full reproduction + log evidence in #391.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core reconnection control flow in `shard_connection::attempt_reconnect`, which can affect benchmark thread liveness under error conditions; regression coverage is added to reduce risk.
> 
> **Overview**
> Prevents benchmark threads from being spuriously restarted when libevent delivers multiple connection-error callbacks while a reconnect timer is already pending (especially with `--max-reconnect-attempts=0` *unlimited*), by treating those duplicate callbacks as a no-op instead of breaking the event loop.
> 
> Adds a regression test (`test_reconnect_unlimited_no_spurious_thread_restart`) that repeatedly kills connections and asserts the misleading "Maximum reconnection attempts (0) exceeded" message never appears and the run exits successfully. CI/ASAN/UBSAN workflow test step timeouts are increased from 10 to 15 minutes to reduce flakiness for the expanded test suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3a220184cc0c458f592f2d4c37e64032d33d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->