### PR TITLE
feat(miss-tracking): hit/miss ratio columns and miss-rate warnings for arbitrary/monitor commands

### DIFF
--- a/command_meta.h
+++ b/command_meta.h
@@ -91,5 +91,25 @@ const CommandSpec *lookup(const char *name);
 // Number of commands compiled into the static table.
 size_t count();
 
+inline const char *reply_shape_name(ReplyShape shape)
+{
+    switch (shape) {
+    case ReplyShape::NotMissable:
+        return "NotMissable";
+    case ReplyShape::SingleNullBulk:
+        return "SingleNullBulk";
+    case ReplyShape::ArrayPerElementNulls:
+        return "ArrayPerElementNulls";
+    case ReplyShape::EmptyCollection:
+        return "EmptyCollection";
+    case ReplyShape::IntegerMembership:
+        return "IntegerMembership";
+    case ReplyShape::Unknown:
+        return "Unknown";
+    default:
+        return "?";
+    }
+}
+
 } // namespace command_meta
 } // namespace memtier

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -72,7 +72,9 @@
 
 #endif
 
+#include <cmath>
 #include <cstring>
+#include <set>
 #include <stdexcept>
 #include <atomic>
 #include <algorithm>
@@ -587,6 +589,7 @@ static void config_init_defaults(struct benchmark_config *cfg)
     if (!cfg->hdr_prefix) cfg->hdr_prefix = "";
     if (!cfg->print_percentiles.is_defined()) cfg->print_percentiles = config_quantiles("50,99,99.9");
     if (!cfg->monitor_pattern) cfg->monitor_pattern = 'S';
+    if (cfg->miss_rate_threshold < 0.0) cfg->miss_rate_threshold = 0.01; // Default: warn above 1%
 
     // StatsD defaults - port only matters if host is set
     if (!cfg->statsd_port) cfg->statsd_port = 8125;
@@ -720,6 +723,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_monitor_pattern,
         o_command_stats_breakdown,
         o_command_miss_tracking,
+        o_miss_rate_threshold,
         o_tls,
         o_tls_cert,
         o_tls_key,
@@ -829,6 +833,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         {"monitor-pattern", 1, 0, o_monitor_pattern},
         {"command-stats-breakdown", 1, 0, o_command_stats_breakdown},
         {"command-miss-tracking", 1, 0, o_command_miss_tracking},
+        {"miss-rate-threshold", 1, 0, o_miss_rate_threshold},
         {"rate-limiting", 1, 0, o_rate_limiting},
         {"uri", 1, 0, o_uri},
         {"statsd-host", 1, 0, o_statsd_host},
@@ -1404,6 +1409,16 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
             }
             break;
         }
+        case o_miss_rate_threshold: {
+            endptr = NULL;
+            double pct = strtod(optarg, &endptr);
+            if (endptr == optarg || !endptr || *endptr != '\0' || !std::isfinite(pct) || pct < 0.0 || pct > 100.0) {
+                fprintf(stderr, "error: --miss-rate-threshold must be a percentage between 0 and 100.\n");
+                return -1;
+            }
+            cfg->miss_rate_threshold = pct / 100.0;
+            break;
+        }
         case o_rate_limiting: {
             endptr = NULL;
             cfg->request_rate = (unsigned int) strtoul(optarg, &endptr, 10);
@@ -1671,6 +1686,9 @@ void usage()
         "HGET, HMGET, GETEX, EXISTS, ...)\n"
         "                                 off:  disable; mb.json will not contain per-arbitrary-command "
         "Hits/Misses fields\n"
+        "      --miss-rate-threshold=PERCENTAGE\n"
+        "                                 Warn when miss rate exceeds this percentage (default: 1.0).\n"
+        "                                 Accepts fractional values, e.g. 0.5 for half a percent.\n"
         "      --statsd-host=HOST         StatsD server hostname to send real-time metrics (default: none, disabled)\n"
         "      --statsd-port=PORT         StatsD server UDP port (default: 8125)\n"
         "      --statsd-prefix=PREFIX     Prefix for StatsD metric names (default: memtier)\n"
@@ -2693,6 +2711,7 @@ int main(int argc, char *argv[])
     // 0 must remain a valid user-specified "disabled" value, so initialize the
     // sentinel before parsing args.
     cfg.max_retries = -1;
+    cfg.miss_rate_threshold = -1.0;   // sentinel; config_init_defaults replaces with 0.01
     cfg.command_miss_tracking = true; // Default: auto-track misses for known shapes
 
     if (config_parse_args(argc, argv, &cfg) < 0) {
@@ -2709,6 +2728,11 @@ int main(int argc, char *argv[])
 
         if (!cfg.monitor_commands->load_from_file(cfg.monitor_input)) {
             exit(1);
+        }
+
+        if (cfg.arbitrary_commands->size() == 0) {
+            fprintf(stderr, "warning: --monitor-input specified but no --command was given; "
+                            "the monitor file will be ignored and a standard SET/GET benchmark will run.\n");
         }
 
         // Expand monitor placeholders in commands
@@ -2738,6 +2762,28 @@ int main(int argc, char *argv[])
                     // Mark it as a stats-only slot (no actual command to send)
                     stats_cmd.command_args.clear();
                     stats_cmd.stats_only = true;
+                    // resolve_command_meta() returns early for empty argv, so look up
+                    // spec directly and stamp miss_tracking_enabled so runtime hit/miss
+                    // accounting actually fires for this slot.
+                    {
+                        using memtier::command_meta::ReplyShape;
+                        const memtier::command_meta::CommandSpec *cmd_spec =
+                            memtier::command_meta::lookup(cmd_type.c_str());
+                        stats_cmd.spec = cmd_spec;
+                        if (cmd_spec != nullptr) {
+                            switch (cmd_spec->reply_shape) {
+                            case ReplyShape::SingleNullBulk:
+                            case ReplyShape::ArrayPerElementNulls:
+                            case ReplyShape::EmptyCollection:
+                            case ReplyShape::IntegerMembership:
+                                stats_cmd.miss_tracking_enabled = true;
+                                break;
+                            default:
+                                stats_cmd.miss_tracking_enabled = false;
+                                break;
+                            }
+                        }
+                    }
                     cfg.arbitrary_commands->add_command(stats_cmd);
                 }
 
@@ -2835,6 +2881,37 @@ int main(int argc, char *argv[])
     if (!cfg.command_miss_tracking) {
         for (unsigned int i = 0; i < cfg.arbitrary_commands->size(); i++) {
             cfg.arbitrary_commands->at(i).miss_tracking_enabled = false;
+        }
+    }
+
+    // Log resolved command metadata once per unique command type. Gated behind
+    // --debug to avoid startup noise in normal runs.
+    if (cfg.debug && cfg.arbitrary_commands->size() > 0) {
+        std::set<std::string> logged_types;
+        for (size_t i = 0; i < cfg.arbitrary_commands->size(); i++) {
+            const arbitrary_command &cmd = cfg.arbitrary_commands->at(i);
+            if (cmd.command_type == "MONITOR_RANDOM") continue;
+            if (!logged_types.insert(cmd.command_type).second) continue;
+            // stats-only slots (created for __monitor_line@__ expansion) don't go through
+            // resolve_command_meta(), so look up the spec directly from the command type.
+            const memtier::command_meta::CommandSpec *spec =
+                cmd.spec != nullptr ? cmd.spec : memtier::command_meta::lookup(cmd.command_type.c_str());
+            bool miss_tracking = cmd.miss_tracking_enabled;
+            if (cmd.stats_only && spec != nullptr) {
+                using memtier::command_meta::ReplyShape;
+                miss_tracking = cfg.command_miss_tracking && (spec->reply_shape == ReplyShape::SingleNullBulk ||
+                                                              spec->reply_shape == ReplyShape::ArrayPerElementNulls ||
+                                                              spec->reply_shape == ReplyShape::EmptyCollection ||
+                                                              spec->reply_shape == ReplyShape::IntegerMembership);
+            }
+            if (spec != nullptr) {
+                fprintf(stderr, "Command meta: %s reply_shape=%s key_specs=%u miss_tracking=%s\n",
+                        cmd.command_type.c_str(), memtier::command_meta::reply_shape_name(spec->reply_shape),
+                        spec->num_key_specs, miss_tracking ? "enabled" : "disabled");
+            } else {
+                fprintf(stderr, "Command meta: %s not found in static table, miss_tracking=disabled\n",
+                        cmd.command_type.c_str());
+            }
         }
     }
 

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1689,6 +1689,7 @@ void usage()
         "      --miss-rate-threshold=PERCENTAGE\n"
         "                                 Warn when miss rate exceeds this percentage (default: 1.0).\n"
         "                                 Accepts fractional values, e.g. 0.5 for half a percent.\n"
+        "                                 0 warns on any miss.\n"
         "      --statsd-host=HOST         StatsD server hostname to send real-time metrics (default: none, disabled)\n"
         "      --statsd-port=PORT         StatsD server UDP port (default: 8125)\n"
         "      --statsd-prefix=PREFIX     Prefix for StatsD metric names (default: memtier)\n"

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -167,6 +167,7 @@ struct benchmark_config
     char monitor_pattern;
     bool command_stats_by_type; // true = aggregate by command type (default), false = per command line
     bool command_miss_tracking; // true = auto (track misses for known shapes), false = off
+    double miss_rate_threshold; // warn when miss rate exceeds this fraction (default 0.01 = 1%)
     const char *hdr_prefix;
     unsigned int request_rate;
     unsigned int request_per_interval;

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -846,6 +846,16 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
         for (unsigned int j = 0; j < i->m_ar_commands_latency_histograms.size(); j++) {
             hdr_add(m_ar_commands_latency_histograms.at(j), i->m_ar_commands_latency_histograms.at(j));
         }
+
+        // Accumulate per-arbitrary-command hit/miss totals across runs so that
+        // the AVERAGE report shows correct Hits/sec and Misses/sec columns.
+        if (m_arbitrary_misses.size() < i->m_arbitrary_misses.size()) {
+            m_arbitrary_misses.resize(i->m_arbitrary_misses.size());
+        }
+        for (size_t j = 0; j < i->m_arbitrary_misses.size(); ++j) {
+            m_arbitrary_misses[j].total_hits += i->m_arbitrary_misses[j].total_hits;
+            m_arbitrary_misses[j].total_misses += i->m_arbitrary_misses[j].total_misses;
+        }
     }
 
     m_totals.m_set_cmd.aggregate_average(all_stats.size());
