### PR TITLE
Add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+We treat this repo as "Open Source" within Redis: anyone who clears the bar below is welcome to contribute.
+
+## Local setup
+
+<!-- TODO: fill in repo-specific setup steps -->
+
+```bash
+# Example — replace with actual steps
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+# install dependencies, build, etc.
+```
+
+## Branch naming
+
+```
+<type>/<short-description>
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+Example: `feat/add-pipeline-mode`
+
+## Coding standards
+
+- Keep changes focused; one logical change per PR.
+- Follow the conventions already present in the codebase (formatting, naming, error handling).
+- No dead code, no commented-out blocks.
+
+## Submitting changes
+
+1. Fork or create a branch from `main`.
+2. Make your changes with clear, atomic commits.
+3. Open a pull request against `main` with a descriptive title and summary.
+4. Address review comments promptly; force-push to the same branch to update.
+
+## Testing
+
+- All new behaviour must be covered by tests.
+- Existing tests must pass: run the test suite locally before opening a PR.
+- Coverage should not decrease.
+
+<!-- TODO: add the exact test command for this repo -->
+
+## Review process
+
+- At least one maintainer approval is required before merge.
+- CI must be green.
+- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ git clone git@github.com:redis/memtier_benchmark.git
 cd memtier_benchmark
 autoreconf -ivf
 ./configure
-make -j
+make
 ```
 
 The binary is produced at `./memtier_benchmark`. Run `sudo make install` to install system-wide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,34 @@ We treat this repo as "Open Source" within Redis: anyone who clears the bar belo
 
 ## Local setup
 
-<!-- TODO: fill in repo-specific setup steps -->
+memtier_benchmark is a C++ project built with GNU Autotools. The following steps work on Ubuntu/Debian; see [DEVELOPMENT.md](DEVELOPMENT.md) for CentOS/Red Hat and macOS instructions.
+
+**Install build dependencies (Ubuntu/Debian):**
 
 ```bash
-# Example — replace with actual steps
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
-# install dependencies, build, etc.
+sudo apt-get install build-essential autoconf automake \
+    libevent-dev pkg-config zlib1g-dev libssl-dev clang-format
 ```
+
+**Clone and build:**
+
+```bash
+git clone git@github.com:redis/memtier_benchmark.git
+cd memtier_benchmark
+autoreconf -ivf
+./configure
+make -j
+```
+
+The binary is produced at `./memtier_benchmark`. Run `sudo make install` to install system-wide.
+
+**Enable the pre-commit formatting hook (once per clone):**
+
+```bash
+make install-hooks
+```
+
+This runs `make format-check-staged` before each commit to catch clang-format violations early.
 
 ## Branch naming
 
@@ -28,12 +48,13 @@ Example: `feat/add-pipeline-mode`
 - Keep changes focused; one logical change per PR.
 - Follow the conventions already present in the codebase (formatting, naming, error handling).
 - No dead code, no commented-out blocks.
+- All C++ files must pass `clang-format` checks. Run `make format` to auto-format, then `make format-check` to verify.
 
 ## Submitting changes
 
-1. Fork or create a branch from `main`.
+1. Fork the repository or create a branch from `master`.
 2. Make your changes with clear, atomic commits.
-3. Open a pull request against `main` with a descriptive title and summary.
+3. Open a pull request against `master` with a descriptive title and summary.
 4. Address review comments promptly; force-push to the same branch to update.
 
 ## Testing
@@ -42,10 +63,24 @@ Example: `feat/add-pipeline-mode`
 - Existing tests must pass: run the test suite locally before opening a PR.
 - Coverage should not decrease.
 
-<!-- TODO: add the exact test command for this repo -->
+The integration tests use [RLTest](https://github.com/RedisLabsModules/RLTest) and require a Redis server on `$PATH`. Set up a Python virtualenv and run the suite:
+
+```bash
+mkdir -p .env
+virtualenv .env
+source .env/bin/activate
+pip install -r tests/test_requirements.txt
+./tests/run_tests.sh
+```
+
+To see all available test options:
+
+```bash
+./tests/run_tests.sh --help
+```
 
 ## Review process
 
 - At least one maintainer approval is required before merge.
 - CI must be green.
-- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.
+- Maintainers may request changes or close PRs that do not meet the bar — this is normal and not personal.


### PR DESCRIPTION
## Summary
- Adds baseline `CONTRIBUTING.md` (project setup, coding standards, PR workflow, testing, review process)
- Adds `AGENTS.md` with AI agent guidelines

Part of the Redis "Open Source within Redis" initiative — ensuring every repo in the org has clear contribution and agent guidelines to enable cross-team contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on binaries, dependencies, or production behavior.
> 
> **Overview**
> Adds **`CONTRIBUTING.md`** so contributors have a single entry point for Redis’s “open source within Redis” bar: local Autotools build, `make install-hooks`, branch naming (`feat`/`fix`/etc.), clang-format expectations, PR flow against `master`, RLTest/Redis integration test setup, and maintainer/CI review rules.
> 
> No application, build, or runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0d80fc7e9185bf3d6ec9558e8bd5da7abc29ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->