### PR TITLE
chore: bump GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
     steps:
     - name: Checkout Code for ubuntu:bionic
       if: matrix.image == 'ubuntu:bionic'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Checkout Code for other versions
       if: matrix.image != 'ubuntu:bionic'
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
@@ -73,7 +73,7 @@ jobs:
         apt-get install -y git ca-certificates
 
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install build dependencies
       run: |
@@ -99,7 +99,7 @@ jobs:
   build-notls:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
@@ -116,7 +116,7 @@ jobs:
   build-ubuntu-latest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
@@ -136,7 +136,7 @@ jobs:
         platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
@@ -190,7 +190,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     name: Test ${{ matrix.test-config.name }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Download build artifact
       uses: actions/download-artifact@v5
@@ -244,7 +244,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: "StatsD: docker-compose Integration"
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Download build artifact
       uses: actions/download-artifact@v5
@@ -307,7 +307,7 @@ jobs:
   coverage-ubuntu:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
@@ -376,7 +376,7 @@ jobs:
       run: apk add --no-cache git
 
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Install build dependencies
       run: |
@@ -397,7 +397,7 @@ jobs:
     runs-on: macos-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent openssl@${{ matrix.openssl }}
     - name: Build
@@ -413,7 +413,7 @@ jobs:
   build-macos-openssl-1-1:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent openssl@1.1
     - name: Build
@@ -428,7 +428,7 @@ jobs:
   build-macos-openssl-1-0-2:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: brew install autoconf automake libtool libevent pkg-config
     - name: Install openssl v1.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Download build artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: memtier-build-${{ matrix.platform }}
 
@@ -247,7 +247,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Download build artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: memtier-build-ubuntu-22.04
 

--- a/.github/workflows/dockers.yml
+++ b/.github/workflows/dockers.yml
@@ -20,15 +20,15 @@ jobs:
     if: (github.repository == 'redis/memtier_benchmark')
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
         with:
           install: true
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         dist: ${{ fromJSON(vars.BUILD_DISTS) }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         path: repo
     - name: Copy source code to build dir
@@ -104,7 +104,7 @@ jobs:
         exclude: ${{ fromJSON(vars.BUILD_EXCLUDE) }}
     needs: build-source-package
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Determine build architecture
       run: |
           if [ ${{ matrix.arch }} = "i386" ]; then
@@ -147,7 +147,7 @@ jobs:
     - name: Upload as release assets
       # we don't upload on workflow dispatch
       if: github.event_name == 'release'
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         files: |
           *.deb


### PR DESCRIPTION
GitHub is deprecating the **node20** runner for GitHub Actions on **June 16, 2026**. Workflow steps using node20-based action versions will fail after this date.

This PR bumps all affected actions to their latest node24-compatible versions.

> Reviewed by 3 independent agents (opus/sonnet/haiku) before opening.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency version bumps with no changes to build scripts, secrets handling, or application code.
> 
> **Overview**
> Updates **CI**, **Docker publish**, and **APT release** workflows so checkout and related steps use **node24-compatible** action major versions before GitHub retires **node20** runners (June 2026).
> 
> In **`ci.yml`**, every **`actions/checkout`** step moves from **v3/v5** to **v6**; integration jobs that pull build artifacts use **`actions/download-artifact@v8`** instead of **v5**. **`dockers.yml`** bumps **`actions/checkout@v6`** and Docker setup/login actions from **v3** to **v4** (build-push stays on **v6**). **`release.yml`** uses **`actions/checkout@v6`** and **`softprops/action-gh-release@v3`** for release asset uploads. A couple of lines are whitespace-only (e.g. macOS **ssl** grep indent, file EOF).
> 
> No application or benchmark code changes—only workflow action pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff1393457db26fa61ff710ead360533875bc778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->