### PR TITLE
ci: declare workflow-level `contents: read` on 5 build/sanitizer workflows

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   build-asan:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   smoketest-build-distros:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   cpp-format-check:
     name: C++ Format Check

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   build-tsan:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   build-ubsan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Five CI workflows (`ci`, `asan`, `tsan`, `code-style`, `ubsan`) all run pure build and sanitizer checks. No GitHub API writes from the workflows.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally with `yaml.safe_load` on each touched file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that tightens GitHub token permissions and should not affect build/test logic beyond potential permission-related checkout/tooling issues.
> 
> **Overview**
> Adds workflow-level `permissions: contents: read` to the `ci`, `asan`, `tsan`, `ubsan`, and `code-style` GitHub Actions workflows to explicitly scope the default `GITHUB_TOKEN` to read-only repository access.
> 
> This is a hardening change aligned with least-privilege CI execution; no job steps or build/test behavior is otherwise modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af94e61043b34775f00aaa9715dfaa79dd3cf101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->