### PR TITLE
ci: parallelize the sanitizer OSS-CLUSTER test cells

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -68,10 +68,10 @@ jobs:
             env: { OSS_STANDALONE: "1", OSS_CLUSTER: "0", TLS: "1", TLS_PROTOCOLS: "TLSv1.3", VERBOSE: "1", ASAN_OPTIONS: "detect_leaks=1" }
             tls: true
           - name: "OSS-CLUSTER API: TCP Plaintext"
-            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", VERBOSE: "1", ASAN_OPTIONS: "detect_leaks=1" }
+            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", VERBOSE: "1", ASAN_OPTIONS: "detect_leaks=1", PARALLELISM: "2" }
             tls: false
           - name: "OSS-CLUSTER API: TCP TLS"
-            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", TLS: "1", VERBOSE: "1", ASAN_OPTIONS: "detect_leaks=1" }
+            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", TLS: "1", VERBOSE: "1", ASAN_OPTIONS: "detect_leaks=1", PARALLELISM: "2" }
             tls: true
     runs-on: ubuntu-latest
     name: ASAN ${{ matrix.test-config.name }}

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -67,7 +67,7 @@ jobs:
             env: { OSS_STANDALONE: "1", OSS_CLUSTER: "0", TLS: "1", VERBOSE: "1" }
             tls: true
           - name: "OSS-CLUSTER API: TCP Plaintext"
-            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", VERBOSE: "1" }
+            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", VERBOSE: "1", PARALLELISM: "2" }
             tls: false
     runs-on: ubuntu-latest
     name: TSAN ${{ matrix.test-config.name }}

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -63,10 +63,10 @@ jobs:
             env: { OSS_STANDALONE: "1", OSS_CLUSTER: "0", TLS: "1", TLS_PROTOCOLS: "TLSv1.3", VERBOSE: "1", UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1" }
             tls: true
           - name: "OSS-CLUSTER API: TCP Plaintext"
-            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", VERBOSE: "1", UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1" }
+            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", VERBOSE: "1", UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1", PARALLELISM: "2" }
             tls: false
           - name: "OSS-CLUSTER API: TCP TLS"
-            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", TLS: "1", VERBOSE: "1", UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1" }
+            env: { OSS_STANDALONE: "0", OSS_CLUSTER: "1", TLS: "1", VERBOSE: "1", UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1", PARALLELISM: "2" }
             tls: true
     runs-on: ubuntu-latest
     name: UBSan ${{ matrix.test-config.name }}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -24,6 +24,10 @@ help() {
 		VERBOSE=1           Print commands
 		LOG_LEVEL=level     RLTest log level (default: debug)
 		TEST_TIMEOUT=n      Test timeout in seconds (default: 300)
+		PARALLELISM=n       Run n tests concurrently (RLTest --parallelism); each
+		                    worker gets its own redis env on a distinct port range.
+		                    Unset = serial. Used to keep the slow sanitizer cluster
+		                    cells under the CI step timeout.
 		RLTEST_VERBOSE=1    Enable RLTest verbose mode
 		RLTEST_DEBUG=1      Enable RLTest debug print
 
@@ -76,6 +80,7 @@ MEMTIER_BINARY=$ROOT/memtier_benchmark
 
 RLTEST_ARGS=" --cluster-start-timeout 180 --oss-redis-path $REDIS_SERVER --enable-debug-command --cluster_node_timeout 15000"
 [[ "$TEST" != "" ]] && RLTEST_ARGS+=" --test $TEST"
+[[ -n "$PARALLELISM" ]] && RLTEST_ARGS+=" --parallelism $PARALLELISM"
 [[ $VERBOSE == 1 ]] && RLTEST_ARGS+=" -v"
 [[ $TLS == 1 ]] && RLTEST_ARGS+=" --tls-cert-file $TLS_CERT --tls-key-file $TLS_KEY --tls-ca-cert-file $TLS_CACERT --tls"
 


### PR DESCRIPTION
## Problem

The slowest CI matrix cell — **ASAN `OSS-CLUSTER API: TCP TLS`** — runs the full test suite under ASAN + a 3-node cluster + TLS, and has crept to the edge of its **15-minute** "Run tests" step timeout as this release added several cluster-heavy test files (mget-cluster, cluster-transaction, transaction-pipeline, monitor-cluster-backpressure, monitor-cluster). On master (`893006e`) it is **already failing** this cell at 15m52s, and the other sanitizer cluster cells are all jammed against the cap.

## Change

Use RLTest's built-in `--parallelism` to run tests concurrently — each worker gets its own redis env on a distinct port range — roughly halving wall-time for the cluster cells:

- **`tests/run_tests.sh`**: append `--parallelism $PARALLELISM` when the `PARALLELISM` env var is set. Unset = serial (unchanged default); documented in the help text.
- **`asan.yml` / `tsan.yml` / `ubsan.yml`**: set `PARALLELISM: "2"` on the **OSS-CLUSTER matrix entries only** (5 cells total). Standalone cells are fast and stay serial, so the extra per-runner resource pressure from concurrent sanitized processes is confined to the cells that need the headroom.

## Why parallelism (Option A) over matrix sharding

`--parallelism` is a one-flag, in-job change with no test-file bookkeeping and no extra runner minutes. `N=2` keeps memory/CPU pressure modest on the 4-core/16 GB `ubuntu-latest` runners (2 concurrent envs). If a cell ever needs more isolation, a matrix `shard` axis is the follow-up.

This **complements** (doesn't replace) keeping individual cluster tests lean.

## Results (measured)

Serial baseline = master `893006e` (this PR's exact base, run serially) vs this PR's parallel run — same tests, only `--parallelism 2` differs:

| Cell | Serial (master) | Parallel (this PR) | Speedup |
|------|----------------:|-------------------:|--------:|
| ASAN cluster Plaintext | 13m17s | **6m55s** | 1.92× |
| ASAN cluster **TLS** | 15m52s ❌ (timeout) | **8m23s** ✅ | 1.89× |
| TSAN cluster Plaintext | 13m48s | **7m18s** | 1.89× |
| UBSan cluster Plaintext | 12m45s | **7m04s** | 1.80× |
| UBSan cluster TLS | 14m37s | **8m01s** | 1.82× |

- Job-total speedup is **~1.8–1.9×**. The *test-execution* phase is closer to a true 2× — each job total still carries ~1.5–2 min of non-parallelizable fixed setup (checkout, artifact download, redis/deps install, TLS cert gen) that doesn't shrink.
- The previously **failing** ASAN OSS-CLUSTER TLS cell (15m52s timeout) now **passes at 8m23s**.
- No new flakiness observed across any of the 5 cluster cells; full run was green (64 pass, 1 skip, 0 fail).

## Test plan

- [x] All sanitizer OSS-CLUSTER cells pass with comfortable margin under the 15-min cap (parallelism effective).
- [x] No new flakiness from concurrent envs (port allocation / resource contention).
- [x] Standalone cells unchanged (serial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)