### PR TITLE
fix(cluster-slots): validate reply shape before indexing, log+skip malformed shards

### DIFF
--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -370,6 +370,13 @@ void cluster_client::handle_cluster_slots(protocol_response *r)
         return;
     }
 
+    // Track whether any shard in the reply passed validation. If every shard
+    // is malformed and we fall through the loop with no `close_sc[j] = false`
+    // anywhere, the close-stale-connections pass below would tear down EVERY
+    // existing connection (including the bootstrap), which contradicts the
+    // documented "bootstrap stays in service" invariant. (Cursor bugbot.)
+    bool any_valid_shard = false;
+
     // run over response and create connections
     for (unsigned int i = 0; i < r->get_mbulk_value()->mbulks_elements.size(); i++) {
         mbulk_element *shard_el = r->get_mbulk_value()->mbulks_elements[i];
@@ -468,8 +475,18 @@ void cluster_client::handle_cluster_slots(protocol_response *r)
             m_slot_to_shard[j] = sc->get_id();
         }
 
+        any_valid_shard = true;
         free(addr);
         free(port);
+    }
+
+    // If every shard in the reply was malformed and skipped, treat the reply
+    // as unusable -- skip the close-stale pass below so we don't disconnect
+    // the bootstrap and any other currently-live connections (cursor bugbot).
+    if (!any_valid_shard) {
+        benchmark_error_log("warning: CLUSTER SLOTS: every shard in the reply was malformed; "
+                            "leaving existing connections in service\n");
+        return;
     }
 
     // check if some connections left with no slots, and need to be closed

--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -350,22 +350,51 @@ void cluster_client::handle_cluster_slots(protocol_response *r)
     unsigned long prev_connections_size = m_connections.size();
     std::vector<bool> close_sc(prev_connections_size, true);
 
