### PR TITLE
fix(monitor-input): preserve byte count past NUL; handle CR-only line endings

### DIFF
--- a/config_types.cpp
+++ b/config_types.cpp
@@ -718,30 +718,56 @@ bool monitor_command_list::load_from_file(const char *filename)
 
     // Use getline() for dynamic allocation - handles arbitrarily long lines
     while ((line_len = getline(&line, &line_capacity, file)) != -1) {
-        total_lines++;
-        // Find the first quote - this is where the command starts
-        char *first_quote = strchr(line, '"');
-        if (!first_quote) {
-            continue; // Skip lines without commands
+        // Normalise CR-only line endings (\r without \n) by replacing every
+        // bare \r with \n so that the segment loop below works uniformly.
+        // getline already consumed the terminating \n (if any), so a trailing
+        // \r here is a CRLF remnant stripped below; internal \r bytes are the
+        // classic-Mac / some-Windows-export case that must be split on.
+        for (ssize_t i = 0; i < line_len - 1; i++) {
+            if (line[i] == '\r' && line[i + 1] != '\n') {
+                line[i] = '\n';
+            }
         }
 
-        // Extract everything from first quote to end of line
-        // We keep the quotes as-is to avoid re-parsing
-        std::string command_str(first_quote);
+        // Process each \n-delimited segment within the (possibly rewritten) buffer.
+        // In the common case there is exactly one segment and no extra allocation occurs.
+        char *seg_start = line;
+        char *seg_end;
+        while (seg_start < line + line_len) {
+            seg_end = (char *) memchr(seg_start, '\n', line + line_len - seg_start);
+            size_t seg_len = seg_end ? (size_t) (seg_end - seg_start) : (size_t) (line + line_len - seg_start);
 
-        // Remove trailing newline if present
-        if (!command_str.empty() && command_str[command_str.length() - 1] == '\n') {
-            command_str.erase(command_str.length() - 1);
+            total_lines++;
+            // Find the first quote - this is where the command starts
+            char *first_quote = (char *) memchr(seg_start, '"', seg_len);
+            if (!first_quote) {
+                seg_start = seg_end ? seg_end + 1 : line + line_len;
+                continue; // Skip segments without commands
+            }
+
+            // Extract everything from first quote to end of segment.
+            // Use the explicit byte-count constructor so that embedded \0
+            // bytes in binary blobs are preserved (the C-string ctor would
+            // silently truncate at the first \0).
+            size_t cmd_len = seg_len - (size_t) (first_quote - seg_start);
+            std::string command_str(first_quote, cmd_len);
+
+            // Remove trailing newline / carriage-return if present
+            if (!command_str.empty() && command_str[command_str.length() - 1] == '\n') {
+                command_str.erase(command_str.length() - 1);
+            }
+            if (!command_str.empty() && command_str[command_str.length() - 1] == '\r') {
+                command_str.erase(command_str.length() - 1);
+            }
+
+            commands.push_back(command_str);
+
+            // Extract and store the command type (e.g., "SET", "GET")
+            std::string cmd_type = extract_command_type(command_str);
+            command_types.push_back(cmd_type);
+
+            seg_start = seg_end ? seg_end + 1 : line + line_len;
         }
-        if (!command_str.empty() && command_str[command_str.length() - 1] == '\r') {
-            command_str.erase(command_str.length() - 1);
-        }
-
-        commands.push_back(command_str);
-
-        // Extract and store the command type (e.g., "SET", "GET")
-        std::string cmd_type = extract_command_type(command_str);
-        command_types.push_back(cmd_type);
     }
 
     free(line);

--- a/tests/test_monitor_input.py
+++ b/tests/test_monitor_input.py
@@ -781,6 +781,154 @@ def test_monitor_input_malformed_command_skipped(env):
         )
 
 
+def test_monitor_input_nul_byte_in_prefix_not_truncated(env):
+    """
+    Regression test for NUL-truncation in load_from_file (review finding #30, bug F1).
+
+    Before the fix, load_from_file used strchr(line, '"') to locate the start
+    of the command portion.  strchr stops at the first NUL byte, so a MONITOR
+    capture line whose metadata prefix contains an embedded \\0 (e.g. a binary
+    timestamp field) caused the entire line to be skipped with a "no commands
+    found" warning — even though getline had read the full byte count and the
+    '"CMD"' portion was intact.
+
+    The fix replaces strchr with memchr(seg_start, '"', seg_len), which searches
+    exactly the byte count returned by getline and therefore finds the opening
+    quote regardless of NUL bytes in the prefix.
+
+    This test writes three MONITOR-format lines to a binary file, where the
+    second line has a NUL byte embedded in its metadata prefix (before the
+    first '"').  The benchmark is run with __monitor_line@__ and we assert that
+    all three commands are loaded (i.e. line 2 was NOT silently dropped).
+    """
+    env.skipOnCluster()
+
+    test_dir = tempfile.mkdtemp()
+    monitor_file = os.path.join(test_dir, "monitor_nul.bin")
+
+    # Write the file in binary mode so the NUL byte is preserved verbatim.
+    # Line 2 has '\x00' in the metadata prefix, before the first '"'.
+    line1 = b'1764031576.604009 [0 127.0.0.1:51682] "SET" "nul_key1" "value1"\n'
+    line2 = b'1764031576.605000\x00[0 127.0.0.1:51682] "SET" "nul_key2" "value2"\n'
+    line3 = b'1764031576.606000 [0 127.0.0.1:51682] "SET" "nul_key3" "value3"\n'
+    with open(monitor_file, "wb") as f:
+        f.write(line1 + line2 + line3)
+
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--monitor-input={}".format(monitor_file),
+            "--command=__monitor_line@__",
+            "--hide-histogram",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+
+    config = get_default_memtier_config(threads=1, clients=1, requests=9)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+
+    debugPrintMemtierOnError(config, env)
+    env.assertTrue(memtier_ok == True,
+                   message="memtier failed while replaying monitor file with NUL byte in prefix")
+
+    # All three commands must have been loaded — if line 2 was dropped due to
+    # NUL truncation the count would be 2, not 3.
+    with open("{0}/mb.stderr".format(config.results_dir)) as stderr:
+        stderr_content = stderr.read()
+        env.assertTrue(
+            "Loaded 3 monitor commands from 3 total lines" in stderr_content,
+            message="Expected 3 loaded commands (NUL-in-prefix line was silently dropped). "
+                    "stderr: {}".format(stderr_content[-800:]),
+        )
+
+
+def test_monitor_input_cr_only_line_endings(env):
+    """
+    Regression test for CR-only line-ending handling in load_from_file
+    (review finding #30, bug F2).
+
+    Before the fix, getline() used '\\n' as the sole delimiter.  A monitor
+    capture file whose lines are separated by bare '\\r' (classic Mac / some
+    Windows exporters) was therefore read as a single giant line; the metadata
+    of every line after the first was appended as extra tokens to the first
+    command, and most commands were dropped or mis-routed silently.
+
+    The fix normalises bare '\\r' bytes to '\\n' before tokenising, so each
+    logical MONITOR line is treated as a separate segment.
+
+    This test writes three MONITOR-format SET commands separated by '\\r' only
+    (no '\\n') and asserts that all three commands are loaded.
+    """
+    env.skipOnCluster()
+
+    test_dir = tempfile.mkdtemp()
+    monitor_file = os.path.join(test_dir, "monitor_cr.bin")
+
+    # Three SET commands, separated by \r only (no \n).
+    line1 = b'1764031576.604009 [0 127.0.0.1:51682] "SET" "cr_key1" "value1"'
+    line2 = b'1764031576.605000 [0 127.0.0.1:51682] "SET" "cr_key2" "value2"'
+    line3 = b'1764031576.606000 [0 127.0.0.1:51682] "SET" "cr_key3" "value3"'
+    with open(monitor_file, "wb") as f:
+        f.write(line1 + b"\r" + line2 + b"\r" + line3 + b"\r")
+
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--monitor-input={}".format(monitor_file),
+            "--command=__monitor_line@__",
+            "--hide-histogram",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+
+    config = get_default_memtier_config(threads=1, clients=1, requests=9)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+
+    debugPrintMemtierOnError(config, env)
+    env.assertTrue(memtier_ok == True,
+                   message="memtier failed while replaying CR-only monitor file")
+
+    # All three commands must have been loaded.  Pre-fix, the entire file was
+    # read as one line and only one (malformed) command would be found.
+    with open("{0}/mb.stderr".format(config.results_dir)) as stderr:
+        stderr_content = stderr.read()
+        env.assertTrue(
+            "Loaded 3 monitor commands from 3 total lines" in stderr_content,
+            message="Expected 3 loaded commands (CR-only line endings not split correctly). "
+                    "stderr: {}".format(stderr_content[-800:]),
+        )
+
+    # Verify that all three keys were actually set in Redis.
+    master_nodes_connections = env.getOSSMasterNodesConnectionList()
+    keys_found = set()
+    for master_connection in master_nodes_connections:
+        for key in ("cr_key1", "cr_key2", "cr_key3"):
+            try:
+                result = master_connection.execute_command("EXISTS", key)
+                if result:
+                    keys_found.add(key)
+            except Exception:
+                pass
+    env.assertTrue(
+        len(keys_found) == 3,
+        message="Expected all 3 CR-only keys in Redis, found: {}".format(keys_found),
+    )
+
+
 def test_monitor_input_large_line_no_stack_overflow(env):
     """
     Regression test for the VLA stack-overflow in


### PR DESCRIPTION
## Summary

Two silent data-loss bugs in `monitor_command_list::load_from_file` (config_types.cpp), found during 2.4 release review (finding #30).

**Bug F1 — NUL truncation (strchr → memchr)**
`strchr(line, '"')` stops at the first `\0` byte. A MONITOR capture whose metadata prefix contains an embedded NUL causes the line to be silently skipped — `first_quote` becomes NULL even though getline returned the full byte count with the `"CMD"` portion intact. Fix: replace `strchr` with `memchr(seg_start, '"', seg_len)` so the search spans exactly the bytes returned by `getline`.

Additionally, `std::string command_str(first_quote)` used the C-string constructor which truncates at the first `\0` in the command part. Fix: use `std::string command_str(first_quote, cmd_len)` with the explicit byte count.

**Bug F2 — CR-only line endings**
`getline` uses `\n` as its sole delimiter. A file with pure `\r` separators (classic Mac / some Windows exports) is read as one giant line; the metadata of every line after the first is appended as extra tokens to the first command — most commands are silently dropped. Fix: a pre-pass normalises bare `\r` → `\n` within the buffer before segment processing.

Neither path crashed; both lost data without surfacing.

## Changes

- `config_types.cpp` (`load_from_file`): CR normalisation pass + inner segment loop + `memchr` + explicit `std::string(ptr, len)` constructor.
- `tests/test_monitor_input.py`: two new regression tests:
  - `test_monitor_input_nul_byte_in_prefix_not_truncated` — binary monitor file with `\x00` in line 2's metadata prefix; asserts all 3 commands are loaded.
  - `test_monitor_input_cr_only_line_endings` — binary monitor file with `\r`-only separators; asserts all 3 commands are loaded and all 3 keys land in Redis.

## Test plan

- [ ] `make -j$(nproc)` — clean build, no new warnings.
- [ ] `make format-check-staged` — clang-format clean (verified locally).
- [ ] Existing `tests/test_monitor_input.py` tests pass unmodified (no behaviour change on normal `\n`-delimited files).
- [ ] New `test_monitor_input_nul_byte_in_prefix_not_truncated` — fails on old code (count = 2), passes on fixed code (count = 3).
- [ ] New `test_monitor_input_cr_only_line_endings` — fails on old code (count = 1 or parse error), passes on fixed code (count = 3, all 3 keys in Redis).

Refs: 2.4 review finding #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to monitor capture parsing in config_types.cpp with targeted regression tests; normal newline-delimited files should behave the same.
> 
> **Overview**
> Fixes **silent data loss** when loading `--monitor-input` capture files in `monitor_command_list::load_from_file` (`config_types.cpp`).
> 
> **NUL in metadata:** Locating the command with `strchr` and building `std::string` from a C string could stop at embedded `\0` bytes in the prefix, so valid lines were skipped. The loader now splits each `getline` buffer into segments, finds `"` with **`memchr` over a bounded length**, and copies commands with **`std::string(ptr, len)`** so NULs in the payload are preserved.
> 
> **CR-only line endings:** Bare `\r` separators (no `\n`) used to be one physical line; the code **normalizes internal `\r` → `\n`** and processes each segment so every MONITOR record becomes its own command.
> 
> `tests/test_monitor_input.py` adds regression tests for NUL-in-prefix (expects 3 loaded commands) and CR-only files (3 commands + keys in Redis).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65c605bcd89c2b5823ab2a74c6c7d40d1248055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->