### PR TITLE
fix(opts): validate --run-count (Refs #426 phase 2a)

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -90,6 +90,15 @@
 
 int log_level = 0;
 
+// Upper bound for --run-count.  main() allocates several per-run vectors
+// (run_stats, cmd_stats histograms, HDR histograms) that grow linearly with
+// run_count; values in the tens of thousands push tens of MiB of metadata
+// before a single op has been sent, and INT_MAX trivially OOMs the allocator
+// (issue #426).  1024 covers every realistic benchmarking use case (the
+// default is 1) while keeping pre-run allocations comfortably under 100 MiB
+// even on memory-constrained hosts.
+#define MAX_RUN_COUNT 1024
+
 // Global flag for signal handling
 static volatile sig_atomic_t g_interrupted = 0;
 
@@ -1034,14 +1043,32 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         case o_client_stats:
             cfg->client_stats = optarg;
             break;
-        case 'x':
+        case 'x': {
+            // Parse via signed strtol so negative values do not silently wrap
+            // through the unsigned cast (e.g. -1 -> ~4.3B -> vector::reserve
+            // throwing std::bad_alloc).  Also cap at MAX_RUN_COUNT because the
+            // aggregated best/worst/average path in main() allocates several
+            // per-run vectors of run_stats / cmd_stats that grow linearly with
+            // run_count; values in the hundreds of millions are not a useful
+            // benchmark configuration and just OOM the allocator.
             endptr = NULL;
-            cfg->run_count = (unsigned int) strtoul(optarg, &endptr, 10);
-            if (!cfg->run_count || !endptr || *endptr != '\0') {
+            errno = 0;
+            long parsed_run_count = strtol(optarg, &endptr, 10);
+            if (optarg[0] == '\0' || !endptr || *endptr != '\0' || errno == ERANGE) {
+                fprintf(stderr, "error: run count must be a positive integer.\n");
+                return -1;
+            }
+            if (parsed_run_count <= 0) {
                 fprintf(stderr, "error: run count must be greater than zero.\n");
                 return -1;
             }
+            if (parsed_run_count > MAX_RUN_COUNT) {
+                fprintf(stderr, "error: run count must be <= %d (got %ld).\n", MAX_RUN_COUNT, parsed_run_count);
+                return -1;
+            }
+            cfg->run_count = (unsigned int) parsed_run_count;
             break;
+        }
         case 'D':
             cfg->debug++;
             break;

--- a/tests/test_cli_validation_run_count.py
+++ b/tests/test_cli_validation_run_count.py
@@ -1,0 +1,179 @@
+"""
+CLI validation regression tests for --run-count.
+
+Closes items 4 and 5 from issue #426 (phase 2a):
+
+  4. ``memtier_benchmark --run-count -1`` previously triggered SIGABRT with
+     ``std::bad_alloc`` because the negative value silently wrapped through
+     the unsigned cast (-1 -> ~4.3B), which the per-run vectors then tried
+     to reserve.
+
+  5. ``memtier_benchmark --run-count 2147483647`` (INT_MAX) previously
+     triggered SIGABRT with ``std::bad_alloc`` because no upper bound was
+     enforced and the allocator OOM'd while reserving the per-run
+     bookkeeping vectors.
+
+After the fix, both inputs must be rejected at parse time with a non-zero
+exit code and a readable error on stderr.  A reasonable valid value (2)
+must still run normally end-to-end.
+
+The CLI rejection cases (1-3 below) only exercise the argument-parsing
+path and do not need a live Redis connection.  The happy-path case (4)
+runs against the RLTest-provided server.
+
+Run with:
+  TEST=test_cli_validation_run_count.py OSS_STANDALONE=1 ./tests/run_tests.sh
+"""
+import json
+import os
+import subprocess
+import tempfile
+
+from include import (
+    MEMTIER_BINARY,
+    add_required_env_arguments,
+    addTLSArgs,
+    debugPrintMemtierOnError,
+    ensure_clean_benchmark_folder,
+    get_default_memtier_config,
+)
+from mb import Benchmark, RunConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_memtier(args):
+    """Run memtier_benchmark with *args* and return the CompletedProcess.
+
+    No --server is supplied: validation must reject the bad --run-count
+    value before any connection attempt is made.
+    """
+    return subprocess.run(
+        [MEMTIER_BINARY] + args,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. --run-count=-1  (issue #426 item 4)
+# ---------------------------------------------------------------------------
+
+def test_run_count_negative_rejected(env):
+    """``--run-count=-1`` must be rejected (was SIGABRT std::bad_alloc)."""
+    result = _run_memtier(["--run-count=-1"])
+
+    env.assertNotEqual(
+        result.returncode, 0,
+        message="--run-count=-1 must exit non-zero (was SIGABRT std::bad_alloc)",
+    )
+    env.assertTrue(
+        "run count must be greater than zero" in result.stderr,
+        message=(
+            "Expected 'run count must be greater than zero' in stderr, "
+            "got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. --run-count=0
+# ---------------------------------------------------------------------------
+
+def test_run_count_zero_rejected(env):
+    """``--run-count=0`` must be rejected with a clear error."""
+    result = _run_memtier(["--run-count=0"])
+
+    env.assertNotEqual(
+        result.returncode, 0,
+        message="--run-count=0 must exit non-zero",
+    )
+    env.assertTrue(
+        "run count must be greater than zero" in result.stderr,
+        message=(
+            "Expected 'run count must be greater than zero' in stderr, "
+            "got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. --run-count=INT_MAX  (issue #426 item 5)
+# ---------------------------------------------------------------------------
+
+def test_run_count_int_max_rejected(env):
+    """``--run-count=2147483647`` must be rejected (was SIGABRT std::bad_alloc)."""
+    result = _run_memtier(["--run-count=2147483647"])
+
+    env.assertNotEqual(
+        result.returncode, 0,
+        message="--run-count=2147483647 must exit non-zero (was SIGABRT std::bad_alloc)",
+    )
+    env.assertTrue(
+        "run count must be <=" in result.stderr,
+        message=(
+            "Expected upper-bound rejection ('run count must be <= ...') in stderr, "
+            "got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. --run-count=2  happy path
+# ---------------------------------------------------------------------------
+
+def test_run_count_valid_runs_normally(env):
+    """``--run-count=2`` must run end-to-end without error."""
+    env.skipOnCluster()
+
+    test_dir = tempfile.mkdtemp()
+    config = get_default_memtier_config(threads=1, clients=1, requests=20)
+    benchmark_specs = {
+        "name": env.testName,
+        "args": ["--run-count=2"],
+    }
+    addTLSArgs(benchmark_specs, env)
+    add_required_env_arguments(
+        benchmark_specs, config, env, env.getMasterNodesList()
+    )
+
+    run_config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(run_config.results_dir)
+    benchmark = Benchmark.from_json(run_config, benchmark_specs)
+
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(run_config, env)
+    env.assertTrue(
+        memtier_ok,
+        message="--run-count=2 (a valid value) must complete successfully",
+    )
+
+    json_filename = os.path.join(run_config.results_dir, "mb.json")
+    env.assertTrue(
+        os.path.isfile(json_filename),
+        message="Expected mb.json to be produced for valid --run-count run",
+    )
+
+    with open(json_filename) as f:
+        results = json.load(f)
+
+    # With run_count > 1 the report emits BEST/WORST/AGGREGATED sections.
+    # Their presence confirms run_count was honored (not silently coerced
+    # to 1 by the fix).
+    env.assertTrue(
+        "BEST RUN RESULTS" in results,
+        message=(
+            "Expected 'BEST RUN RESULTS' section in mb.json with --run-count=2; "
+            "top-level keys: {}".format(sorted(results.keys()))
+        ),
+    )
+    env.assertTrue(
+        "WORST RUN RESULTS" in results,
+        message=(
+            "Expected 'WORST RUN RESULTS' section in mb.json with --run-count=2; "
+            "top-level keys: {}".format(sorted(results.keys()))
+        ),
+    )


### PR DESCRIPTION
## Summary
- `--run-count=-1` and `--run-count=2147483647` previously triggered SIGABRT (`std::bad_alloc`): the parser cast straight to `unsigned int` (so `-1` wrapped to ~4.3B) and had no upper bound, so the per-run vectors allocated in `main()` blew up the allocator before any work started.
- The parser now reads via signed `strtol`, rejects empty/non-numeric input, rejects zero/negative, and caps at `MAX_RUN_COUNT = 1024` (default is 1; the cap keeps per-run bookkeeping well under ~100 MiB even on memory-constrained hosts and covers every realistic benchmarking use case).
- Each rejection prints a readable error to stderr and bubbles through the existing `-1 -> usage() -> exit(2)` path, matching the style of every other option-parsing error in `memtier_benchmark.cpp`.

## Items closed from #426
- Item 4: `--run-count -1` -> SIGABRT, `std::bad_alloc`
- Item 5: `--run-count 2147483647` (INT_MAX) -> SIGABRT, `std::bad_alloc`

The `tests/cli_fuzz.py` strategy exclusion for `--run-count` is intentionally left in place; flipping it back on is the follow-up tracked in #426.

## Test plan
New regression coverage in `tests/test_cli_validation_run_count.py` (RLTest-compatible, mirrors `tests/test_monitor_input.py` and `tests/test_mget_validation.py`):

- [x] `--run-count=-1` -> non-zero exit, stderr contains `run count must be greater than zero`
- [x] `--run-count=0` -> non-zero exit, stderr contains `run count must be greater than zero`
- [x] `--run-count=2147483647` -> non-zero exit, stderr contains `run count must be <=`
- [x] `--run-count=2` -> end-to-end run, `mb.json` contains `BEST RUN RESULTS` and `WORST RUN RESULTS` sections

Run:
```
TEST=test_cli_validation_run_count.py OSS_STANDALONE=1 ./tests/run_tests.sh
# Total Tests Run: 4, Total Tests Failed: 0, Total Tests Passed: 4
```

Also verified:
- `make -j` clean build on the changed file.
- `make format-check` clean on the changed file (`clang-format --dry-run --Werror memtier_benchmark.cpp` exits 0).
- Pre-commit hook (`make format-check-staged`) passed on commit.

Refs #426

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only validation before benchmark startup; no change to runtime benchmarking logic beyond rejecting previously dangerous inputs.
> 
> **Overview**
> **`--run-count` is validated at CLI parse time** so invalid values no longer crash the process with `std::bad_alloc` before benchmarking starts (issue #426).
> 
> Parsing now uses signed `strtol` instead of `strtoul`, so **negative values** (e.g. `-1`) are rejected instead of wrapping to a huge `unsigned` and forcing massive per-run vector reservations in `main()`. **Zero, non-numeric input, and overflow** get clear stderr errors. A new **`MAX_RUN_COUNT` (1024)** caps huge values (e.g. `INT_MAX`) that previously OOM’d while reserving run bookkeeping.
> 
> **Regression tests** in `tests/test_cli_validation_run_count.py` cover rejections for `-1`, `0`, and `2147483647`, plus an end-to-end run with `--run-count=2` that checks `BEST`/`WORST` JSON sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66a38de746a199e5dbee184586e04dd507aa941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->