+    // Validate the top-level reply shape before walking it. as_mbulk_size()
+    // and as_bulk() both call assert(0) on type mismatch, and bare
+    // mbulks_elements[N] indexing is UB past-end. A malformed CLUSTER SLOTS
+    // reply from a misbehaving / hostile server (#417: fixture
+    // `cluster_slots_malformed.bin` from #409) hit both. Drop malformed
+    // shards instead of crashing; if the entire reply is unusable, the
+    // existing bootstrap connection stays in service.
+    if (r->get_mbulk_value() == NULL) {
+        benchmark_error_log("CLUSTER SLOTS: server returned non-array; ignoring reply\n");
+        return;
+    }
+
     // run over response and create connections
     for (unsigned int i = 0; i < r->get_mbulk_value()->mbulks_elements.size(); i++) {
-        // create connection
-        mbulk_size_el *shard = r->get_mbulk_value()->mbulks_elements[i]->as_mbulk_size();
+        mbulk_element *shard_el = r->get_mbulk_value()->mbulks_elements[i];
+        if (shard_el == NULL || !shard_el->is_mbulk_size()) {
+            benchmark_error_log("CLUSTER SLOTS: shard %u not an array; skipping\n", i);
+            continue;
+        }
+        mbulk_size_el *shard = shard_el->as_mbulk_size();
+        if (shard->mbulks_elements.size() < 3 || !shard->mbulks_elements[0]->is_bulk() ||
+            !shard->mbulks_elements[1]->is_bulk() || !shard->mbulks_elements[2]->is_mbulk_size()) {
+            benchmark_error_log("CLUSTER SLOTS: shard %u malformed (need [start, end, [host, port, ...]]); skipping\n",
+                                i);
+            continue;
+        }
 
         int min_slot = strtol(shard->mbulks_elements[0]->as_bulk()->value + 1, NULL, 10);
         int max_slot = strtol(shard->mbulks_elements[1]->as_bulk()->value + 1, NULL, 10);
 
+        mbulk_size_el *node = shard->mbulks_elements[2]->as_mbulk_size();
+        if (node->mbulks_elements.size() < 2 || !node->mbulks_elements[0]->is_bulk() ||
+            !node->mbulks_elements[1]->is_bulk()) {
+            benchmark_error_log("CLUSTER SLOTS: shard %u node tuple malformed (need host, port); skipping\n", i);
+            continue;
+        }
+
         // hostname/ip
-        bulk_el *mbulk_addr_el = shard->mbulks_elements[2]->as_mbulk_size()->mbulks_elements[0]->as_bulk();
+        bulk_el *mbulk_addr_el = node->mbulks_elements[0]->as_bulk();
         char *addr = (char *) malloc(mbulk_addr_el->value_len + 1);
         memcpy(addr, mbulk_addr_el->value, mbulk_addr_el->value_len);
         addr[mbulk_addr_el->value_len] = '\0';
 
         // port
-        bulk_el *mbulk_port_el = shard->mbulks_elements[2]->as_mbulk_size()->mbulks_elements[1]->as_bulk();
+        bulk_el *mbulk_port_el = node->mbulks_elements[1]->as_bulk();
         char *port = (char *) malloc(mbulk_port_el->value_len + 1);
         memcpy(port, mbulk_port_el->value + 1, mbulk_port_el->value_len);
         port[mbulk_port_el->value_len] = '\0';

--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -358,7 +358,15 @@ void cluster_client::handle_cluster_slots(protocol_response *r)
     // shards instead of crashing; if the entire reply is unusable, the
     // existing bootstrap connection stays in service.
     if (r->get_mbulk_value() == NULL) {
-        benchmark_error_log("CLUSTER SLOTS: server returned non-array; ignoring reply\n");
+        benchmark_error_log("warning: CLUSTER SLOTS: server returned non-array; ignoring reply\n");
+        return;
+    }
+
+    // A *valid* zero-shard reply would silently retire every existing
+    // connection (the close_sc[] loop further down). That's worse than
+    // crashing -- the benchmark continues with no shards. Reject it.
+    if (r->get_mbulk_value()->mbulks_elements.size() == 0) {
+        benchmark_error_log("warning: CLUSTER SLOTS: server returned empty topology; ignoring reply\n");
         return;
     }
 
@@ -366,35 +374,65 @@ void cluster_client::handle_cluster_slots(protocol_response *r)
     for (unsigned int i = 0; i < r->get_mbulk_value()->mbulks_elements.size(); i++) {
         mbulk_element *shard_el = r->get_mbulk_value()->mbulks_elements[i];
         if (shard_el == NULL || !shard_el->is_mbulk_size()) {
-            benchmark_error_log("CLUSTER SLOTS: shard %u not an array; skipping\n", i);
+            benchmark_error_log("warning: CLUSTER SLOTS: shard %u not an array; skipping\n", i);
             continue;
         }
         mbulk_size_el *shard = shard_el->as_mbulk_size();
         if (shard->mbulks_elements.size() < 3 || !shard->mbulks_elements[0]->is_bulk() ||
             !shard->mbulks_elements[1]->is_bulk() || !shard->mbulks_elements[2]->is_mbulk_size()) {
-            benchmark_error_log("CLUSTER SLOTS: shard %u malformed (need [start, end, [host, port, ...]]); skipping\n",
-                                i);
+            benchmark_error_log(
+                "warning: CLUSTER SLOTS: shard %u malformed (need [start, end, [host, port, ...]]); skipping\n", i);
             continue;
         }
 
-        int min_slot = strtol(shard->mbulks_elements[0]->as_bulk()->value + 1, NULL, 10);
-        int max_slot = strtol(shard->mbulks_elements[1]->as_bulk()->value + 1, NULL, 10);
+        // Slot bounds: must be parseable, in [0, MAX_CLUSTER_HSLOT], and
+        // min <= max. The old code took the strtol result verbatim and
+        // wrote into m_slot_to_shard[min..max] -- a hostile server could
+        // make us write past the end of the 16384-sized array (OOB write).
+        bulk_el *min_el = shard->mbulks_elements[0]->as_bulk();
+        bulk_el *max_el = shard->mbulks_elements[1]->as_bulk();
+        if (min_el->value_len == 0 || max_el->value_len == 0) {
+            benchmark_error_log("warning: CLUSTER SLOTS: shard %u empty slot bound; skipping\n", i);
+            continue;
+        }
+        errno = 0;
+        long parsed_min = strtol(min_el->value + 1, NULL, 10);
+        long parsed_max = strtol(max_el->value + 1, NULL, 10);
+        if (errno == ERANGE || parsed_min < 0 || parsed_max < 0 || parsed_min > MAX_CLUSTER_HSLOT ||
+            parsed_max > MAX_CLUSTER_HSLOT || parsed_min > parsed_max) {
+            benchmark_error_log("warning: CLUSTER SLOTS: shard %u slot range [%ld, %ld] out of [0, %d]; skipping\n", i,
+                                parsed_min, parsed_max, MAX_CLUSTER_HSLOT);
+            continue;
+        }
+        int min_slot = (int) parsed_min;
+        int max_slot = (int) parsed_max;
 
         mbulk_size_el *node = shard->mbulks_elements[2]->as_mbulk_size();
         if (node->mbulks_elements.size() < 2 || !node->mbulks_elements[0]->is_bulk() ||
             !node->mbulks_elements[1]->is_bulk()) {
-            benchmark_error_log("CLUSTER SLOTS: shard %u node tuple malformed (need host, port); skipping\n", i);
+            benchmark_error_log("warning: CLUSTER SLOTS: shard %u node tuple malformed (need host, port); skipping\n",
+                                i);
             continue;
         }
 
-        // hostname/ip
+        // hostname/ip + port: reject zero-length bulks (memcpy(..., NULL+1, 0)
+        // is technically UB; embedded NULs would also alias other addrs in
+        // strcmp-based lookup).
         bulk_el *mbulk_addr_el = node->mbulks_elements[0]->as_bulk();
+        bulk_el *mbulk_port_el = node->mbulks_elements[1]->as_bulk();
+        if (mbulk_addr_el->value_len == 0 || mbulk_port_el->value_len == 0) {
+            benchmark_error_log("warning: CLUSTER SLOTS: shard %u empty host/port; skipping\n", i);
+            continue;
+        }
+        if (memchr(mbulk_addr_el->value, '\0', mbulk_addr_el->value_len) != NULL) {
+            benchmark_error_log("warning: CLUSTER SLOTS: shard %u host contains NUL; skipping\n", i);
+            continue;
+        }
+
         char *addr = (char *) malloc(mbulk_addr_el->value_len + 1);
         memcpy(addr, mbulk_addr_el->value, mbulk_addr_el->value_len);
         addr[mbulk_addr_el->value_len] = '\0';
 
-        // port
-        bulk_el *mbulk_port_el = node->mbulks_elements[1]->as_bulk();
         char *port = (char *) malloc(mbulk_port_el->value_len + 1);
         memcpy(port, mbulk_port_el->value + 1, mbulk_port_el->value_len);
         port[mbulk_port_el->value_len] = '\0';


### PR DESCRIPTION
Fixes #417

`cluster_client::handle_cluster_slots()` walked the `CLUSTER SLOTS` reply with bare `mbulks_elements[N]` indexing and `as_bulk()` / `as_mbulk_size()` casts that `assert(0)` on type mismatch. A malformed reply from a hostile or buggy server crashed memtier with SIGSEGV — captured by the RESP-fuzzer fixture `tests/fixtures/resp_payloads/cluster_slots_malformed.bin` introduced in PR #419 (which is `env.skip()`'d with a `TODO(#417)` until this lands).

## Repro

```
*1\r\n*1\r\n+notanint\r\n
```

i.e. an outer 1-element array containing an inner 1-element array whose only element is a simple-string. Old code did `shard->mbulks_elements[1]` past the inner-array's only element → out-of-bounds read → SEGV.

## Fix

Validate before indexing:
- top-level `get_mbulk_value()` is non-null
- each shard element passes `is_mbulk_size()`
- shard has ≥ 3 children (start, end, [host, port, ...])
- elements 0 and 1 (slot bounds) pass `is_bulk()`
- element 2 (node tuple) passes `is_mbulk_size()` and has ≥ 2 `is_bulk()` children (host, port)

Any malformed shard logs a `benchmark_error_log` and is skipped — the existing bootstrap connection stays in service. If the whole reply is non-array, log and return without touching topology.

## Test plan

- [x] Builds clean (default + ASAN); `make format-check` clean.
- [ ] Once merged: drop the `env.skip()` + `TODO(#417)` from `tests/test_resp_response_fuzzer.py::test_cluster_slots_malformed`. That test now exercises the validation path. (Follow-up PR.)
- [ ] Full CI matrix on this PR — to be confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster topology parsing and connection lifecycle on refresh; validation reduces crash/OOB risk but alters behavior when servers return bad or empty slot maps.
> 
> **Overview**
> **Hardens `cluster_client::handle_cluster_slots()`** so memtier no longer crashes or corrupts memory on a bad `CLUSTER SLOTS` RESP reply (fixes #417).
> 
> Before walking shards, the handler now requires a non-empty top-level array and validates each shard’s shape (`[start, end, [host, port, …]]`) with `is_*` checks instead of unchecked `as_bulk()` / `as_mbulk_size()` (which could `assert` or read past the end). **Slot bounds** are parsed with `strtol`, checked for `ERANGE`, and clamped to `[0, MAX_CLUSTER_HSLOT]` with `min <= max` so `m_slot_to_shard` cannot be written out of bounds. **Host/port** bulks must be non-empty; hosts with embedded NULs are rejected.
> 
> Malformed shards are **logged and skipped**; wholly bad replies (non-array, empty topology, or every shard invalid) are ignored so existing connections—including bootstrap—stay up instead of tearing down all shards via `close_sc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721fc26a43dac930dd18fb3f33760889da74bc89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->