### PR TITLE
fix(opts): validate --command / --command-ratio at parse time (Refs #426 phase 2c)

### DIFF
--- a/config_types.cpp
+++ b/config_types.cpp
@@ -503,12 +503,31 @@ bool arbitrary_command::set_key_pattern(const char *pattern_str)
 
 bool arbitrary_command::set_ratio(const char *ratio_str)
 {
-    char *q = NULL;
-    ratio = strtoul(ratio_str, &q, 10);
-    if (!q || *q != '\0') {
+    // Reject empty / null / whitespace-only / negative input. strtoul()
+    // silently accepts the empty string (returns 0) and wraps negatives to
+    // a huge unsigned value, both of which lead to a worker loop that never
+    // picks this command and hangs forever (issue #426 item 14).
+    if (ratio_str == NULL || *ratio_str == '\0') {
+        return false;
+    }
+    const char *first = ratio_str;
+    while (*first && isspace((unsigned char) *first)) {
+        first++;
+    }
+    if (*first == '\0' || *first == '-' || *first == '+') {
         return false;
     }
 
+    char *q = NULL;
+    unsigned long parsed = strtoul(ratio_str, &q, 10);
+    if (!q || *q != '\0') {
+        return false;
+    }
+    if (parsed == 0) {
+        return false;
+    }
+
+    ratio = (unsigned int) parsed;
     return true;
 }
 

--- a/config_types.cpp
+++ b/config_types.cpp
@@ -519,11 +519,17 @@ bool arbitrary_command::set_ratio(const char *ratio_str)
     }
 
     char *q = NULL;
+    errno = 0;
     unsigned long parsed = strtoul(ratio_str, &q, 10);
     if (!q || *q != '\0') {
         return false;
     }
-    if (parsed == 0) {
+    // ERANGE catches the strtoul overflow case; the narrow-to-unsigned-int
+    // check catches values above UINT_MAX that strtoul accepted on a 64-bit
+    // unsigned long without ERANGE (e.g. "4294967296" on x86_64). Without
+    // either guard a too-large value silently truncates and a wrap-to-0
+    // value re-introduces the very hang we're guarding against.
+    if (errno == ERANGE || parsed == 0 || parsed > UINT_MAX) {
         return false;
     }
 

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -742,15 +742,19 @@ static bool verify_cluster_option(struct benchmark_config *cfg)
 // the user gets a readable error instead of SIGABRT.
 static bool first_arg_is_placeholder(const std::string &token)
 {
-    if (token == KEY_PLACEHOLDER || token == DATA_PLACEHOLDER || token == SCAN_CURSOR_PLACEHOLDER ||
-        token == MONITOR_RANDOM_PLACEHOLDER) {
+    // The runtime assert in protocol.cpp ("first arg is not command name?")
+    // fires on substring containment via memmem(), not exact equality, so
+    // a literal like `FOO__key__` or `setkey__key__` still SIGABRTs without
+    // this guard. Mirror the same substring contract here at parse time so
+    // the user gets a readable error instead of an abort.
+    if (token.find(KEY_PLACEHOLDER) != std::string::npos || token.find(DATA_PLACEHOLDER) != std::string::npos ||
+        token.find(SCAN_CURSOR_PLACEHOLDER) != std::string::npos ||
+        token.find(MONITOR_RANDOM_PLACEHOLDER) != std::string::npos) {
         return true;
     }
-    // __monitor_lineN__ (any digits / @) - the placeholder prefix is the
-    // recognised marker. The whole-command monitor placeholder path is
-    // handled separately upstream; here we just guard against it leaking
-    // into the first-arg slot of a regular --command.
-    if (token.compare(0, strlen(MONITOR_PLACEHOLDER_PREFIX), MONITOR_PLACEHOLDER_PREFIX) == 0) {
+    // __monitor_lineN__ (any digits / @) -- the placeholder prefix is the
+    // recognised marker; same substring rule.
+    if (token.find(MONITOR_PLACEHOLDER_PREFIX) != std::string::npos) {
         return true;
     }
     return false;

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -734,6 +734,28 @@ static bool verify_cluster_option(struct benchmark_config *cfg)
     return true;
 }
 
+// Returns true when `token` is one of the placeholder tokens that
+// arbitrary-command parsing recognises (__key__, __data__, __monitor_line*__,
+// __scan_cursor__). The first argv of --command must be a literal command
+// name; allowing a placeholder there is what triggers the runtime assert in
+// protocol.cpp ("first arg is not command name?"). We check at parse time so
+// the user gets a readable error instead of SIGABRT.
+static bool first_arg_is_placeholder(const std::string &token)
+{
+    if (token == KEY_PLACEHOLDER || token == DATA_PLACEHOLDER || token == SCAN_CURSOR_PLACEHOLDER ||
+        token == MONITOR_RANDOM_PLACEHOLDER) {
+        return true;
+    }
+    // __monitor_lineN__ (any digits / @) - the placeholder prefix is the
+    // recognised marker. The whole-command monitor placeholder path is
+    // handled separately upstream; here we just guard against it leaking
+    // into the first-arg slot of a regular --command.
+    if (token.compare(0, strlen(MONITOR_PLACEHOLDER_PREFIX), MONITOR_PLACEHOLDER_PREFIX) == 0) {
+        return true;
+    }
+    return false;
+}
+
 static bool verify_arbitrary_command_option(struct benchmark_config *cfg)
 {
     if (cfg->key_pattern) {
@@ -1420,6 +1442,27 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                 // Regular arbitrary command
                 arbitrary_command cmd(cmd_str);
                 if (cmd.split_command_to_args()) {
+                    // Parse-time validation: split_command_to_args() returns
+                    // true even on an empty or whitespace-only string (it
+                    // simply emits zero argv tokens). Without this guard
+                    // --command '' parses as a 0-arg command and the worker
+                    // loop spins forever (issue #426 item 13).
+                    if (cmd.command_args.empty()) {
+                        fprintf(stderr, "error: --command requires a non-empty command string.\n");
+                        return -1;
+                    }
+                    // The first argv must be a literal command name. A
+                    // placeholder there (e.g. --command __key__) trips the
+                    // assert in protocol.cpp:774 at runtime; reject it at
+                    // parse time so the user gets a readable error instead
+                    // of SIGABRT (issue #426 item 12).
+                    if (first_arg_is_placeholder(cmd.command_args[0].data)) {
+                        fprintf(stderr,
+                                "error: --command first token must be a literal command name, not the "
+                                "placeholder '%s'.\n",
+                                cmd.command_args[0].data.c_str());
+                        return -1;
+                    }
                     // Resolve key positions and reply shape from the static
                     // command_meta registry (vendored Redis commands.json).
                     // Memcached / module / unknown commands return spec=null
@@ -1457,7 +1500,12 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
             // command configuration always applied on last configured command
             arbitrary_command &cmd = cfg->arbitrary_commands->get_last_command();
             if (!cmd.set_ratio(optarg)) {
-                fprintf(stderr, "error: failed to set ratio for command %s.\n", cmd.command_name.c_str());
+                // set_ratio() rejects empty / negative / non-integer / zero
+                // input. Zero is the most user-confusing case (the worker
+                // loop spins forever picking nothing — issue #426 item 14)
+                // so call it out explicitly.
+                fprintf(stderr, "error: --command-ratio must be a positive integer (got '%s') for command %s.\n",
+                        optarg ? optarg : "", cmd.command_name.c_str());
                 return -1;
             }
             break;

--- a/tests/test_cli_validation_command.py
+++ b/tests/test_cli_validation_command.py
@@ -1,0 +1,190 @@
+"""
+Regression tests for `--command` and `--command-ratio` parse-time validation.
+
+Covers items 12, 13 and 14 from issue #426 (CLI-fuzz follow-ups, Phase 2c):
+
+  12. `--command __key__` (bare placeholder, no command name) used to trip the
+      runtime assert at protocol.cpp:774 ("first arg is not command name?")
+      and SIGABRT. We now reject at parse time with a readable error.
+
+  13. `--command ''` parsed as a zero-arg command, then the worker loop spun
+      forever picking nothing. We now reject the empty / whitespace-only
+      command at parse time.
+
+  14. `--command-ratio 0` (also empty / whitespace / negative) made strtoul()
+      return 0 (or wrap to UINT_MAX for negatives), the ratio sampler then
+      never picked the command and the run hung. We now require a positive
+      integer at parse time.
+
+These tests exercise the argument-parsing path only and don't need a live
+Redis - we invoke the binary with `subprocess`, expect a non-zero exit and a
+clear error message in stderr. The valid case (`--command-ratio 1`) is run
+against the test fixture's Redis to confirm the happy path still completes.
+
+Run with:
+  TEST=test_cli_validation_command.py OSS_STANDALONE=1 ./tests/run_tests.sh
+"""
+import subprocess
+import tempfile
+
+from include import (
+    MEMTIER_BINARY,
+    add_required_env_arguments,
+    addTLSArgs,
+    debugPrintMemtierOnError,
+    ensure_clean_benchmark_folder,
+    get_default_memtier_config,
+)
+from mb import Benchmark, RunConfig
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _run_memtier(args, timeout=10):
+    """Run memtier_benchmark with *args* and return the CompletedProcess.
+
+    A timeout guards against regressions - if the parse-time validation is
+    ever removed the binary would re-enter the hang/spin path and we want
+    the test to fail loudly rather than block the suite.
+    """
+    return subprocess.run(
+        [MEMTIER_BINARY] + args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _build_benchmark(env, test_dir, extra_args, threads=1, clients=1,
+                     requests=100):
+    """Return (Benchmark, RunConfig) for an arbitrary workload."""
+    config = get_default_memtier_config(threads=threads, clients=clients,
+                                        requests=requests)
+    benchmark_specs = {"name": env.testName, "args": list(extra_args)}
+    addTLSArgs(benchmark_specs, env)
+    add_required_env_arguments(benchmark_specs, config, env,
+                               env.getMasterNodesList())
+    run_config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(run_config.results_dir)
+    return Benchmark.from_json(run_config, benchmark_specs), run_config
+
+
+# ---------------------------------------------------------------------------
+# CLI rejection tests
+# ---------------------------------------------------------------------------
+
+def test_command_first_arg_placeholder_rejected(env):
+    """`--command __key__` must be rejected before reaching the assert path.
+
+    Item 12 from #426: a bare placeholder as the command name used to SIGABRT
+    inside protocol.cpp::format_arbitrary_command at the
+    "first arg is not command name?" assert.
+    """
+    master = env.getMasterNodesList()[0]
+    result = _run_memtier([
+        "-s", "127.0.0.1",
+        "-p", str(master["port"]),
+        "--command", "__key__",
+        "--test-time=1",
+    ])
+
+    env.assertNotEqual(
+        result.returncode, 0,
+        message="--command __key__ must exit non-zero",
+    )
+    env.assertTrue(
+        "first token must be a literal command name" in result.stderr,
+        message="Expected literal-command-name rejection in stderr; "
+                "got: {!r}".format(result.stderr),
+    )
+    env.assertTrue(
+        "__key__" in result.stderr,
+        message="Expected offending placeholder in stderr; "
+                "got: {!r}".format(result.stderr),
+    )
+
+
+def test_command_empty_string_rejected(env):
+    """`--command ''` must be rejected before entering the worker loop.
+
+    Item 13 from #426: an empty command parsed as zero argv tokens and the
+    benchmark hung forever ignoring --test-time.
+    """
+    master = env.getMasterNodesList()[0]
+    result = _run_memtier([
+        "-s", "127.0.0.1",
+        "-p", str(master["port"]),
+        "--command", "",
+        "--test-time=1",
+    ])
+
+    env.assertNotEqual(
+        result.returncode, 0,
+        message="--command '' must exit non-zero",
+    )
+    env.assertTrue(
+        "--command requires a non-empty command string" in result.stderr,
+        message="Expected non-empty-command rejection in stderr; "
+                "got: {!r}".format(result.stderr),
+    )
+
+
+def test_command_ratio_zero_rejected(env):
+    """`--command-ratio 0` must be rejected at parse time.
+
+    Item 14 from #426: a zero ratio made the worker pick nothing and the run
+    hung; the previous error message ("failed to set ratio") also didn't make
+    the bound clear.
+    """
+    master = env.getMasterNodesList()[0]
+    result = _run_memtier([
+        "-s", "127.0.0.1",
+        "-p", str(master["port"]),
+        "--command", "SET __key__ __data__",
+        "--command-ratio", "0",
+        "--test-time=1",
+    ])
+
+    env.assertNotEqual(
+        result.returncode, 0,
+        message="--command-ratio 0 must exit non-zero",
+    )
+    env.assertTrue(
+        "--command-ratio must be a positive integer" in result.stderr,
+        message="Expected positive-integer message in stderr; "
+                "got: {!r}".format(result.stderr),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path regression
+# ---------------------------------------------------------------------------
+
+def test_command_ratio_one_succeeds(env):
+    """`--command-ratio 1` must still parse and run end-to-end.
+
+    Sanity check that the tightened set_ratio() (now rejects 0 / empty /
+    negative) doesn't break the documented default-equivalent value.
+    """
+    test_dir = tempfile.mkdtemp()
+
+    benchmark, run_config = _build_benchmark(
+        env, test_dir,
+        extra_args=[
+            "--command", "SET __key__ __data__",
+            "--command-ratio", "1",
+            "--command-key-pattern", "R",
+        ],
+        threads=1,
+        clients=1,
+        requests=50,
+    )
+
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(run_config, env)
+    env.assertTrue(
+        memtier_ok,
+        message="Benchmark must complete cleanly with --command-ratio 1",
+    )


### PR DESCRIPTION
## Summary

Three CLI-fuzz reproducers from #426 share the same root cause: missing
parse-time validation lets bad `--command` / `--command-ratio` input
through into the worker loop where it either trips a runtime assert or
hangs forever ignoring `--test-time`. This PR moves the checks to the
argument-parsing path so the user gets a readable error and exit 2
instead of a crash or unbounded hang.

- `--command __key__` (and other bare placeholders) is rejected at parse
  time instead of SIGABRTing inside `protocol.cpp::format_arbitrary_command`
  at the `first arg is not command name?` assert.
- `--command ''` (or whitespace-only) is rejected; previously
  `split_command_to_args()` returned true with zero argv tokens and the
  worker loop spun forever.
- `--command-ratio 0` (also empty / whitespace / negative) is rejected;
  `set_ratio()` is tightened so `strtoul("")==0` and negative wrap-around
  no longer slip through.

Monitor-placeholder commands (handled via the existing
`MONITOR_PLACEHOLDER_PREFIX` branch in `o_command`) are unaffected. The
existing `test_arbitrary_command_misses` / `test_monitor_input` /
`test_scan` suites still pass.

## Items closed (from #426)

- 12. `--command __key__` SIGABRT at `protocol.cpp:774`
- 13. `--command ''` hangs
- 14. `--command-ratio 0` hangs (also empty / whitespace / negative)

## Test plan

- [x] Manual repro of items 12, 13, 14 against the unfixed binary
  (SIGABRT / hang) and the fixed binary (clean exit 2 with readable
  stderr).
- [x] New regression tests in `tests/test_cli_validation_command.py`
  (4 cases: items 12, 13, 14 plus a happy-path `--command-ratio 1`
  end-to-end run); each guarded by a subprocess timeout so a future
  regression that re-introduces the hang fails the test loudly.
- [x] `make format-check` clean.
- [x] `make` clean.
- [x] Adjacent suites still green:
  `test_arbitrary_command_misses` (12/12), `test_monitor_input` (11/11),
  `test_scan` (15/15).

Refs #426

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only validation and stricter ratio parsing; monitor-placeholder `--command` paths are unchanged, with new subprocess tests guarding regressions.
> 
> **Overview**
> Adds **parse-time validation** for `--command` and `--command-ratio` so bad CLI input fails with readable stderr instead of **SIGABRT** or an **infinite worker hang** (issue #426 items 12–14).
> 
> For **`--command`**, empty or whitespace-only strings are rejected after parsing (zero argv tokens). The **first token** must be a real command name: placeholders such as `__key__`, `__data__`, `__scan_cursor__`, and monitor markers are detected with the same **substring rules** as `protocol.cpp`, so values like `FOO__key__` are caught too.
> 
> For **`--command-ratio`**, `set_ratio()` now rejects null/empty/whitespace, signs, non-integers, **zero**, `ERANGE` overflow, and values above **`UINT_MAX`** before they can truncate or wrap and starve the ratio sampler.
> 
> New regression tests in `tests/test_cli_validation_command.py` cover the three rejection cases plus a happy-path run with `--command-ratio 1` (subprocess timeouts guard against reintroduced hangs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b1898eb275cf5286841d21240053362842f503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->