@@ -860,6 +870,13 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
     m_totals.m_ask_sec /= all_stats.size();
     m_totals.m_bytes_sec /= all_stats.size();
     m_totals.m_latency /= all_stats.size();
+    // Average the accumulated hit/miss counts
+    if (!all_stats.empty()) {
+        for (size_t j = 0; j < m_arbitrary_misses.size(); ++j) {
+            m_arbitrary_misses[j].total_hits /= all_stats.size();
+            m_arbitrary_misses[j].total_misses /= all_stats.size();
+        }
+    }
 }
 
 void run_stats::merge(const run_stats &other, int iteration)
@@ -1112,6 +1129,9 @@ run_stats::build_aggregated_command_stats(arbitrary_command_list &command_list)
         // Get per-second stats for this command
         std::vector<one_sec_cmd_stats> cmd_per_sec = get_one_sec_cmd_stats_arbitrary_command(i);
 
+        unsigned long long cmd_hits = i < m_arbitrary_misses.size() ? m_arbitrary_misses[i].total_hits : 0;
+        unsigned long long cmd_misses = i < m_arbitrary_misses.size() ? m_arbitrary_misses[i].total_misses : 0;
+
         auto it = type_map.find(cmd_type);
         if (it == type_map.end()) {
             // First command of this type
@@ -1121,12 +1141,16 @@ run_stats::build_aggregated_command_stats(arbitrary_command_list &command_list)
             hdr_add(agg.latency_hist, m_ar_commands_latency_histograms[i]);
             agg.command_indices.push_back(i);
             agg.per_second_stats = cmd_per_sec;
+            agg.total_hits = cmd_hits;
+            agg.total_misses = cmd_misses;
             type_map[cmd_type] = agg;
         } else {
             // Aggregate with existing stats
             it->second.stats.add(m_totals.m_ar_commands[i]);
             hdr_add(it->second.latency_hist, m_ar_commands_latency_histograms[i]);
             it->second.command_indices.push_back(i);
+            it->second.total_hits += cmd_hits;
+            it->second.total_misses += cmd_misses;
             // Merge per-second stats
             for (size_t s = 0; s < cmd_per_sec.size() && s < it->second.per_second_stats.size(); s++) {
                 it->second.per_second_stats[s].merge(cmd_per_sec[s]);
@@ -1232,32 +1256,83 @@ void run_stats::print_ops_sec_column(output_table &table, const std::vector<aggr
 
     table.add_column(column);
 }
-void run_stats::print_hits_sec_column(output_table &table)
+void run_stats::print_hits_sec_column(output_table &table, const std::vector<aggregated_command_type_stats> *aggregated)
 {
     table_el el;
     table_column column(12);
 
     column.elements.push_back(*el.init_str("%12s ", "Hits/sec"));
     column.elements.push_back(*el.init_str("%s", "-------------"));
-    column.elements.push_back(*el.init_str("%12s ", "---"));
-    column.elements.push_back(*el.init_double("%12.2f ", m_totals.m_hits_sec));
-    column.elements.push_back(*el.init_str("%12s ", "---"));
-    column.elements.push_back(*el.init_double("%12.2f ", m_totals.m_hits_sec));
+
+    if (print_arbitrary_commands_results()) {
+        unsigned long int test_duration_usec = ts_diff(m_start_time, m_end_time);
+        unsigned long long total_hits = 0;
+        if (aggregated != nullptr) {
+            for (const auto &agg : *aggregated) {
+                double hits_sec =
+                    test_duration_usec > 0 ? (double) agg.total_hits / (double) test_duration_usec * 1000000.0 : 0.0;
+                column.elements.push_back(*el.init_double("%12.2f ", hits_sec));
+                total_hits += agg.total_hits;
+            }
+        } else {
+            for (size_t i = 0; i < m_arbitrary_misses.size(); i++) {
+                double hits_sec = test_duration_usec > 0 ? (double) m_arbitrary_misses[i].total_hits /
+                                                               (double) test_duration_usec * 1000000.0
+                                                         : 0.0;
+                column.elements.push_back(*el.init_double("%12.2f ", hits_sec));
+                total_hits += m_arbitrary_misses[i].total_hits;
+            }
+        }
+        double total_hits_sec =
+            test_duration_usec > 0 ? (double) total_hits / (double) test_duration_usec * 1000000.0 : 0.0;
+        column.elements.push_back(*el.init_double("%12.2f ", total_hits_sec));
+    } else {
+        column.elements.push_back(*el.init_str("%12s ", "---"));
+        column.elements.push_back(*el.init_double("%12.2f ", m_totals.m_hits_sec));
+        column.elements.push_back(*el.init_str("%12s ", "---"));
+        column.elements.push_back(*el.init_double("%12.2f ", m_totals.m_hits_sec));
+    }
 
     table.add_column(column);
 }
 
-void run_stats::print_missess_sec_column(output_table &table)
+void run_stats::print_missess_sec_column(output_table &table,
+                                         const std::vector<aggregated_command_type_stats> *aggregated)
 {
     table_el el;
     table_column column(12);
 
     column.elements.push_back(*el.init_str("%12s ", "Misses/sec"));
     column.elements.push_back(*el.init_str("%s", "-------------"));
-    column.elements.push_back(*el.init_str("%12s ", "---"));
-    column.elements.push_back(*el.init_double("%12.2f ", m_totals.m_misses_sec));
-    column.elements.push_back(*el.init_str("%12s ", "---"));
-    column.elements.push_back(*el.init_double("%12.2f ", m_totals.m_misses_sec));
+
+    if (print_arbitrary_commands_results()) {
+        unsigned long int test_duration_usec = ts_diff(m_start_time, m_end_time);
+        unsigned long long total_misses = 0;
+        if (aggregated != nullptr) {
+            for (const auto &agg : *aggregated) {
+                double misses_sec =
+                    test_duration_usec > 0 ? (double) agg.total_misses / (double) test_duration_usec * 1000000.0 : 0.0;
+                column.elements.push_back(*el.init_double("%12.2f ", misses_sec));
+                total_misses += agg.total_misses;
+            }
+        } else {
+            for (size_t i = 0; i < m_arbitrary_misses.size(); i++) {
+                double misses_sec = test_duration_usec > 0 ? (double) m_arbitrary_misses[i].total_misses /
+                                                                 (double) test_duration_usec * 1000000.0
+                                                           : 0.0;
+                column.elements.push_back(*el.init_double("%12.2f ", misses_sec));
+                total_misses += m_arbitrary_misses[i].total_misses;
+            }
+        }
+        double total_misses_sec =
+            test_duration_usec > 0 ? (double) total_misses / (double) test_duration_usec * 1000000.0 : 0.0;
+        column.elements.push_back(*el.init_double("%12.2f ", total_misses_sec));
+    } else {
+        column.elements.push_back(*el.init_str("%12s ", "---"));
+        column.elements.push_back(*el.init_double("%12.2f ", m_totals.m_misses_sec));
+        column.elements.push_back(*el.init_str("%12s ", "---"));
+        column.elements.push_back(*el.init_double("%12.2f ", m_totals.m_misses_sec));
+    }
 
     table.add_column(column);
 }
@@ -1617,7 +1692,24 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
                              quantiles_list, m_wait_latency_histogram, timestamps, wait_stats);
     }
     std::vector<one_sec_cmd_stats> total_stats = get_one_sec_cmd_stats_totals();
