### PR TITLE
fix(arbitrary-command): heap-allocate split-token buffer to avoid VLA stack overflow

### DIFF
--- a/config_types.cpp
+++ b/config_types.cpp
@@ -517,7 +517,11 @@ bool arbitrary_command::split_command_to_args()
     const char *p = command.c_str();
     size_t command_len = command.length();
 
-    char buffer[command_len];
+    // Heap-allocated scratch buffer; we used to declare `char buffer[command_len]`
+    // here, but with --monitor-input replays this is called per request with
+    // attacker-controlled length, so a multi-MB MONITOR-captured value (e.g.
+    // an HSET storing a gzipped blob) would blow the worker thread's stack.
+    std::vector<char> buffer(command_len);
     unsigned int buffer_len = 0;
 
     while (1) {
@@ -641,7 +645,7 @@ bool arbitrary_command::split_command_to_args()
             }
 
             // add new arg
-            command_arg arg(buffer, buffer_len);
+            command_arg arg(buffer.data(), buffer_len);
             command_args.push_back(arg);
         } else {
             return true;

--- a/tests/test_monitor_input.py
+++ b/tests/test_monitor_input.py
@@ -779,3 +779,83 @@ def test_monitor_input_malformed_command_skipped(env):
             "warning: skipping" in stderr_content.lower()
             or "Loaded" in stderr_content  # At minimum, the file was loaded
         )
+
+
+def test_monitor_input_large_line_no_stack_overflow(env):
+    """
+    Regression test for the VLA stack-overflow in
+    arbitrary_command::split_command_to_args (config_types.cpp).
+
+    Before the fix the function declared `char buffer[command_len]` on the
+    stack and was called per-request from shard_connection::fill_pipeline ->
+    client::create_arbitrary_request. Any MONITOR-replay line larger than
+    the worker thread's stack (default 8-12 MB on Linux) blew the stack the
+    moment the random/sequential picker selected it -> SIGSEGV (or, when
+    glibc's canary caught it first, "*** stack smashing detected ***").
+
+    The fix moves the buffer to the heap (std::vector<char>); this test
+    feeds memtier a single SET line whose value is comfortably larger than
+    the default per-thread stack and asserts memtier completes the run
+    without crashing.
+    """
+    # --monitor-input does not support cluster mode (see other tests).
+    env.skipOnCluster()
+
+    # 16 MiB value: comfortably larger than the typical 8-12 MB Linux
+    # per-thread stack on CI runners and dev boxes, smaller than redis'
+    # default proto-max-bulk-len (512 MB). Pre-fix this crashed
+    # deterministically on the very first request that selected the line.
+    test_dir = tempfile.mkdtemp()
+    monitor_file = os.path.join(test_dir, "monitor_huge.txt")
+    big_value = "A" * (16 * 1024 * 1024)
+    with open(monitor_file, "w") as f:
+        f.write('"SET" "regression_key" "' + big_value + '"\n')
+
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--monitor-input={}".format(monitor_file),
+            "--command=__monitor_line@__",
+            "--hide-histogram",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+
+    # Small request count: 10 SETs of 16 MiB is ~160 MB on loopback - fast
+    # enough for CI, and 10 calls is well past the first one that would have
+    # crashed pre-fix.
+    config = get_default_memtier_config(threads=1, clients=1, requests=10)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+
+    debugPrintMemtierOnError(config, env)
+    env.assertTrue(memtier_ok == True,
+                   message="memtier crashed (likely VLA stack overflow regression) "
+                           "while replaying a large --monitor-input line")
+    # Sanity: stderr must not carry the canary message.
+    with open("{0}/mb.stderr".format(config.results_dir)) as stderr:
+        stderr_content = stderr.read()
+        env.assertFalse("stack smashing detected" in stderr_content,
+                        message="glibc stack canary tripped: {}".format(
+                            stderr_content[-500:]))
+
+    # Sanity: the value made it to the server.
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+    found = False
+    for master_connection in master_nodes_connections:
+        try:
+            result = master_connection.execute_command("STRLEN", "regression_key")
+        except Exception:
+            continue
+        if result == len(big_value):
+            found = True
+            break
+    env.assertTrue(found,
+                   message="SET with 16 MiB value did not land in redis "
+                           "- memtier may have crashed before sending it")


### PR DESCRIPTION
Fixes #404

## TL;DR

\`arbitrary_command::split_command_to_args()\` at \`config_types.cpp:520\` was declaring \`char buffer[command_len]\` on the stack. With \`--monitor-input\` replays the function is called **per request** from worker threads, so any captured MONITOR line larger than the worker's stack (default 8-12 MB on Linux) blew the stack the moment the picker selected it — SIGSEGV or \`*** stack smashing detected ***\`. The crash handler then often re-crashed in \`_dl_fixup\` because the stack was already corrupted, which is why the typical bug report was truncated.

## Reproduction

Real 77 MB MONITOR capture containing one ~20 MB \`HSET\` (gzipped blob in the value):
\`\`\`
memtier_benchmark -s host -p port -t 4 --clients 50 --pipeline 1 \
    --monitor-input=replay.txt --command="__monitor_line@__" --requests=1000
\`\`\`

| stack ulimit | result |
|---|---|
| default (\`ulimit -s 12500\`) | reproduces every run, ~77% in |
| \`ulimit -s 65536\` (> longest line) | clean exit, full workload completes |

Reproduces on current master (\`15dae38\`) and on the 2.3.1 release.

## Crash path

\`\`\`
shard_connection::fill_pipeline           (shard_connection.cpp:1007)
  -> client::create_arbitrary_request        (client.cpp:396)
    -> arbitrary_command::split_command_to_args (config_types.cpp:520)   <- SEGV / canary trip
\`\`\`

## The fix

Replace the VLA with a \`std::vector<char>\` so the scratch buffer lives on the heap and the stack-size dependency is gone. The function runs once per request — one heap allocation per call is a fair trade for removing an attacker-controlled stack allocation.

## Test plan

\`tests/test_monitor_input.py::test_monitor_input_large_line_no_stack_overflow\` generates a single \`"SET" "regression_key" "<16 MiB blob>"\` MONITOR line, runs memtier with \`--monitor-input\` + \`--command="__monitor_line@__"\`, and asserts:
1. \`memtier_benchmark\` exits cleanly (no crash, no \`stack smashing detected\` in stderr)
2. \`STRLEN regression_key\` on the server matches the 16 MiB sent value

Locally I verified the test:
- [x] **FAILS** on the pre-fix binary (\`memtier crashed (likely VLA stack overflow regression)\`)
- [x] **PASSES** on the post-fix binary
- [x] \`make format-check\` clean

The test is bounded to standalone (\`env.skipOnCluster()\`) because \`--monitor-input\` doesn't support cluster mode, matching the other tests in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change in per-request argument parsing with a targeted regression test; removes attacker-controlled stack allocation rather than altering auth or data semantics.
> 
> **Overview**
> Fixes a **stack overflow** when replaying large `--monitor-input` lines: `arbitrary_command::split_command_to_args()` no longer uses a variable-length array `char buffer[command_len]` on the worker stack (which could exceed typical 8–12 MB thread stacks for multi‑MB MONITOR values). The token scratch buffer is now a **`std::vector<char>`** on the heap, with `command_arg` built from `buffer.data()`.
> 
> Adds **`test_monitor_input_large_line_no_stack_overflow`**, which replays a single `SET` with a **16 MiB** value via `__monitor_line@__` and checks memtier exits cleanly (no `stack smashing detected`), plus **`STRLEN`** on Redis matches the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4e0fc2f80320f0f945d1387f190623955e6c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->