### PR TITLE
fix(connection-stage): bound retry loop with --connection-stage-timeout (Refs #426 phase 1)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ completions_DATA=bash-completion/memtier_benchmark
 memtier_benchmark_CPPFLAGS = \
 	$(CODE_COVERAGE_CFLAGS) \
 	$(LIBEVENT_CFLAGS) \
+	$(LIBEVENT_PTHREADS_CFLAGS) \
 	$(LIBEVENT_OPENSSL_CFLAGS) \
 	$(LIBCRYPTO_CFLAGS) \
 	$(LIBSSL_CFLAGS)
@@ -63,6 +64,7 @@ memtier_benchmark_SOURCES = \
 memtier_benchmark_LDADD = \
 	$(CODE_COVERAGE_LIBS) \
 	$(LIBEVENT_LIBS) \
+	$(LIBEVENT_PTHREADS_LIBS) \
 	$(LIBEVENT_OPENSSL_LIBS) \
 	$(LIBCRYPTO_LIBS) \
 	$(LIBSSL_LIBS)

--- a/bash-completion/memtier_benchmark
+++ b/bash-completion/memtier_benchmark
@@ -28,6 +28,7 @@ _memtier_completions()
                    "--statsd-host" "--statsd-port" "--statsd-prefix" "--statsd-run-label" "--graphite-port"\
                    "--monitor-input" "--hdr-file-prefix"\
                    "--max-reconnect-attempts" "--reconnect-backoff-factor" "--connection-timeout"\
+                   "--connection-stage-timeout"\
                    "--max-retries" "--retry-backoff-ms" "--retry-backoff-factor" "--retry-on"\
                    "--max-retry-queue" "--failed-keys-file"\
                    "--thread-conn-start-min-jitter-micros" "--thread-conn-start-max-jitter-micros"\

--- a/client.cpp
+++ b/client.cpp
@@ -1268,8 +1268,20 @@ void client_group::interrupt(void)
 {
     // Mark all clients as interrupted
     set_all_clients_interrupted();
-    // Break the event loop to stop processing
+    // Break the event loop to stop processing.
+    //
+    // We pair loopbreak() (terminate after the current iteration) with a
+    // loopexit(timeval{0,0}) (schedule an immediate timer that wakes the
+    // poll). Without the loopexit wake-up, a worker that is sitting idle
+    // in epoll_wait() with no live event sources (e.g. a connection that
+    // failed setup but never disconnected) will block forever, so
+    // pthread_join() in the parent hangs indefinitely. This is the same
+    // pattern libevent recommends for terminating an idle loop from
+    // another thread; loopbreak alone is documented to only take effect
+    // *between* iterations.
     event_base_loopbreak(m_base);
+    struct timeval zero = {0, 0};
+    event_base_loopexit(m_base, &zero);
     // Set end time for all clients as close as possible to the loop break
     finalize_all_clients();
 }

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,17 @@ PKG_CHECK_MODULES(LIBEVENT,
     AC_SUBST(LIBEVENT_CFLAGS) AC_SUBST(LIBEVENT_LIBS)
 )
 
+# libevent_pthreads: needed for evthread_use_pthreads(). Without this,
+# event_base_loopbreak() / event_base_loopexit() called from a *different*
+# thread than the one running event_base_dispatch() do not wake the
+# epoll_wait(), so an idle worker hangs after a cross-thread shutdown
+# request (Phase 1 of #426 / Ctrl+C). The pthreads bindings ship as a
+# separate .so since libevent 2.0, so we have to depend on it explicitly.
+PKG_CHECK_MODULES(LIBEVENT_PTHREADS,
+    [libevent_pthreads >= 2.0.10],
+    AC_SUBST(LIBEVENT_PTHREADS_CFLAGS) AC_SUBST(LIBEVENT_PTHREADS_LIBS)
+)
+
 # bash completion
 PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
     [BASH_COMPLETION_DIR="`pkg-config --variable=completionsdir bash-completion`"],

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -51,6 +51,7 @@
 #include <sys/utsname.h>
 #include <dirent.h>
 #include <event2/event.h>
+#include <event2/thread.h>
 
 #ifdef USE_TLS
 #include <openssl/crypto.h>
@@ -93,6 +94,11 @@ int log_level = 0;
 // Global flag for signal handling
 static volatile sig_atomic_t g_interrupted = 0;
 
+// Set when run_benchmark() aborts because --connection-stage-timeout
+// elapsed without any thread reaching steady state. main() reads it after
+// the run loop to decide between exit(0) and exit(2).
+static std::atomic<bool> g_connection_stage_aborted{false};
+
 // Forward declarations
 struct cg_thread;
 static void print_client_list(FILE *fp, int pid, const char *timestr);
@@ -100,6 +106,118 @@ static void print_all_threads_stack_trace(FILE *fp, int pid, const char *timestr
 
 // Global pointer to threads for crash handler access
 static std::vector<cg_thread *> *g_threads = NULL;
+
+// ---------------------------------------------------------------------------
+// Connection-stage supervisor state (declarations in memtier_benchmark.h)
+// ---------------------------------------------------------------------------
+//
+// Worker threads call report_connection_stage_failure/success() lock-free
+// (except for the last-error string update, which uses a tiny mutex). The
+// main thread polls connection_stage_should_abort() once per second from
+// run_benchmark() while waiting for active_threads to drain.
+//
+// Lifetimes:
+//   - reset by connection_stage_supervisor_reset() at the start of every
+//     run_benchmark() invocation; --run-count > 1 must restart the policy
+//     because a previous run's success latch is meaningless for the next.
+//   - g_conn_stage_run_start tracks the time of that reset; we measure
+//     "elapsed in setup phase" from there, NOT from each individual
+//     failure, so a single late failure can still trigger the timeout.
+static std::atomic<bool> g_conn_stage_steady_state{false};
+static std::atomic<long> g_conn_stage_streak_start_sec{0}; // 0 = no failure yet
+static std::atomic<long> g_conn_stage_run_start_sec{0};
+static std::atomic<unsigned long long> g_conn_stage_failure_count{0};
+static pthread_mutex_t g_conn_stage_err_mutex = PTHREAD_MUTEX_INITIALIZER;
+static std::string g_conn_stage_last_err; // guarded by g_conn_stage_err_mutex
+
+void connection_stage_supervisor_reset(void)
+{
+    g_conn_stage_steady_state.store(false, std::memory_order_release);
+    g_conn_stage_streak_start_sec.store(0, std::memory_order_release);
+    g_conn_stage_failure_count.store(0, std::memory_order_release);
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    g_conn_stage_run_start_sec.store(now.tv_sec, std::memory_order_release);
+    pthread_mutex_lock(&g_conn_stage_err_mutex);
+    g_conn_stage_last_err.clear();
+    pthread_mutex_unlock(&g_conn_stage_err_mutex);
+}
+
+void report_connection_stage_failure(const char *err)
+{
+    // Once any thread has reached steady state we stop policing setup; a
+    // late "auth failed" log line during a normal --reconnect-on-error
+    // cycle must not bring the run down.
+    if (g_conn_stage_steady_state.load(std::memory_order_acquire)) return;
+
+    struct timeval now;
+    gettimeofday(&now, NULL);
+
+    // First failure in a streak: stamp the wall-clock start. Subsequent
+    // failures only update the last-error string. CAS on 0 keeps this
+    // race-free without a mutex.
+    long zero = 0;
+    g_conn_stage_streak_start_sec.compare_exchange_strong(zero, now.tv_sec, std::memory_order_acq_rel);
+    g_conn_stage_failure_count.fetch_add(1, std::memory_order_relaxed);
+
+    if (err != NULL && *err != '\0') {
+        pthread_mutex_lock(&g_conn_stage_err_mutex);
+        g_conn_stage_last_err.assign(err);
+        pthread_mutex_unlock(&g_conn_stage_err_mutex);
+    }
+}
+
+void report_connection_stage_success(void)
+{
+    // First call wins; subsequent calls are no-ops. We don't reset the
+    // failure_count / last_err — they may be useful in JSON output and
+    // they're only read by the supervisor, which is now disarmed.
+    bool expected = false;
+    if (g_conn_stage_steady_state.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        g_conn_stage_streak_start_sec.store(0, std::memory_order_release);
+    }
+}
+
+bool connection_stage_should_abort(unsigned int timeout_secs, std::string *out_last_err, unsigned int *out_elapsed)
+{
+    if (timeout_secs == 0) return false; // operator opt-out
+    if (g_conn_stage_steady_state.load(std::memory_order_acquire)) return false;
+
+    struct timeval now;
+    gettimeofday(&now, NULL);
+
+    long streak_start = g_conn_stage_streak_start_sec.load(std::memory_order_acquire);
+    long run_start = g_conn_stage_run_start_sec.load(std::memory_order_acquire);
+
+    // Two trip conditions:
+    //   (a) a failure streak has been live for >= timeout_secs (covers
+    //       AUTH-fail / SELECT-fail / CLUSTER-SLOTS-fail / -ERR reconnect
+    //       loops),
+    //   (b) no failure has ever been observed but the run has been alive
+    //       for >= timeout_secs without anyone reaching steady state
+    //       (covers --wait-ratio 0:1 with no slaves — the connection
+    //       handshakes but the very first WAIT command never returns).
+    long elapsed_streak = (streak_start > 0) ? (now.tv_sec - streak_start) : 0;
+    long elapsed_run = (run_start > 0) ? (now.tv_sec - run_start) : 0;
+
+    bool trip_streak = (streak_start > 0 && elapsed_streak >= (long) timeout_secs);
+    bool trip_run = (run_start > 0 && elapsed_run >= (long) timeout_secs);
+    if (!trip_streak && !trip_run) return false;
+
+    if (out_elapsed != NULL) {
+        *out_elapsed = (unsigned int) (trip_streak ? elapsed_streak : elapsed_run);
+    }
+    if (out_last_err != NULL) {
+        pthread_mutex_lock(&g_conn_stage_err_mutex);
+        if (!g_conn_stage_last_err.empty()) {
+            *out_last_err = g_conn_stage_last_err;
+        } else {
+            out_last_err->assign("no response from server during setup");
+        }
+        pthread_mutex_unlock(&g_conn_stage_err_mutex);
+    }
+    return true;
+}
 
 // Per-thread alternate signal stack. Without this, SA_ONSTACK is a no-op
 // and a SIGSEGV caused by stack-overflow is unrecoverable (the handler
@@ -427,6 +545,7 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
             "max_retry_queue = %u\n"
             "failed_keys_file = %s\n"
             "connection_timeout = %u\n"
+            "connection_stage_timeout = %u\n"
             "thread_conn_start_min_jitter_micros = %u\n"
             "thread_conn_start_max_jitter_micros = %u\n"
             "multi_key_get = %u\n"
@@ -456,7 +575,7 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
             cfg->key_prefix, cfg->key_minimum, cfg->key_maximum, cfg->key_pattern, cfg->key_stddev, cfg->key_median,
             cfg->reconnect_interval, cfg->retry_on_error ? "yes" : "no", cfg->max_retries, cfg->retry_backoff_ms,
             cfg->retry_backoff_factor, cfg->retry_on_filter ? cfg->retry_on_filter : "", cfg->max_retry_queue,
-            cfg->failed_keys_file ? cfg->failed_keys_file : "", cfg->connection_timeout,
+            cfg->failed_keys_file ? cfg->failed_keys_file : "", cfg->connection_timeout, cfg->connection_stage_timeout,
             cfg->thread_conn_start_min_jitter_micros, cfg->thread_conn_start_max_jitter_micros, cfg->multi_key_get,
             cfg->authenticate ? cfg->authenticate : "", cfg->select_db, cfg->no_expiry ? "yes" : "no",
             cfg->wait_ratio.a, cfg->wait_ratio.b, cfg->num_slaves.min, cfg->num_slaves.max, cfg->wait_timeout.min,
@@ -525,6 +644,7 @@ static void config_print_to_json(json_handler *jsonhandler, struct benchmark_con
     jsonhandler->write_obj("max_retry_queue", "%u", cfg->max_retry_queue);
     jsonhandler->write_obj("failed_keys_file", "\"%s\"", cfg->failed_keys_file ? cfg->failed_keys_file : "");
     jsonhandler->write_obj("connection_timeout", "%u", cfg->connection_timeout);
+    jsonhandler->write_obj("connection_stage_timeout", "%u", cfg->connection_stage_timeout);
     jsonhandler->write_obj("thread_conn_start_min_jitter_micros", "%u", cfg->thread_conn_start_min_jitter_micros);
     jsonhandler->write_obj("thread_conn_start_max_jitter_micros", "%u", cfg->thread_conn_start_max_jitter_micros);
     jsonhandler->write_obj("multi_key_get", "%u", cfg->multi_key_get);
@@ -690,6 +810,8 @@ static void config_init_defaults(struct benchmark_config *cfg)
     if (!cfg->print_percentiles.is_defined()) cfg->print_percentiles = config_quantiles("50,99,99.9");
     if (!cfg->monitor_pattern) cfg->monitor_pattern = 'S';
     if (cfg->miss_rate_threshold < 0.0) cfg->miss_rate_threshold = 0.01; // Default: warn above 1%
+    // Default --connection-stage-timeout to 30 s; 0 means "operator disabled".
+    if (cfg->connection_stage_timeout == UINT_MAX) cfg->connection_stage_timeout = 30;
 
     // StatsD defaults - port only matters if host is set
     if (!cfg->statsd_port) cfg->statsd_port = 8125;
@@ -804,6 +926,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_max_retry_queue,
         o_failed_keys_file,
         o_connection_timeout,
+        o_connection_stage_timeout,
         o_thread_conn_start_min_jitter_micros,
         o_thread_conn_start_max_jitter_micros,
         o_generate_keys,
@@ -912,6 +1035,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         {"max-retry-queue", 1, 0, o_max_retry_queue},
         {"failed-keys-file", 1, 0, o_failed_keys_file},
         {"connection-timeout", 1, 0, o_connection_timeout},
+        {"connection-stage-timeout", 1, 0, o_connection_stage_timeout},
         {"thread-conn-start-min-jitter-micros", 1, 0, o_thread_conn_start_min_jitter_micros},
         {"thread-conn-start-max-jitter-micros", 1, 0, o_thread_conn_start_max_jitter_micros},
         {"multi-key-get", 1, 0, o_multi_key_get},
@@ -1330,6 +1454,16 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
             cfg->connection_timeout = (unsigned int) strtoul(optarg, &endptr, 10);
             if (!endptr || *endptr != '\0') {
                 fprintf(stderr, "error: connection-timeout must be a valid number.\n");
+                return -1;
+            }
+            break;
+        case o_connection_stage_timeout:
+            endptr = NULL;
+            cfg->connection_stage_timeout = (unsigned int) strtoul(optarg, &endptr, 10);
+            // 0 is allowed and disables the supervisor (opt-out for users
+            // running long pre-warmed handshakes against slow servers).
+            if (!endptr || *endptr != '\0') {
+                fprintf(stderr, "error: connection-stage-timeout must be a valid number (seconds, 0 disables).\n");
                 return -1;
             }
             break;
@@ -1823,6 +1957,13 @@ void usage()
         "                                 permanent error) as CSV: timestamp,command,key,status,retries.\n"
         "                                 Off by default. The benchmark continues if the file is unwritable.\n"
         "      --connection-timeout=SECS  Connection timeout in seconds, 0 to disable (default: 0)\n"
+        "      --connection-stage-timeout=SECS\n"
+        "                                 Abort with exit code 2 if no thread reaches steady state within\n"
+        "                                 SECS, or if connection-setup failures (AUTH / HELLO / SELECT /\n"
+        "                                 CLUSTER SLOTS / -ERR during initial probe) persist for SECS\n"
+        "                                 without a successful handshake. Bounds the *startup* phase;\n"
+        "                                 --test-time still bounds the steady-state run. Default: 30,\n"
+        "                                 0 disables the supervisor.\n"
         "      --thread-conn-start-min-jitter-micros=NUM Minimum jitter in microseconds between connection creation "
         "(default: 0)\n"
         "      --thread-conn-start-max-jitter-micros=NUM Maximum jitter in microseconds between connection creation "
@@ -2022,7 +2163,14 @@ static void *cg_thread_start(void *t)
 
         // Check if we should restart due to connection failures
         // If the thread finished but still has time left and connection errors, request restart
-        if (thread->m_cg->get_total_connection_errors() > 0) {
+        //
+        // Exception: do NOT request restart if the connection-stage
+        // supervisor already gave up. Restarting would re-enter the same
+        // doomed handshake (AUTH against no-auth server, SELECT against
+        // missing DB, etc.) and silently re-trigger the same failure mode
+        // we just aborted on, masking the abort code from exit.
+        if (thread->m_cg->get_total_connection_errors() > 0 &&
+            !g_connection_stage_aborted.load(std::memory_order_acquire)) {
             benchmark_error_log("Thread %u finished due to connection failures, requesting restart.\n",
                                 thread->m_thread_id);
             thread->m_restart_requested = true;
@@ -2032,11 +2180,15 @@ static void *cg_thread_start(void *t)
     } catch (const std::exception &e) {
         benchmark_error_log("Thread %u caught exception: %s\n", thread->m_thread_id, e.what());
         thread->m_finished = true;
-        thread->m_restart_requested = true;
+        if (!g_connection_stage_aborted.load(std::memory_order_acquire)) {
+            thread->m_restart_requested = true;
+        }
     } catch (...) {
         benchmark_error_log("Thread %u caught unknown exception\n", thread->m_thread_id);
         thread->m_finished = true;
-        thread->m_restart_requested = true;
+        if (!g_connection_stage_aborted.load(std::memory_order_acquire)) {
+            thread->m_restart_requested = true;
+        }
     }
 
     return t;
@@ -2267,6 +2419,11 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     // Record benchmark start time (used for staircase global deadline)
     gettimeofday(&cfg->benchmark_start_time, NULL);
 
+    // Arm the connection-stage supervisor. Must happen *before* threads
+    // start so the first failure timestamp is meaningful (some servers
+    // reply to AUTH on the same TCP RTT as the connect).
+    connection_stage_supervisor_reset();
+
     // launch threads
     fprintf(stderr, "[RUN #%u] Launching threads now...\n", run_id);
     for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {
@@ -2331,6 +2488,30 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
                 (*i)->m_cg->interrupt();
             }
             break;
+        }
+
+        // Phase 1 of #426: bound the startup phase.
+        //
+        // Workers report failures (AUTH / HELLO / SELECT / CLUSTER SLOTS /
+        // -ERR / parse-error during initial probe) and the first post-setup
+        // success into the supervisor. If neither has happened within
+        // --connection-stage-timeout seconds, abort the run rather than
+        // letting the reconnect / "stuck WAIT" loop ignore --test-time.
+        // 0 = supervisor disabled.
+        {
+            std::string last_err;
+            unsigned int elapsed = 0;
+            if (connection_stage_should_abort(cfg->connection_stage_timeout, &last_err, &elapsed)) {
+                fprintf(stderr,
+                        "\nmemtier_benchmark: aborting after %u seconds of connection-stage failures "
+                        "(last error: %s). See --connection-stage-timeout.\n",
+                        elapsed, last_err.c_str());
+                g_connection_stage_aborted.store(true, std::memory_order_release);
+                for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {
+                    (*i)->m_cg->interrupt();
+                }
+                break;
+            }
         }
 
         unsigned long int total_ops = 0;
@@ -2778,6 +2959,18 @@ static void cleanup_openssl(void)
 
 int main(int argc, char *argv[])
 {
+    // Enable libevent's pthreads bindings so event_base_loopbreak() /
+    // event_base_loopexit() called from the main thread reliably wake a
+    // worker thread that is blocked in epoll_wait() with no live events.
+    // Without this, an idle event base never notices a cross-thread break
+    // request and the parent's pthread_join() hangs after a
+    // --connection-stage-timeout abort (Phase 1 of #426) or a Ctrl+C.
+    // Must run before any event_base is created so the locking callbacks
+    // are installed for every subsequent base.
+    if (evthread_use_pthreads() < 0) {
+        fprintf(stderr, "warning: evthread_use_pthreads() failed; cross-thread loop wakeups may stall.\n");
+    }
+
     // Install signal handler for Ctrl+C
     signal(SIGINT, sigint_handler);
 
@@ -2813,6 +3006,11 @@ int main(int argc, char *argv[])
     cfg.max_retries = -1;
     cfg.miss_rate_threshold = -1.0;   // sentinel; config_init_defaults replaces with 0.01
     cfg.command_miss_tracking = true; // Default: auto-track misses for known shapes
+    // Sentinel for --connection-stage-timeout: UINT_MAX means "operator did
+    // not specify"; config_init_defaults replaces with 30 s. We can't reuse 0
+    // as the unset marker because 0 is a valid user-specified "disable the
+    // supervisor entirely" value.
+    cfg.connection_stage_timeout = UINT_MAX;
 
     if (config_parse_args(argc, argv, &cfg) < 0) {
         usage();
@@ -3641,4 +3839,14 @@ int main(int argc, char *argv[])
         cleanup_openssl();
     }
 #endif
+
+    // Phase 1 of #426: propagate the connection-stage abort up to the shell.
+    // We still ran every teardown above (stats output, JSON, etc.) so the
+    // operator can read why the abort fired. exit(2) keeps the failure
+    // distinguishable from a successful test (0) and from --help (also 2 via
+    // usage(), but those exits happen before main reaches this point).
+    if (g_connection_stage_aborted.load(std::memory_order_acquire)) {
+        return 2;
+    }
+    return 0;
 }

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -126,7 +126,6 @@ static std::vector<cg_thread *> *g_threads = NULL;
 static std::atomic<bool> g_conn_stage_steady_state{false};
 static std::atomic<long> g_conn_stage_streak_start_sec{0}; // 0 = no failure yet
 static std::atomic<long> g_conn_stage_run_start_sec{0};
-static std::atomic<unsigned long long> g_conn_stage_failure_count{0};
 static pthread_mutex_t g_conn_stage_err_mutex = PTHREAD_MUTEX_INITIALIZER;
 static std::string g_conn_stage_last_err; // guarded by g_conn_stage_err_mutex
 
@@ -134,7 +133,11 @@ void connection_stage_supervisor_reset(void)
 {
     g_conn_stage_steady_state.store(false, std::memory_order_release);
     g_conn_stage_streak_start_sec.store(0, std::memory_order_release);
-    g_conn_stage_failure_count.store(0, std::memory_order_release);
+    // Must reset g_connection_stage_aborted as well: with --run-count > 1, a
+    // run-1 abort would otherwise leave the flag latched into run 2,
+    // suppressing legitimate thread restarts in cg_thread_start() and
+    // forcing main() to exit with code 2 even after subsequent runs succeed.
+    g_connection_stage_aborted.store(false, std::memory_order_release);
     struct timeval now;
     gettimeofday(&now, NULL);
     g_conn_stage_run_start_sec.store(now.tv_sec, std::memory_order_release);
@@ -158,7 +161,6 @@ void report_connection_stage_failure(const char *err)
     // race-free without a mutex.
     long zero = 0;
     g_conn_stage_streak_start_sec.compare_exchange_strong(zero, now.tv_sec, std::memory_order_acq_rel);
-    g_conn_stage_failure_count.fetch_add(1, std::memory_order_relaxed);
 
     if (err != NULL && *err != '\0') {
         pthread_mutex_lock(&g_conn_stage_err_mutex);
@@ -169,9 +171,9 @@ void report_connection_stage_failure(const char *err)
 
 void report_connection_stage_success(void)
 {
-    // First call wins; subsequent calls are no-ops. We don't reset the
-    // failure_count / last_err — they may be useful in JSON output and
-    // they're only read by the supervisor, which is now disarmed.
+    // First call wins; subsequent calls are no-ops. We don't reset
+    // last_err — it's only read by the supervisor (which is now disarmed)
+    // and can be useful for post-mortem diagnostics.
     bool expected = false;
     if (g_conn_stage_steady_state.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
         g_conn_stage_streak_start_sec.store(0, std::memory_order_release);

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <vector>
+#include <string>
 #include <sys/time.h>
 #include <pthread.h>
 #include "config_types.h"
@@ -140,6 +141,13 @@ struct benchmark_config
     // logged once and the benchmark continues.
     const char *failed_keys_file;
     unsigned int connection_timeout;
+    // Per-process bound on time spent in the *connection-setup* phase
+    // (AUTH, HELLO, SELECT, CLUSTER SLOTS, initial probe). Once any thread
+    // reaches steady-state (first non-setup response processed), this bound
+    // no longer applies; --test-time takes over. Independent of
+    // --connection-timeout (which is per-connect attempt) and --test-time
+    // (which bounds the steady-state run). Default 30 s; 0 disables.
+    unsigned int connection_stage_timeout;
     unsigned int thread_conn_start_min_jitter_micros;
     unsigned int thread_conn_start_max_jitter_micros;
     int multi_key_get;
@@ -204,5 +212,36 @@ struct benchmark_config
 extern void benchmark_log_file_line(int level, const char *filename, unsigned int line, const char *fmt, ...);
 extern void benchmark_log(int level, const char *fmt, ...);
 bool is_redis_protocol(enum PROTOCOL_TYPE type);
+
+// ---------------------------------------------------------------------------
+// Connection-stage supervisor (Phase 1 of #426)
+// ---------------------------------------------------------------------------
+//
+// The worker threads (shard_connection / cluster_client) report two events
+// here:
+//   - report_connection_stage_failure(): a connection-setup step failed
+//     (AUTH / HELLO / SELECT / CLUSTER SLOTS / -ERR / parse error during
+//     initial probe). The first call in a streak stamps the wall-clock
+//     start of the streak; subsequent calls only update the last-error
+//     message.
+//   - report_connection_stage_success(): the worker exited the conn-setup
+//     phase and processed a real response. Clears the streak and arms a
+//     latch (steady_state_reached) so the supervisor stops policing this
+//     run for setup-stalls.
+//
+// The main thread polls connection_stage_should_abort() once per second
+// from run_benchmark(). It returns true when either:
+//   (a) a failure streak has been live for >= --connection-stage-timeout, or
+//   (b) the run has been alive for >= --connection-stage-timeout without
+//       any thread ever reaching steady state (covers the "stuck WAIT" /
+//       "first request never returns" hangs in #426 #17).
+//
+// All state lives behind atomics + a small mutex protecting the
+// last-error string so worker threads can call into it lock-free on the
+// hot success path.
+void connection_stage_supervisor_reset(void);
+void report_connection_stage_failure(const char *err);
+void report_connection_stage_success(void);
+bool connection_stage_should_abort(unsigned int timeout_secs, std::string *out_last_err, unsigned int *out_elapsed);
 
 #endif /* _MEMTIER_BENCHMARK_H */

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -880,6 +880,15 @@ void shard_connection::process_response(void)
         case rt_auth:
             if (r->is_error()) {
                 benchmark_error_log("error: authentication failed [%s]\n", r->get_status());
+                {
+                    // Forward the server-side status to the connection-stage
+                    // supervisor so --connection-stage-timeout has actionable
+                    // context to surface (e.g. "called without any password
+                    // configured for the default user.").
+                    char buf[256];
+                    snprintf(buf, sizeof(buf), "AUTH failed: %s", r->get_status() ? r->get_status() : "");
+                    report_connection_stage_failure(buf);
+                }
                 error = true;
             } else {
                 m_authentication = setup_done;
@@ -889,6 +898,11 @@ void shard_connection::process_response(void)
         case rt_select_db:
             if (strcmp(r->get_status(), "+OK") != 0) {
                 benchmark_error_log("database selection failed.\n");
+                {
+                    char buf[256];
+                    snprintf(buf, sizeof(buf), "SELECT failed: %s", r->get_status() ? r->get_status() : "");
+                    report_connection_stage_failure(buf);
+                }
                 error = true;
             } else {
                 benchmark_debug_log("database selection successful.\n");
@@ -898,6 +912,8 @@ void shard_connection::process_response(void)
         case rt_cluster_slots:
             if (r->get_mbulk_value() == NULL || r->get_mbulk_value()->mbulks_elements.size() == 0) {
                 benchmark_error_log("cluster slot failed.\n");
+                report_connection_stage_failure("CLUSTER SLOTS failed (server returned empty or non-cluster reply; "
+                                                "is the server actually cluster-enabled?)");
                 error = true;
             } else {
                 // parse response
@@ -911,6 +927,11 @@ void shard_connection::process_response(void)
         case rt_hello:
             if (r->is_error()) {
                 benchmark_error_log("error: HELLO failed [%s]\n", r->get_status());
+                {
+                    char buf[256];
+                    snprintf(buf, sizeof(buf), "HELLO failed: %s", r->get_status() ? r->get_status() : "");
+                    report_connection_stage_failure(buf);
+                }
                 error = true;
             } else {
                 m_hello = setup_done;
@@ -923,6 +944,22 @@ void shard_connection::process_response(void)
 
             m_conns_manager->handle_response(m_id, now, req, r);
             m_conns_manager->inc_reqs_processed();
+            // First *successful* post-setup response observed: tell the
+            // supervisor we reached steady state. Idempotent.
+            //
+            // We deliberately do NOT count error responses as steady state
+            // — a -ERR can fire on the very first request (e.g. the
+            // 'invalid bulk length' loop from #426 #8) and then close the
+            // connection, dropping the worker into an infinite reconnect
+            // loop that the supervisor would otherwise be disarmed against.
+            if (!r->is_error()) {
+                report_connection_stage_success();
+            } else {
+                // Forward the error so a later abort can attribute it.
+                char buf[256];
+                snprintf(buf, sizeof(buf), "server error: %s", r->get_status() ? r->get_status() : "");
+                report_connection_stage_failure(buf);
+            }
             responses_handled = true;
             break;
         }
@@ -938,6 +975,13 @@ void shard_connection::process_response(void)
 
     if (ret == -1) {
         benchmark_error_log("error: response parsing failed.\n");
+        // A parser failure during the initial probe (e.g. talking memcache_text
+        // to a Redis server, or memcache_binary to redis) puts the worker
+        // into an unrecoverable spin: the bytes never align, the response
+        // never completes, and we never call inc_reqs_processed(). Report it
+        // as a connection-stage failure so the supervisor bounds the spin.
+        // Once steady state is reached this is a no-op.
+        report_connection_stage_failure("response parsing failed (protocol mismatch?)");
     }
 
     if (m_config->reconnect_interval > 0 && responses_handled) {

--- a/tests/test_cli_fuzz_phase1.py
+++ b/tests/test_cli_fuzz_phase1.py
@@ -1,0 +1,265 @@
+"""
+Regression tests for issue #426 Phase 1 — the --connection-stage-timeout
+supervisor that bounds the connection-setup retry / parse loop.
+
+On master prior to this fix every scenario below ran until SIGKILLed: the
+worker thread enters a tight AUTH-fail / SELECT-fail / CLUSTER-SLOTS-fail /
+HELLO-fail / response-parse-fail / WAIT-never-returns loop that ignores
+--test-time. The fix tracks the first connection-stage failure in a streak
+on the main thread and aborts the process with rc=2 (plus a diagnostic) if
+the streak — or, for the WAIT case, the simple absence of a steady-state
+hand-off — exceeds --connection-stage-timeout seconds. Each test here
+asserts:
+
+  * non-zero exit code (and not a negative signal like -SIGSEGV)
+  * stderr contains the new diagnostic prefix
+  * the process exits well within --connection-stage-timeout + 5 s
+    wall-budget — i.e. the supervisor really bounded the loop, the test
+    didn't just trip its own outer timeout
+
+Run subset:
+  TEST=test_cli_fuzz_phase1.py ./tests/run_tests.sh
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+
+from include import MEMTIER_BINARY
+
+
+# Short timeout so the regression suite finishes in seconds, not 30 s per
+# case. The supervisor's *default* is 30; we pass an explicit override to
+# the CLI in every test so we don't grow the suite by a minute.
+SUPERVISOR_TIMEOUT_SECS = 3
+WALL_BUDGET_SECS = SUPERVISOR_TIMEOUT_SECS + 5
+
+DIAGNOSTIC_PREFIX = "memtier_benchmark: aborting after"
+DIAGNOSTIC_FLAG_HINT = "See --connection-stage-timeout."
+
+
+def _run_memtier(args):
+    """Run memtier with a wall-budget guard and capture stderr.
+
+    Returns (returncode, stderr_text, wall_elapsed_secs).
+
+    The wall-budget guard is *outside* SUPERVISOR_TIMEOUT_SECS so we can
+    distinguish "the supervisor fired and the process exited cleanly" from
+    "the supervisor failed, our outer timer killed the process".
+    """
+    with tempfile.TemporaryDirectory() as td:
+        stdout_path = os.path.join(td, "mb.stdout")
+        stderr_path = os.path.join(td, "mb.stderr")
+        with open(stdout_path, "w") as out, open(stderr_path, "w") as err:
+            start = time.monotonic()
+            try:
+                proc = subprocess.Popen(args, stdout=out, stderr=err)
+                # Wait at most wall_budget; on overshoot, kill so the test
+                # framework's per-test deadline is preserved.
+                try:
+                    rc = proc.wait(timeout=WALL_BUDGET_SECS)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                    elapsed = time.monotonic() - start
+                    with open(stderr_path) as f:
+                        stderr_text = f.read()
+                    return None, stderr_text, elapsed
+            finally:
+                pass
+            elapsed = time.monotonic() - start
+            with open(stderr_path) as f:
+                stderr_text = f.read()
+            return rc, stderr_text, elapsed
+
+
+def _assert_supervisor_tripped(env, args, label):
+    """Common assertions for a single fuzz scenario."""
+    rc, stderr_text, elapsed = _run_memtier(args)
+    # Non-None return code = process exited under its own steam.
+    env.assertIsNotNone(
+        rc,
+        message=(
+            f"[{label}] memtier did not exit within {WALL_BUDGET_SECS}s — "
+            f"--connection-stage-timeout supervisor did NOT bound the loop. "
+            f"stderr tail:\n{stderr_text[-2000:]}"
+        ),
+    )
+    # rc=2 is the dedicated abort code we documented for the supervisor;
+    # accept any non-zero (and non-signal-killed) value as "failure was
+    # reported", but include a stronger preference for 2.
+    env.assertTrue(
+        rc is not None and rc > 0,
+        message=(
+            f"[{label}] expected non-zero exit; got rc={rc}. "
+            f"stderr tail:\n{stderr_text[-2000:]}"
+        ),
+    )
+    # rc must not be a signal-kill code (those are < 0 from subprocess on
+    # POSIX). subprocess maps SIGSEGV to -11, SIGKILL to -9, etc.
+    env.assertTrue(
+        rc >= 0,
+        message=(
+            f"[{label}] memtier died from a signal (rc={rc}), not a clean abort. "
+            f"This typically means the supervisor never fired and the OS killed "
+            f"the process. stderr tail:\n{stderr_text[-2000:]}"
+        ),
+    )
+    # Diagnostic must mention the supervisor — both the abort prefix and
+    # the --connection-stage-timeout hint so the operator can self-serve.
+    env.assertTrue(
+        DIAGNOSTIC_PREFIX in stderr_text,
+        message=(
+            f"[{label}] expected '{DIAGNOSTIC_PREFIX}' in stderr; got:\n"
+            f"{stderr_text[-2000:]}"
+        ),
+    )
+    env.assertTrue(
+        DIAGNOSTIC_FLAG_HINT in stderr_text,
+        message=(
+            f"[{label}] expected '{DIAGNOSTIC_FLAG_HINT}' in stderr; got:\n"
+            f"{stderr_text[-2000:]}"
+        ),
+    )
+    # Wall budget: must exit well within SUPERVISOR_TIMEOUT + 5 s. This
+    # is the key invariant the fix promises — on master prior to #426 fix
+    # every case ran for the full WALL_BUDGET (and longer; the outer guard
+    # would kill it).
+    env.assertTrue(
+        elapsed < WALL_BUDGET_SECS,
+        message=(
+            f"[{label}] memtier took {elapsed:.1f}s to exit, expected < "
+            f"{WALL_BUDGET_SECS}s. The supervisor likely didn't fire on time."
+        ),
+    )
+
+
+def _base_args(env, **extra):
+    """Build the common argv prefix; subtests append scenario-specific flags."""
+    if env.isUnixSocket():
+        env.skip()
+        return None
+    if env.isCluster():
+        # These tests intentionally target a *standalone* Redis to reproduce
+        # the connection-stage retry loops — running them in cluster mode
+        # changes (or hides) the failure modes we're regressing.
+        env.skip()
+        return None
+
+    master_nodes_list = env.getMasterNodesList()
+    port = master_nodes_list[0]["port"]
+    args = [
+        MEMTIER_BINARY,
+        "-s", "127.0.0.1",
+        "-p", str(port),
+        "-c", "1",
+        "-t", "1",
+        f"--connection-stage-timeout={SUPERVISOR_TIMEOUT_SECS}",
+        "--test-time=1",
+        "--hide-histogram",
+    ]
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Issue #426 item 1: --authenticate '' against no-auth Redis hangs.
+# ---------------------------------------------------------------------------
+def test_426_1_authenticate_empty_password_against_no_auth(env):
+    args = _base_args(env)
+    if args is None:
+        return
+    args.append("--authenticate=")
+    _assert_supervisor_tripped(env, args, "#1 --authenticate ''")
+
+
+# ---------------------------------------------------------------------------
+# Issue #426 item 2: --cluster-mode against standalone hangs in CLUSTER SLOTS.
+# ---------------------------------------------------------------------------
+def test_426_2_cluster_mode_against_standalone(env):
+    args = _base_args(env)
+    if args is None:
+        return
+    args.append("--cluster-mode")
+    _assert_supervisor_tripped(env, args, "#2 --cluster-mode vs standalone")
+
+
+# ---------------------------------------------------------------------------
+# Issue #426 item 3: memcache_{text,binary} protocol against a Redis server
+# (response parser never aligns → tight spin in process_response).
+# ---------------------------------------------------------------------------
+def test_426_3_memcache_text_against_redis(env):
+    args = _base_args(env)
+    if args is None:
+        return
+    args.extend(["--protocol", "memcache_text"])
+    _assert_supervisor_tripped(env, args, "#3 --protocol memcache_text vs redis")
+
+
+def test_426_3_memcache_binary_against_redis(env):
+    args = _base_args(env)
+    if args is None:
+        return
+    args.extend(["--protocol", "memcache_binary"])
+    _assert_supervisor_tripped(env, args, "#3 --protocol memcache_binary vs redis")
+
+
+# ---------------------------------------------------------------------------
+# Issue #426 item 8: --data-size-range 1-9999999999 → server replies
+# "-ERR Protocol error: invalid bulk length" and resets the connection;
+# memtier reconnects forever.
+#
+# This is the most server-dependent of the six; it relies on the server
+# actually rejecting the oversized bulk. We temporarily lower
+# proto-max-bulk-len so the rejection is deterministic across CI images.
+# ---------------------------------------------------------------------------
+def test_426_8_data_size_range_too_large(env):
+    args = _base_args(env)
+    if args is None:
+        return
+
+    master_connections = env.getOSSMasterNodesConnectionList()
+    original_max = None
+    try:
+        original_max = master_connections[0].config_get("proto-max-bulk-len").get(
+            "proto-max-bulk-len"
+        )
+        # Clamp below the data-size-range upper bound so the server rejects.
+        for c in master_connections:
+            c.config_set("proto-max-bulk-len", 100000000)
+        args.append("--data-size-range=1-9999999999")
+        _assert_supervisor_tripped(env, args, "#8 --data-size-range 1-9999999999")
+    finally:
+        if original_max is not None:
+            for c in master_connections:
+                try:
+                    c.config_set("proto-max-bulk-len", original_max)
+                except Exception:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Issue #426 item 11: --select-db beyond the configured DB count → every
+# SELECT comes back with "DB index is out of range", connection stays
+# half-open, worker loops.
+# ---------------------------------------------------------------------------
+def test_426_11_select_db_out_of_range(env):
+    args = _base_args(env)
+    if args is None:
+        return
+    # 100 is comfortably above the Redis default of 16 DBs.
+    args.append("--select-db=100")
+    _assert_supervisor_tripped(env, args, "#11 --select-db 100")
+
+
+# ---------------------------------------------------------------------------
+# Issue #426 item 17: --wait-ratio 0:1 --num-slaves 1-10 against a
+# standalone (no replicas) → WAIT never returns; first response never
+# arrives so we never reach steady state.
+# ---------------------------------------------------------------------------
+def test_426_17_wait_ratio_unsatisfiable(env):
+    args = _base_args(env)
+    if args is None:
+        return
+    args.extend(["--wait-ratio=0:1", "--num-slaves=1-10"])
+    _assert_supervisor_tripped(env, args, "#17 --wait-ratio 0:1 --num-slaves 1-10")

--- a/tests/test_cli_fuzz_phase1.py
+++ b/tests/test_cli_fuzz_phase1.py
@@ -32,8 +32,19 @@ from include import MEMTIER_BINARY
 # Short timeout so the regression suite finishes in seconds, not 30 s per
 # case. The supervisor's *default* is 30; we pass an explicit override to
 # the CLI in every test so we don't grow the suite by a minute.
-SUPERVISOR_TIMEOUT_SECS = 3
-WALL_BUDGET_SECS = SUPERVISOR_TIMEOUT_SECS + 5
+#
+# Sanitizer cells (TSAN especially) slow memtier startup + libevent
+# scheduling enough that a 3-s supervisor + 5-s outer budget is too tight:
+# TSAN added ~3 s of overhead per case on the OSS-TLS cells, tipping
+# case #8 (--data-size-range with the reconnect-loop server reply) past
+# the budget. Detect sanitizer instrumentation via the runtime env hooks
+# the CI workflows set (`ASAN_OPTIONS`, `TSAN_OPTIONS`, `UBSAN_OPTIONS`)
+# and double the supervisor + outer budgets when any of them is present.
+_SANITIZER_ACTIVE = any(
+    os.environ.get(k) for k in ("ASAN_OPTIONS", "TSAN_OPTIONS", "UBSAN_OPTIONS")
+)
+SUPERVISOR_TIMEOUT_SECS = 6 if _SANITIZER_ACTIVE else 3
+WALL_BUDGET_SECS = SUPERVISOR_TIMEOUT_SECS + (10 if _SANITIZER_ACTIVE else 5)
 
 DIAGNOSTIC_PREFIX = "memtier_benchmark: aborting after"
 DIAGNOSTIC_FLAG_HINT = "See --connection-stage-timeout."


### PR DESCRIPTION
## Summary

Phase 1 of #426: add a main-thread supervisor that bounds the connection-setup retry / parse loop with a new `--connection-stage-timeout=<seconds>` flag (default 30s; 0 disables).

Worker threads report failures (AUTH / HELLO / SELECT / CLUSTER SLOTS / `-ERR` / parse-error during initial probe) and the first *successful* steady-state response into the supervisor. The main thread polls once per second from `run_benchmark()` and aborts with `rc=2` + a clear diagnostic if either:
- a failure streak has been live for `>= --connection-stage-timeout`, or
- the run has been alive that long without any thread reaching steady state (covers the "WAIT never satisfied" / "first request never returns" hangs).

`--test-time` still bounds the steady-state run; this new bound applies only to startup.

Two small ancillary fixes the supervisor depends on:
- `evthread_use_pthreads()` is now called in `main()` and `libevent_pthreads` is linked, so cross-thread `event_base_loopbreak()` / `event_base_loopexit()` actually wake an idle worker. (This also fixed a pre-existing Ctrl+C hang in the same "stuck setup" connections.)
- `client_group::interrupt()` pairs `loopbreak()` with `loopexit({0,0})` so the worker's poll wakes immediately.
- `cg_thread_start()` no longer requests a thread restart after a connection-stage abort, otherwise the restart would silently re-enter the same doomed handshake and mask the abort.

## Items closed in this PR

From #426: **1, 2, 3, 8, 11, 17** (all 6 items that share the "connection-stage retry loop ignores --test-time" root cause).

| # | Repro | Before | After |
|---|---|---|---|
| 1 | `--authenticate ''` against no-auth Redis | hang | rc=2, AUTH error in diagnostic |
| 2 | `--cluster-mode` against standalone Redis | hang | rc=2, CLUSTER SLOTS error |
| 3 | `--protocol memcache_{text,binary}` against Redis | hang | rc=2, "protocol mismatch?" |
| 8 | `--data-size-range 1-9999999999` | hang | rc=2, server -ERR in diagnostic |
| 11 | `--select-db 100` against default 16-DB Redis | hang | rc=2, SELECT error |
| 17 | `--wait-ratio 0:1 --num-slaves 1-10` against standalone | hang | rc=2, "no response from server during setup" |

`Refs #426`

## Test plan

- [x] `make -j` builds clean
- [x] `make format-check-staged` clean
- [x] `tests/test_cli_fuzz_phase1.py` (7 new tests, one per item above): all pass; each asserts non-zero exit, the new diagnostic in stderr, and a `--connection-stage-timeout + 5s` wall budget
- [x] `tests/test_reconnections.py`: 4/4 pass (validates the cross-thread loop-wakeup change didn't regress the normal reconnect-on-error path)
- [x] `tests/test_retry_on_error.py`: 5/5 pass
- [x] `tests/test_sigpipe_immunity.py`: pass
- [x] Spot-check: a normal `memtier_benchmark --test-time=2` still exits 0
- [x] `--connection-stage-timeout=0` opt-out: confirmed the original hang still occurs (supervisor disabled)

## Out of scope

Phases 2 (argument-range validation) and 3 (sampler safety) of #426 are separate PRs. The `tests/cli_fuzz.py` exclusion list is intentionally left untouched here — narrowing it after the fixes land is a planned follow-up so the fuzzer regression net expands together with the bug landings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup/shutdown and thread-interrupt behavior across all runs; mis-tuned timeouts or steady-state detection could abort valid slow startups or mask rare edge cases, though defaults and `0` opt-out limit exposure.
> 
> **Overview**
> Adds **`--connection-stage-timeout`** (default 30s, `0` disables) so startup cannot spin forever when AUTH/HELLO/SELECT/CLUSTER SLOTS, protocol mismatch, or the first workload response never succeeds. Workers report setup failures and the first **non-error** steady-state response; the main thread polls once per second and aborts with **exit code 2** and a stderr diagnostic.
> 
> **Shutdown reliability:** links **`libevent_pthreads`**, calls **`evthread_use_pthreads()`** before creating event bases, and pairs **`event_base_loopbreak()`** with **`event_base_loopexit({0,0})`** in **`client_group::interrupt()`** so cross-thread stop (supervisor abort, Ctrl+C) wakes idle workers instead of hanging **`pthread_join()`**. After a stage abort, thread restart on connection errors is suppressed so the process does not re-enter the same failed handshake.
> 
> **Instrumentation:** **`shard_connection`** forwards setup and early `-ERR`/parse failures to the supervisor; **`tests/test_cli_fuzz_phase1.py`** covers the #426 hang scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c50065750f5975b4ff0197e31fe8ccaafb9fc6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->