-    result_print_to_json(jsonhandler, "Totals", m_totals.m_ops_sec, m_totals.m_hits_sec, m_totals.m_misses_sec,
+    // For arbitrary-command runs, m_totals.m_hits_sec / m_misses_sec are always 0
+    // (summarize() only reads GET hit counters). Compute the correct aggregate from
+    // m_arbitrary_misses so JSON Totals matches the text table Totals row.
+    double totals_hits_sec = m_totals.m_hits_sec;
+    double totals_misses_sec = m_totals.m_misses_sec;
+    if (print_arbitrary_commands_results()) {
+        unsigned long int dur_usec = ts_diff(m_start_time, m_end_time);
+        if (dur_usec > 0) {
+            unsigned long long all_hits = 0, all_misses = 0;
+            for (size_t j = 0; j < m_arbitrary_misses.size(); ++j) {
+                all_hits += m_arbitrary_misses[j].total_hits;
+                all_misses += m_arbitrary_misses[j].total_misses;
+            }
+            totals_hits_sec = (double) all_hits / (double) dur_usec * 1000000.0;
+            totals_misses_sec = (double) all_misses / (double) dur_usec * 1000000.0;
+        }
+    }
+    result_print_to_json(jsonhandler, "Totals", m_totals.m_ops_sec, totals_hits_sec, totals_misses_sec,
                          cluster_mode ? m_totals.m_moved_sec : -1, cluster_mode ? m_totals.m_ask_sec : -1,
                          m_totals.m_bytes_sec, m_totals.m_bytes_sec_rx, m_totals.m_bytes_sec_tx, m_totals.m_latency,
                          m_totals.m_total_latency, m_totals.m_ops, m_totals.m_connection_errors_sec,
@@ -1776,15 +1868,11 @@ void run_stats::print(FILE *out, benchmark_config *config, const char *header /*
     // Ops/sec column
     print_ops_sec_column(table, aggregated_ptr);
 
-    // Hits/sec column (not relevant for arbitrary commands)
-    if (!print_arbitrary_commands_results()) {
-        print_hits_sec_column(table);
-    }
+    // Hits/sec column
+    print_hits_sec_column(table, aggregated_ptr);
 
-    // Misses/sec column (not relevant for arbitrary commands)
-    if (!print_arbitrary_commands_results()) {
-        print_missess_sec_column(table);
-    }
+    // Misses/sec column
+    print_missess_sec_column(table, aggregated_ptr);
 
     // Moved & ASK column (relevant only for cluster mode)
     if (config->cluster_mode) {
@@ -1811,6 +1899,47 @@ void run_stats::print(FILE *out, benchmark_config *config, const char *header /*
 
     // print results
     table.print(out, header);
+
+    // Warn when miss rate exceeds the configured threshold. Goes to stderr
+    // so it doesn't corrupt piped / redirected table output.
+    const double miss_threshold = config->miss_rate_threshold;
+    if (print_arbitrary_commands_results()) {
+        if (aggregated_ptr != nullptr) {
+            for (const auto &agg : *aggregated_ptr) {
+                unsigned long long total = agg.total_hits + agg.total_misses;
+                if (total == 0) continue;
+                double miss_rate = (double) agg.total_misses / (double) total;
+                if (miss_rate > miss_threshold) {
+                    fprintf(stderr, "warning: %s miss rate %.2f%% above target %.2f%% (%llu misses / %llu ops)\n",
+                            agg.command_type.c_str(), miss_rate * 100.0, miss_threshold * 100.0, agg.total_misses,
+                            total);
+                }
+            }
+        } else {
+            for (size_t i = 0; i < m_arbitrary_misses.size(); i++) {
+                const arbitrary_misses_total &am = m_arbitrary_misses[i];
+                unsigned long long total = am.total_hits + am.total_misses;
+                if (total == 0) continue;
+                double miss_rate = (double) am.total_misses / (double) total;
+                if (miss_rate > miss_threshold) {
+                    const char *cmd_name = i < config->arbitrary_commands->size()
+                                               ? config->arbitrary_commands->at(i).command_type.c_str()
+                                               : "unknown";
+                    fprintf(stderr, "warning: %s miss rate %.2f%% above target %.2f%% (%llu misses / %llu ops)\n",
+                            cmd_name, miss_rate * 100.0, miss_threshold * 100.0, am.total_misses, total);
+                }
+            }
+        }
+    } else {
+        unsigned long long total = m_totals.m_hits + m_totals.m_misses;
+        if (total > 0) {
+            double miss_rate = (double) m_totals.m_misses / (double) total;
+            if (miss_rate > miss_threshold) {
+                fprintf(stderr, "warning: GET miss rate %.2f%% above target %.2f%% (%lu misses / %llu ops)\n",
+                        miss_rate * 100.0, miss_threshold * 100.0, m_totals.m_misses, total);
+            }
+        }
+    }
 
     ////////////////////////////////////////
     // JSON print handling

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -830,6 +830,8 @@ bool one_second_stats_predicate(const one_second_stats &a, const one_second_stat
 
 void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
 {
+    unsigned long long total_duration_usec = 0;
+
     for (std::vector<run_stats>::const_iterator i = all_stats.begin(); i != all_stats.end(); i++) {
         totals i_totals;
         i_totals.setup_arbitrary_commands(m_totals.m_ar_commands.size());
@@ -856,6 +858,8 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
             m_arbitrary_misses[j].total_hits += i->m_arbitrary_misses[j].total_hits;
             m_arbitrary_misses[j].total_misses += i->m_arbitrary_misses[j].total_misses;
         }
+
+        total_duration_usec += ts_diff(i->m_start_time, i->m_end_time);
     }
 
     m_totals.m_set_cmd.aggregate_average(all_stats.size());
@@ -876,6 +880,17 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
             m_arbitrary_misses[j].total_hits /= all_stats.size();
             m_arbitrary_misses[j].total_misses /= all_stats.size();
         }
+    }
+
+    // Set a synthetic duration so ts_diff(m_start_time, m_end_time) returns the
+    // average run duration. Without this, print_hits_sec_column and print_json see
+    // a zero duration and suppress Hits/sec / Misses/sec in the AVERAGE report.
+    if (!all_stats.empty() && total_duration_usec > 0) {
+        unsigned long long avg_usec = total_duration_usec / all_stats.size();
+        m_start_time.tv_sec = 0;
+        m_start_time.tv_usec = 0;
+        m_end_time.tv_sec = (time_t) (avg_usec / 1000000);
+        m_end_time.tv_usec = (suseconds_t) (avg_usec % 1000000);
     }
 }
 

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -888,27 +888,21 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
     m_totals.m_ask_sec /= all_stats.size();
     m_totals.m_bytes_sec /= all_stats.size();
     m_totals.m_latency /= all_stats.size();
-    // Average the accumulated hit/miss counts (totals and per-key buckets)
-    if (!all_stats.empty()) {
-        for (size_t j = 0; j < m_arbitrary_misses.size(); ++j) {
-            m_arbitrary_misses[j].total_hits /= all_stats.size();
-            m_arbitrary_misses[j].total_misses /= all_stats.size();
-            for (size_t k = 0; k < m_arbitrary_misses[j].per_key_hits.size(); ++k) {
-                m_arbitrary_misses[j].per_key_hits[k] /= all_stats.size();
-                m_arbitrary_misses[j].per_key_misses[k] /= all_stats.size();
-            }
-        }
-    }
 
-    // Set a synthetic duration so ts_diff(m_start_time, m_end_time) returns the
-    // average run duration. Without this, print_hits_sec_column and print_json see
-    // a zero duration and suppress Hits/sec / Misses/sec in the AVERAGE report.
+    // m_arbitrary_misses now holds the SUMMED hit/miss counts across all runs,
+    // and the synthetic duration below is the SUMMED run duration. The rate the
+    // print paths compute, count / ts_diff(m_start_time, m_end_time), is then the
+    // exact time-weighted average Σhits / Σduration — mathematically equal to
+    // dividing both the count and the duration by N, but without the integer
+    // truncation that dividing the unsigned counts by N would introduce (which
+    // could otherwise zero out small miss counts and suppress the miss-rate
+    // warning). Counts are left summed deliberately: the JSON "Per-Key Misses"
+    // section reports cumulative Total Hits/Misses across the runs.
     if (!all_stats.empty() && total_duration_usec > 0) {
-        unsigned long long avg_usec = total_duration_usec / all_stats.size();
         m_start_time.tv_sec = 0;
         m_start_time.tv_usec = 0;
-        m_end_time.tv_sec = (time_t) (avg_usec / 1000000);
-        m_end_time.tv_usec = (suseconds_t) (avg_usec % 1000000);
+        m_end_time.tv_sec = (time_t) (total_duration_usec / 1000000);
+        m_end_time.tv_usec = (suseconds_t) (total_duration_usec % 1000000);
     }
 }
 

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -857,6 +857,20 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
         for (size_t j = 0; j < i->m_arbitrary_misses.size(); ++j) {
             m_arbitrary_misses[j].total_hits += i->m_arbitrary_misses[j].total_hits;
             m_arbitrary_misses[j].total_misses += i->m_arbitrary_misses[j].total_misses;
+            // Accumulate per-key buckets too, so the AVERAGE report's
+            // "Per-Key Misses" JSON section is populated like BEST/WORST.
+            const std::vector<unsigned long long> &src_hits = i->m_arbitrary_misses[j].per_key_hits;
+            if (!src_hits.empty()) {
+                arbitrary_misses_total &dst = m_arbitrary_misses[j];
+                if (dst.per_key_hits.size() < src_hits.size()) {
+                    dst.per_key_hits.resize(src_hits.size(), 0);
+                    dst.per_key_misses.resize(src_hits.size(), 0);
+                }
+                for (size_t k = 0; k < src_hits.size(); ++k) {
+                    dst.per_key_hits[k] += src_hits[k];
+                    dst.per_key_misses[k] += i->m_arbitrary_misses[j].per_key_misses[k];
+                }
+            }
         }
 
         total_duration_usec += ts_diff(i->m_start_time, i->m_end_time);
@@ -874,11 +888,15 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
     m_totals.m_ask_sec /= all_stats.size();
     m_totals.m_bytes_sec /= all_stats.size();
     m_totals.m_latency /= all_stats.size();
-    // Average the accumulated hit/miss counts
+    // Average the accumulated hit/miss counts (totals and per-key buckets)
     if (!all_stats.empty()) {
         for (size_t j = 0; j < m_arbitrary_misses.size(); ++j) {
             m_arbitrary_misses[j].total_hits /= all_stats.size();
             m_arbitrary_misses[j].total_misses /= all_stats.size();
+            for (size_t k = 0; k < m_arbitrary_misses[j].per_key_hits.size(); ++k) {
+                m_arbitrary_misses[j].per_key_hits[k] /= all_stats.size();
+                m_arbitrary_misses[j].per_key_misses[k] /= all_stats.size();
+            }
         }
     }
 
@@ -1290,12 +1308,15 @@ void run_stats::print_hits_sec_column(output_table &table, const std::vector<agg
                 total_hits += agg.total_hits;
             }
         } else {
-            for (size_t i = 0; i < m_arbitrary_misses.size(); i++) {
-                double hits_sec = test_duration_usec > 0 ? (double) m_arbitrary_misses[i].total_hits /
-                                                               (double) test_duration_usec * 1000000.0
-                                                         : 0.0;
+            // Iterate the same row count as the other per-line columns
+            // (Type/Ops/sec use m_ar_commands.size()) so the table stays aligned
+            // even if m_arbitrary_misses ever diverges in size.
+            for (size_t i = 0; i < m_totals.m_ar_commands.size(); i++) {
+                unsigned long long hits = i < m_arbitrary_misses.size() ? m_arbitrary_misses[i].total_hits : 0;
+                double hits_sec =
+                    test_duration_usec > 0 ? (double) hits / (double) test_duration_usec * 1000000.0 : 0.0;
                 column.elements.push_back(*el.init_double("%12.2f ", hits_sec));
-                total_hits += m_arbitrary_misses[i].total_hits;
+                total_hits += hits;
             }
         }
         double total_hits_sec =
@@ -1331,12 +1352,14 @@ void run_stats::print_missess_sec_column(output_table &table,
                 total_misses += agg.total_misses;
             }
         } else {
-            for (size_t i = 0; i < m_arbitrary_misses.size(); i++) {
-                double misses_sec = test_duration_usec > 0 ? (double) m_arbitrary_misses[i].total_misses /
-                                                                 (double) test_duration_usec * 1000000.0
-                                                           : 0.0;
+            // Iterate the same row count as the other per-line columns so the
+            // table stays aligned even if m_arbitrary_misses ever diverges.
+            for (size_t i = 0; i < m_totals.m_ar_commands.size(); i++) {
+                unsigned long long misses = i < m_arbitrary_misses.size() ? m_arbitrary_misses[i].total_misses : 0;
+                double misses_sec =
+                    test_duration_usec > 0 ? (double) misses / (double) test_duration_usec * 1000000.0 : 0.0;
                 column.elements.push_back(*el.init_double("%12.2f ", misses_sec));
-                total_misses += m_arbitrary_misses[i].total_misses;
+                total_misses += misses;
             }
         }
         double total_misses_sec =
@@ -1717,6 +1740,12 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
         if (dur_usec > 0) {
             unsigned long long all_hits = 0, all_misses = 0;
             for (size_t j = 0; j < m_arbitrary_misses.size(); ++j) {
+                // Skip the MONITOR_RANDOM placeholder slot to mirror the text /
+                // aggregated Totals path (the placeholder never accrues counts,
+                // but skipping it keeps the two paths provably identical).
+                if (j < command_list.size() && command_list[j].command_type == "MONITOR_RANDOM") {
+                    continue;
+                }
                 all_hits += m_arbitrary_misses[j].total_hits;
                 all_misses += m_arbitrary_misses[j].total_misses;
             }

--- a/run_stats.h
+++ b/run_stats.h
@@ -112,6 +112,9 @@ struct aggregated_command_type_stats
     safe_hdr_histogram latency_hist;                 // merged histogram
     std::vector<size_t> command_indices;             // indices of commands with this type
     std::vector<one_sec_cmd_stats> per_second_stats; // aggregated per-second stats for JSON time series
+    unsigned long long total_hits;
+    unsigned long long total_misses;
+    aggregated_command_type_stats() : total_hits(0), total_misses(0) {}
 };
 
 class run_stats
@@ -270,8 +273,10 @@ public:
                            const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
     void print_ops_sec_column(output_table &table,
                               const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
-    void print_hits_sec_column(output_table &table);
-    void print_missess_sec_column(output_table &table);
+    void print_hits_sec_column(output_table &table,
+                               const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
+    void print_missess_sec_column(output_table &table,
+                                  const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
     void print_moved_sec_column(output_table &table,
                                 const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
     void print_ask_sec_column(output_table &table,

--- a/tests/test_miss_rate_tracking.py
+++ b/tests/test_miss_rate_tracking.py
@@ -1,0 +1,491 @@
+"""
+Integration tests for hit/miss ratio tracking in arbitrary-command and monitor-input modes.
+
+Covers:
+- Hits/sec and Misses/sec columns appear in text output for --command GET
+- MONITOR_RANDOM (__monitor_line@__) miss tracking fires (non-zero Hits/sec in JSON)
+- JSON Totals Hits/sec is non-zero and matches per-type rows for arbitrary runs
+- --run-count > 1 AVERAGE report shows non-zero Hits/sec (aggregate_average fix)
+- --miss-rate-threshold warning fires in stderr when miss rate exceeds threshold
+- --miss-rate-threshold=0 fires for any miss
+- --monitor-input without --command produces a startup warning
+- --miss-rate-threshold invalid values (empty, NaN) are rejected at startup
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+
+from include import (
+    addTLSArgs,
+    add_required_env_arguments,
+    debugPrintMemtierOnError,
+    ensure_clean_benchmark_folder,
+    get_default_memtier_config,
+    MEMTIER_BINARY,
+)
+from mb import Benchmark, RunConfig
+
+
+_KEY_PREFIX = "memtier-miss-"
+_PRELOADED_KEYS = 3
+_KEY_RANGE_MAX = 10
+_REQUESTS = 300
+
+
+def _preload_strings(env):
+    env.flush()
+    conn = env.getConnection()
+    for i in range(1, _PRELOADED_KEYS + 1):
+        conn.set("{}{}".format(_KEY_PREFIX, i), "v{}".format(i))
+
+
+def _run_benchmark(env, extra_args, threads=1, clients=2, requests=_REQUESTS, run_count=1):
+    """Run memtier and return (memtier_ok, stdout_text, stderr_text, json_dict)."""
+    test_dir = tempfile.mkdtemp()
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--hide-histogram",
+        ] + extra_args,
+    }
+    if run_count > 1:
+        benchmark_specs["args"].append("--run-count={}".format(run_count))
+    addTLSArgs(benchmark_specs, env)
+
+    config = get_default_memtier_config(threads=threads, clients=clients, requests=requests)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(config, env)
+
+    stdout_text = ""
+    stderr_text = ""
+    json_dict = {}
+
+    stdout_path = "{}/mb.stdout".format(config.results_dir)
+    if os.path.isfile(stdout_path):
+        with open(stdout_path) as fh:
+            stdout_text = fh.read()
+
+    stderr_path = "{}/mb.stderr".format(config.results_dir)
+    if os.path.isfile(stderr_path):
+        with open(stderr_path) as fh:
+            stderr_text = fh.read()
+
+    json_path = "{}/mb.json".format(config.results_dir)
+    if os.path.isfile(json_path):
+        with open(json_path) as fh:
+            json_dict = json.load(fh)
+
+    return memtier_ok, stdout_text, stderr_text, json_dict
+
+
+def _make_monitor_file(test_dir):
+    """Write a monitor file containing SET and GET commands and return its path."""
+    monitor_file = os.path.join(test_dir, "monitor.txt")
+    with open(monitor_file, "w") as fh:
+        fh.write('[ proxy1 ] 1764031576.604009 [0 127.0.0.1:51682] "SET" "mon-key1" "v1"\n')
+        fh.write('[ proxy2 ] 1764031576.604010 [0 127.0.0.1:51682] "GET" "mon-key1"\n')
+        fh.write('[ proxy3 ] 1764031576.604011 [0 127.0.0.1:51682] "GET" "mon-key2"\n')
+    return monitor_file
+
+
+# ---------------------------------------------------------------------------
+# 1. Hits/sec and Misses/sec columns appear in text output
+# ---------------------------------------------------------------------------
+
+def test_hits_misses_columns_in_text_output(env):
+    """GET --command: Hits/sec and Misses/sec must appear as non-zero table rows."""
+    env.skipOnCluster()
+    _preload_strings(env)
+
+    ok, stdout, _stderr, _js = _run_benchmark(
+        env,
+        [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+        ],
+    )
+    env.assertTrue(ok)
+
+    lines = stdout.splitlines()
+    hits_lines = [l for l in lines if "Hits/sec" in l]
+    misses_lines = [l for l in lines if "Misses/sec" in l]
+
+    env.assertTrue(len(hits_lines) > 0, message="Hits/sec column missing from text output")
+    env.assertTrue(len(misses_lines) > 0, message="Misses/sec column missing from text output")
+
+    # At least one data row (not just the header) should carry a non-zero value.
+    # The header row contains "Hits/sec" as a column label; data rows start with
+    # a command name like "Gets" and end with a numeric Hits/sec value.
+    data_rows_with_hits = [
+        l for l in lines
+        if l.strip() and not l.strip().startswith("Type") and "Hits/sec" not in l
+        and "Gets" in l
+    ]
+    env.assertTrue(
+        len(data_rows_with_hits) > 0,
+        message="Expected a 'Gets' data row in text output",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. JSON Hits/sec is non-zero for arbitrary GET commands
+# ---------------------------------------------------------------------------
+
+def test_json_hits_sec_nonzero_for_arbitrary_get(env):
+    """JSON Gets.Hits/sec must be > 0 when running --command GET with preloaded keys."""
+    env.skipOnCluster()
+    _preload_strings(env)
+
+    ok, _stdout, _stderr, js = _run_benchmark(
+        env,
+        [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+        ],
+    )
+    env.assertTrue(ok)
+
+    all_stats = js.get("ALL STATS", {})
+    gets = all_stats.get("Gets", {})
+    env.assertTrue("Hits/sec" in gets, message="Gets.Hits/sec missing from JSON")
+    env.assertTrue(
+        gets["Hits/sec"] > 0,
+        message="Gets.Hits/sec={} expected > 0 with preloaded keys".format(gets["Hits/sec"]),
+    )
+    env.assertTrue("Misses/sec" in gets, message="Gets.Misses/sec missing from JSON")
+    env.assertTrue(
+        gets["Misses/sec"] > 0,
+        message="Gets.Misses/sec={} expected > 0 (keys 4-10 are unpopulated)".format(
+            gets["Misses/sec"]
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. JSON Totals Hits/sec matches per-type rows (non-zero, not leftover 0)
+# ---------------------------------------------------------------------------
+
+def test_json_totals_hits_sec_consistent(env):
+    """JSON Totals.Hits/sec must equal the sum of per-type Hits/sec (non-zero)."""
+    env.skipOnCluster()
+    _preload_strings(env)
+
+    ok, _stdout, _stderr, js = _run_benchmark(
+        env,
+        [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+        ],
+    )
+    env.assertTrue(ok)
+
+    all_stats = js.get("ALL STATS", {})
+    totals = all_stats.get("Totals", {})
+    gets = all_stats.get("Gets", {})
+
+    env.assertTrue("Hits/sec" in totals, message="Totals.Hits/sec missing from JSON")
+    env.assertTrue(
+        totals["Hits/sec"] > 0,
+        message="Totals.Hits/sec={} expected > 0".format(totals["Hits/sec"]),
+    )
+    # Totals must equal the single command type row (only one command here).
+    env.assertAlmostEqual(
+        totals["Hits/sec"],
+        gets["Hits/sec"],
+        delta=1.0,
+        message="Totals.Hits/sec should approximate Gets.Hits/sec for a single-command run",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. MONITOR_RANDOM (__monitor_line@__) miss tracking fires
+# ---------------------------------------------------------------------------
+
+def test_monitor_random_hits_sec_nonzero(env):
+    """__monitor_line@__ with GET lines: JSON must show non-zero Hits/sec for Gets."""
+    env.skipOnCluster()
+    env.flush()
+    conn = env.getConnection()
+    conn.set("mon-key1", "v1")  # pre-populate one of the monitor GET targets
+
+    test_dir = tempfile.mkdtemp()
+    monitor_file = _make_monitor_file(test_dir)
+
+    ok, _stdout, _stderr, js = _run_benchmark(
+        env,
+        [
+            "--monitor-input={}".format(monitor_file),
+            "--command=__monitor_line@__",
+            "--monitor-pattern=R",
+        ],
+        requests=200,
+    )
+    env.assertTrue(ok)
+
+    all_stats = js.get("ALL STATS", {})
+    # The GET stats slot should carry non-zero Hits/sec because mon-key1 exists.
+    gets = all_stats.get("Gets", {})
+    env.assertTrue(
+        "Hits/sec" in gets,
+        message="Gets.Hits/sec missing from JSON in monitor-random mode",
+    )
+    env.assertTrue(
+        gets["Hits/sec"] >= 0,
+        message="Gets.Hits/sec must not be negative",
+    )
+    # Total Hits/sec in JSON Totals must also be non-negative.
+    totals = all_stats.get("Totals", {})
+    env.assertTrue(
+        totals.get("Hits/sec", -1) >= 0,
+        message="Totals.Hits/sec must not be negative in monitor-random mode",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. --run-count > 1 AVERAGE Hits/sec is non-zero
+# ---------------------------------------------------------------------------
+
+def test_run_count_average_hits_sec_nonzero(env):
+    """With --run-count=2 the AVERAGE report must carry non-zero Hits/sec."""
+    env.skipOnCluster()
+    _preload_strings(env)
+
+    ok, _stdout, _stderr, js = _run_benchmark(
+        env,
+        [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+        ],
+        requests=150,
+        run_count=2,
+    )
+    env.assertTrue(ok)
+
+    avg_stats = js.get("AVERAGE RESULTS", {})
+    if not avg_stats:
+        # Some older JSON layouts nest under ALL STATS; skip gracefully.
+        env.debugPrint("AVERAGE RESULTS section absent; skipping sub-check", True)
+        return
+
+    gets = avg_stats.get("Gets", {})
+    env.assertTrue(
+        "Hits/sec" in gets,
+        message="Gets.Hits/sec missing from AVERAGE RESULTS",
+    )
+    env.assertTrue(
+        gets["Hits/sec"] > 0,
+        message="AVERAGE Gets.Hits/sec={} expected > 0".format(gets["Hits/sec"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. --miss-rate-threshold warning fires when miss rate exceeds threshold
+# ---------------------------------------------------------------------------
+
+def test_miss_rate_threshold_warning_fires(env):
+    """High miss rate (keys 1-3 preloaded, range 1-10): warning must appear in stderr."""
+    env.skipOnCluster()
+    _preload_strings(env)
+
+    ok, _stdout, stderr, _js = _run_benchmark(
+        env,
+        [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+            "--miss-rate-threshold=5",  # 5% — ~70% actual miss rate will far exceed this
+        ],
+    )
+    env.assertTrue(ok)
+    env.assertTrue(
+        "warning" in stderr.lower() and "miss rate" in stderr.lower(),
+        message="Expected miss-rate-threshold warning in stderr; got: {}".format(stderr[:400]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. --miss-rate-threshold=0 fires for any miss
+# ---------------------------------------------------------------------------
+
+def test_miss_rate_threshold_zero_fires_for_any_miss(env):
+    """threshold=0 means warn even for 0.001% miss rate."""
+    env.skipOnCluster()
+    _preload_strings(env)
+
+    ok, _stdout, stderr, _js = _run_benchmark(
+        env,
+        [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+            "--miss-rate-threshold=0",
+        ],
+    )
+    env.assertTrue(ok)
+    env.assertTrue(
+        "warning" in stderr.lower() and "miss rate" in stderr.lower(),
+        message="threshold=0: expected warning for any miss; got: {}".format(stderr[:400]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. --miss-rate-threshold suppressed when miss rate is below threshold
+# ---------------------------------------------------------------------------
+
+def test_miss_rate_threshold_suppressed_below_threshold(env):
+    """When ALL keys exist (100% hit rate), no miss-rate warning should appear."""
+    env.skipOnCluster()
+    env.flush()
+    conn = env.getConnection()
+    # Populate the entire key range so every GET hits.
+    for i in range(1, _KEY_RANGE_MAX + 1):
+        conn.set("{}{}".format(_KEY_PREFIX, i), "v{}".format(i))
+
+    ok, _stdout, stderr, _js = _run_benchmark(
+        env,
+        [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+            "--miss-rate-threshold=1",  # 1% threshold; hit rate is 100%
+        ],
+    )
+    env.assertTrue(ok)
+    # No miss-rate warning expected when all keys are present.
+    has_warning = "miss rate" in stderr.lower() and "warning" in stderr.lower()
+    env.assertFalse(
+        has_warning,
+        message="Unexpected miss-rate warning with 100% hit rate; stderr: {}".format(stderr[:400]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. --monitor-input without --command emits startup warning
+# ---------------------------------------------------------------------------
+
+def test_monitor_input_without_command_warns(env):
+    """Specifying --monitor-input but no --command must emit a warning to stderr."""
+    env.skipOnCluster()
+
+    test_dir = tempfile.mkdtemp()
+    monitor_file = _make_monitor_file(test_dir)
+
+    ok, _stdout, stderr, _js = _run_benchmark(
+        env,
+        [
+            "--monitor-input={}".format(monitor_file),
+            # Intentionally no --command
+        ],
+        requests=50,
+    )
+    # Run may succeed (falls back to normal SET/GET) — we only care about the warning.
+    env.assertTrue(
+        "warning" in stderr.lower() and "monitor" in stderr.lower(),
+        message="Expected monitor-without-command warning; got: {}".format(stderr[:400]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. --miss-rate-threshold rejects invalid values at startup
+# ---------------------------------------------------------------------------
+
+def test_miss_rate_threshold_rejects_empty_string(env):
+    """--miss-rate-threshold= (empty) must be rejected with a non-zero exit code."""
+    env.skipOnCluster()
+
+    result = subprocess.run(
+        [
+            MEMTIER_BINARY,
+            "--server=127.0.0.1",
+            "--port=6379",
+            "--miss-rate-threshold=",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="Expected non-zero exit for empty --miss-rate-threshold",
+    )
+    env.assertTrue(
+        "error" in result.stderr.lower() or "error" in result.stdout.lower(),
+        message="Expected error message for empty threshold; got stderr={}".format(
+            result.stderr[:200]
+        ),
+    )
+
+
+def test_miss_rate_threshold_rejects_nan(env):
+    """--miss-rate-threshold=nan must be rejected with a non-zero exit code."""
+    env.skipOnCluster()
+
+    result = subprocess.run(
+        [
+            MEMTIER_BINARY,
+            "--server=127.0.0.1",
+            "--port=6379",
+            "--miss-rate-threshold=nan",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="Expected non-zero exit for --miss-rate-threshold=nan",
+    )
+    env.assertTrue(
+        "error" in result.stderr.lower() or "error" in result.stdout.lower(),
+        message="Expected error message for nan threshold; got stderr={}".format(
+            result.stderr[:200]
+        ),
+    )
+
+
+def test_miss_rate_threshold_rejects_out_of_range(env):
+    """--miss-rate-threshold=101 (> 100%) must be rejected."""
+    env.skipOnCluster()
+
+    result = subprocess.run(
+        [
+            MEMTIER_BINARY,
+            "--server=127.0.0.1",
+            "--port=6379",
+            "--miss-rate-threshold=101",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="Expected non-zero exit for --miss-rate-threshold=101",
+    )

--- a/tests/test_miss_rate_tracking.py
+++ b/tests/test_miss_rate_tracking.py
@@ -106,7 +106,7 @@ def test_hits_misses_columns_in_text_output(env):
     env.skipOnCluster()
     _preload_strings(env)
 
-    ok, stdout, _stderr, _js = _run_benchmark(
+    ok, stdout, _stderr, js = _run_benchmark(
         env,
         [
             "--command=GET __key__",
@@ -125,18 +125,27 @@ def test_hits_misses_columns_in_text_output(env):
     env.assertTrue(len(hits_lines) > 0, message="Hits/sec column missing from text output")
     env.assertTrue(len(misses_lines) > 0, message="Misses/sec column missing from text output")
 
-    # At least one data row (not just the header) should carry a non-zero value.
-    # The header row contains "Hits/sec" as a column label; data rows start with
-    # a command name like "Gets" and end with a numeric Hits/sec value.
-    data_rows_with_hits = [
+    # Parse the Gets data row. Columns are:
+    # Type | Ops/sec | Hits/sec | Misses/sec | Avg.Latency | ... | KB/sec
+    gets_rows = [
         l for l in lines
-        if l.strip() and not l.strip().startswith("Type") and "Hits/sec" not in l
-        and "Gets" in l
+        if l.strip().startswith("Gets") and "Hits/sec" not in l
     ]
-    env.assertTrue(
-        len(data_rows_with_hits) > 0,
-        message="Expected a 'Gets' data row in text output",
-    )
+    env.assertTrue(len(gets_rows) == 1, message="Expected exactly one 'Gets' data row")
+    fields = gets_rows[0].split()
+    # fields[0]="Gets", fields[1]=Ops/sec, fields[2]=Hits/sec, fields[3]=Misses/sec
+    text_hits_sec = float(fields[2])
+    text_misses_sec = float(fields[3])
+    env.assertTrue(text_hits_sec > 0, message="text Gets Hits/sec={} expected > 0".format(text_hits_sec))
+    env.assertTrue(text_misses_sec > 0, message="text Gets Misses/sec={} expected > 0".format(text_misses_sec))
+
+    # Numeric parity: the text-table Gets Hits/sec must match the JSON value
+    # (same source, same denominator). %.2f text rounding -> small delta.
+    json_gets = js.get("ALL STATS", {}).get("Gets", {})
+    env.assertAlmostEqual(text_hits_sec, json_gets.get("Hits/sec", -1), 1.0,
+                          message="text vs JSON Hits/sec disagree")
+    env.assertAlmostEqual(text_misses_sec, json_gets.get("Misses/sec", -1), 1.0,
+                          message="text vs JSON Misses/sec disagree")
 
 
 # ---------------------------------------------------------------------------
@@ -241,21 +250,25 @@ def test_monitor_random_hits_sec_nonzero(env):
     env.assertTrue(ok)
 
     all_stats = js.get("ALL STATS", {})
-    # The GET stats slot should carry non-zero Hits/sec because mon-key1 exists.
-    gets = all_stats.get("Gets", {})
+    env.assertContains("Gets", all_stats)
+    gets = all_stats["Gets"]
+    env.assertTrue("Hits/sec" in gets, message="Gets.Hits/sec missing in monitor-random mode")
+    # mon-key1 is preloaded and is one of two GET targets, so over 200 requests
+    # with random selection at least one GET hit is statistically certain. A
+    # zero here would mean MONITOR_RANDOM miss tracking is dead (the bug this
+    # whole slot-stamping fix addresses).
     env.assertTrue(
-        "Hits/sec" in gets,
-        message="Gets.Hits/sec missing from JSON in monitor-random mode",
+        gets["Hits/sec"] > 0,
+        message="Gets.Hits/sec={} expected > 0 (mon-key1 preloaded)".format(gets["Hits/sec"]),
     )
+    # JSON Totals must reflect the same non-zero hits.
+    env.assertContains("Totals", all_stats)
+    totals = all_stats["Totals"]
     env.assertTrue(
-        gets["Hits/sec"] >= 0,
-        message="Gets.Hits/sec must not be negative",
-    )
-    # Total Hits/sec in JSON Totals must also be non-negative.
-    totals = all_stats.get("Totals", {})
-    env.assertTrue(
-        totals.get("Hits/sec", -1) >= 0,
-        message="Totals.Hits/sec must not be negative in monitor-random mode",
+        totals.get("Hits/sec", 0) > 0,
+        message="Totals.Hits/sec={} expected > 0 in monitor-random mode".format(
+            totals.get("Hits/sec")
+        ),
     )
 
 
@@ -282,20 +295,31 @@ def test_run_count_average_hits_sec_nonzero(env):
     )
     env.assertTrue(ok)
 
-    avg_stats = js.get("AVERAGE RESULTS", {})
-    if not avg_stats:
-        # Some older JSON layouts nest under ALL STATS; skip gracefully.
-        env.debugPrint("AVERAGE RESULTS section absent; skipping sub-check", True)
-        return
+    # The averaged section header is "AGGREGATED AVERAGE RESULTS (N runs)";
+    # locate it dynamically rather than guessing the run count.
+    avg_keys = [k for k in js if k.startswith("AGGREGATED AVERAGE RESULTS")]
+    env.assertTrue(
+        len(avg_keys) == 1,
+        message="Expected exactly one 'AGGREGATED AVERAGE RESULTS' section; got keys: {}".format(
+            list(js.keys())
+        ),
+    )
+    avg_stats = js[avg_keys[0]]
 
     gets = avg_stats.get("Gets", {})
     env.assertTrue(
         "Hits/sec" in gets,
-        message="Gets.Hits/sec missing from AVERAGE RESULTS",
+        message="Gets.Hits/sec missing from {}".format(avg_keys[0]),
     )
+    # This is the assertion that actually exercises the aggregate_average()
+    # synthetic-duration fix: without it the averaged Hits/sec is 0.0.
     env.assertTrue(
         gets["Hits/sec"] > 0,
         message="AVERAGE Gets.Hits/sec={} expected > 0".format(gets["Hits/sec"]),
+    )
+    env.assertTrue(
+        gets.get("Misses/sec", 0) > 0,
+        message="AVERAGE Gets.Misses/sec={} expected > 0".format(gets.get("Misses/sec")),
     )
 
 


### PR DESCRIPTION
## Summary

- **Hit/Miss columns in text stats table** — `Hits/sec` and `Misses/sec` columns now appear for `--command` and `--monitor-input` modes. Previously suppressed for arbitrary commands.
- **Fix MONITOR_RANDOM stats-only slots** — `spec` / `miss_tracking_enabled` now populated at creation time (direct `command_meta::lookup()`) so runtime `update_arbitrary_op_misses()` fires correctly for `__monitor_line@__` mode.
- **Fix JSON Totals Hits/sec** — in arbitrary-command runs the JSON `Totals` row now sums `m_arbitrary_misses` instead of the always-zero GET-cmd counters, making JSON and text-table Totals consistent.
- **Fix `aggregate_average()` for `--run-count > 1`** — accumulate and average `m_arbitrary_misses` across runs so AVERAGE reports show correct Hits/sec / Misses/sec.
- **`--miss-rate-threshold=PERCENTAGE`** (default 1%) — warns to stderr after each run when any command type's miss rate exceeds the threshold. Zero is a valid value; NaN and empty strings are rejected.
- **Startup warning for `--monitor-input` without `--command`** — warns that the monitor file will be ignored.
- **`Command meta:` startup log** gated behind `--debug`.
- **`reply_shape_name()` helper** added to `command_meta.h`.

## Test plan

- [ ] `--command "GET __key__"` → `Hits/sec` and `Misses/sec` appear in text table
- [ ] `--command "__monitor_line@__"` → Hits/sec non-zero for GET-shaped commands
- [ ] JSON `Totals.Hits/sec` matches text table Totals row
- [ ] `--run-count 3` → AVERAGE Hits/sec is plausible
- [ ] `--miss-rate-threshold=0` → warnings fire for any miss
- [ ] `--monitor-input file` without `--command` → startup warning emitted
- [ ] `--debug --command "GET __key__"` → `Command meta: GET` appears
- [ ] `--miss-rate-threshold=nan` / `--miss-rate-threshold=` are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark stats aggregation, CLI options, and stderr warnings; no auth, persistence, or server protocol changes.
> 
> **Overview**
> This PR improves **hit/miss reporting** for `--command` and `--monitor-input` workloads and adds **configurable miss-rate warnings**.
> 
> **Reporting:** Text tables now show **Hits/sec** and **Misses/sec** for arbitrary commands (not only classic SET/GET). JSON **Totals** hit/miss rates are derived from `m_arbitrary_misses` so they match the text table. With **`--run-count > 1`**, `aggregate_average()` sums arbitrary hit/miss counts and uses a summed duration so **AVERAGE** rows show correct rates (and per-key miss JSON stays populated).
> 
> **Monitor mode:** Stats-only slots created for `__monitor_line@__` / `MONITOR_RANDOM` get `command_meta::lookup()` and `miss_tracking_enabled` from reply shape so monitor-driven GETs actually accrue hits/misses.
> 
> **CLI:** New **`--miss-rate-threshold=PERCENTAGE`** (default **1%**, `0` warns on any miss; invalid/empty/NaN/out-of-range rejected). Stderr warnings when a command type (or GET totals) exceeds the threshold. Warning if **`--monitor-input`** is set without **`--command`**. **`--debug`** logs resolved `reply_shape` / miss tracking per command type; `reply_shape_name()` added in `command_meta.h`.
> 
> **Tests:** New `tests/test_miss_rate_tracking.py` covers columns, JSON totals, monitor random, multi-run average, threshold warnings, and CLI validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d111e0ff98bb0275fcba7e109ac8d04850e8ff0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->