### PR TITLE
fix(resp3): accept push frames; count nil _ as miss in arbitrary command tracking

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -857,12 +857,13 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp, req
                                 // compatible with a parser that distinguishes.
                                 //
                                 // RESP3 nil "_\r\n" goes through single_type
-                                // and is stored as a bulk_el with value="_"
-                                // (strdup of the bare line, value_len==1).
-                                // Treat it as a miss, same as $-1 null bulk.
-                                bool resp3_nil =
-                                    (bel != NULL && bel->value_len == 1 && bel->value != NULL && bel->value[0] == '_');
-                                if (bel != NULL && bel->value != NULL && !resp3_nil) {
+                                // and is stored as a bulk_el with is_resp3_null
+                                // set to true. Using the flag (set at parse time)
+                                // avoids false positives from a legitimate bulk
+                                // string whose content happens to be the single
+                                // character '_' (parsed via blob_type, which
+                                // never sets is_resp3_null). Treat it as a miss.
+                                if (bel != NULL && bel->value != NULL && !bel->is_resp3_null) {
                                     h = true;
                                 }
                             } else if (el->is_mbulk_size()) {

--- a/client.cpp
+++ b/client.cpp
@@ -795,11 +795,13 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp, req
                 // bulk), *-1 (null array), or anything else (a value).
                 const char *status = response->get_status();
                 // Miss sentinels: $-1 (null bulk), *-1 (null array, RESP2),
-                // and *0 (empty array - returned by SPOP/SRANDMEMBER with a
-                // count argument when the key is absent). Anything else is
-                // a value (or a non-empty container) and counts as a hit.
+                // *0 (empty array - returned by SPOP/SRANDMEMBER with a
+                // count argument when the key is absent), and "_" (RESP3
+                // null, parsed via single_type and stored verbatim as the
+                // status line without the CRLF). Anything else is a value
+                // (or a non-empty container) and counts as a hit.
                 bool is_null = (status != NULL && (strcmp(status, "$-1") == 0 || strcmp(status, "*-1") == 0 ||
-                                                   strcmp(status, "*0") == 0));
+                                                   strcmp(status, "*0") == 0 || strcmp(status, "_") == 0));
                 // Always one bucket for SingleNullBulk: variadic-key blocking
                 // commands like BLPOP carry the winning key in the reply but
                 // we don't parse it, so per-key attribution beyond hit/miss
@@ -853,7 +855,14 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp, req
                                 // convention; the value-pointer check is the
                                 // semantically correct one and is forward-
                                 // compatible with a parser that distinguishes.
-                                if (bel != NULL && bel->value != NULL) {
+                                //
+                                // RESP3 nil "_\r\n" goes through single_type
+                                // and is stored as a bulk_el with value="_"
+                                // (strdup of the bare line, value_len==1).
+                                // Treat it as a miss, same as $-1 null bulk.
+                                bool resp3_nil =
+                                    (bel != NULL && bel->value_len == 1 && bel->value != NULL && bel->value[0] == '_');
+                                if (bel != NULL && bel->value != NULL && !resp3_nil) {
                                     h = true;
                                 }
                             } else if (el->is_mbulk_size()) {

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -471,7 +471,16 @@ bool redis_protocol::aggregate_type(char c)
 {
     if (c == '*') return true;
 
-    if (m_resp3 && (c == '%' || c == '~' || c == '|')) return true;
+    // RESP3: map (%), set (~), attribute (|), and push (>) are all aggregate
+    // types.  Push frames (">N\r\n" followed by N elements) are structurally
+    // identical to arrays and can be emitted by Redis 7+ at any point on a
+    // RESP3 connection (pubsub, keyspace notifications, client-tracking
+    // invalidation).  We parse them as ordinary aggregates and discard the
+    // content; the alternative -- returning -1 from parse_response -- tears
+    // down the connection unnecessarily.
+    // TODO: route drained push frames to an out-of-band callback so callers
+    // can observe server-initiated events without disrupting the reply stream.
+    if (m_resp3 && (c == '%' || c == '~' || c == '|' || c == '>')) return true;
 
     return false;
 }

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -625,6 +625,11 @@ int redis_protocol::parse_response(void)
                     bulk_el *new_bulk = new bulk_el();
                     new_bulk->value = bulk_value;
                     new_bulk->value_len = strlen(bulk_value);
+                    // Mark RESP3 null elements explicitly so the walker can
+                    // distinguish them from a legitimate bulk string whose
+                    // content happens to be the single character '_' (which
+                    // would arrive via blob_type / rs_read_bulk, not here).
+                    new_bulk->is_resp3_null = (line[0] == '_');
 
                     // insert it to current mbulk
                     m_current_mbulk->add_new_element(new_bulk);

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -517,20 +517,22 @@ bool redis_protocol::response_ended()
 {
     if (m_total_bulks_count != 0) return false;
 
-    if (m_attribute) {
-        m_attribute = false;
-        return false;
-    }
+    bool was_push = m_push;
+    bool was_attribute = m_attribute;
 
+    if (was_attribute) m_attribute = false;
     // A RESP3 push frame just finished draining. The actual reply to
     // the in-flight command (if any) is still pending — keep reading
     // and do NOT signal a complete reply for the push.
-    if (m_push) {
+    // Also handles the case where an attribute (|) is nested inside a
+    // push frame (>) and both complete at the same call: clear BOTH
+    // flags together so m_push does not remain set and eat the next reply.
+    if (was_push) {
         m_push = false;
         m_response_len = 0; // reset: push bytes don't count toward the next reply
-        return false;
     }
 
+    if (was_push || was_attribute) return false;
     return true;
 }
 

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -167,6 +167,15 @@ protected:
     mbulk_size_el *m_current_mbulk;
     bool m_resp3;
     bool m_attribute;
+    // Drain mode for RESP3 server-pushed frames ('>'). Pushes are
+    // out-of-band (pubsub, keyspace notifications, client tracking
+    // invalidations) and must not be delivered as a reply to any
+    // in-flight command. While true the parser still walks the frame
+    // to advance the read buffer, but suppresses all writes into
+    // m_last_response (status, mbulk tree, value, hits).
+    // TODO: full out-of-band routing — surface push frames to a
+    // listener instead of silently dropping them.
+    bool m_push;
 
     bool aggregate_type(char c);
     bool blob_type(char c);
@@ -181,7 +190,8 @@ public:
             m_total_bulks_count(0),
             m_current_mbulk(NULL),
             m_resp3(false),
-            m_attribute(false)
+            m_attribute(false),
+            m_push(false)
     {
     }
     virtual redis_protocol *clone(void) { return new redis_protocol(); }
@@ -512,6 +522,14 @@ bool redis_protocol::response_ended()
         return false;
     }
 
+    // A RESP3 push frame just finished draining. The actual reply to
+    // the in-flight command (if any) is still pending — keep reading
+    // and do NOT signal a complete reply for the push.
+    if (m_push) {
+        m_push = false;
+        return false;
+    }
+
     return true;
 }
 
@@ -528,6 +546,7 @@ int redis_protocol::parse_response(void)
             m_response_len = 0;
             m_total_bulks_count = 0;
             m_attribute = 0;
+            m_push = 0;
             m_response_state = rs_read_line;
 
             break;
@@ -562,12 +581,22 @@ int redis_protocol::parse_response(void)
                     m_attribute = true;
                 }
 
+                if (line[0] == '>') {
+                    // Top-level push frame: enter drain mode. Nested
+                    // pushes (push inside push) are not defined by RESP3
+                    // and not expected; only set the flag once.
+                    m_push = true;
+                }
+
                 // Map or Attribute contain key-value pair
                 if (line[0] == '%' || line[0] == '|') {
                     count *= 2;
                 }
 
-                if (m_keep_value) {
+                // Suppress mbulk allocation while draining a push frame:
+                // the contents are out-of-band and must not be delivered
+                // as the reply to any in-flight command.
+                if (m_keep_value && !m_push) {
                     mbulk_size_el *new_mbulk_size = new mbulk_size_el();
                     new_mbulk_size->bulks_count = count;
                     new_mbulk_size->upper_level = m_current_mbulk;
@@ -583,7 +612,11 @@ int redis_protocol::parse_response(void)
                     m_current_mbulk = new_mbulk_size->get_next_mbulk();
                 }
 
-                m_last_response.set_status(line);
+                if (!m_push) {
+                    m_last_response.set_status(line);
+                } else {
+                    free(line);
+                }
                 m_total_bulks_count += count;
 
                 if (response_ended()) {
@@ -598,9 +631,14 @@ int redis_protocol::parse_response(void)
                 }
 
                 m_bulk_len = strtol(line + 1, NULL, 10);
-                m_last_response.set_status(line);
+                // Suppress reply mutation while draining a push frame.
+                if (!m_push) {
+                    m_last_response.set_status(line);
 
-                if (line[0] == '!') m_last_response.set_error();
+                    if (line[0] == '!') m_last_response.set_error();
+                } else {
+                    free(line);
+                }
 
                 /*
                  * only on negative bulk, the data ends right after the first CRLF ($-1\r\n), so
@@ -618,7 +656,7 @@ int redis_protocol::parse_response(void)
                 }
 
                 // if we are not inside mbulk, the status will be kept in m_status anyway
-                if (m_keep_value && m_current_mbulk) {
+                if (m_keep_value && m_current_mbulk && !m_push) {
                     char *bulk_value = strdup(line);
                     assert(bulk_value != NULL);
 
@@ -636,9 +674,13 @@ int redis_protocol::parse_response(void)
                     m_current_mbulk = m_current_mbulk->get_next_mbulk();
                 }
 
-                if (line[0] == '-') m_last_response.set_error();
+                if (!m_push) {
+                    if (line[0] == '-') m_last_response.set_error();
 
-                m_last_response.set_status(line);
+                    m_last_response.set_status(line);
+                } else {
+                    free(line);
+                }
                 m_total_bulks_count--;
 
                 if (response_ended()) {
@@ -664,7 +706,9 @@ int redis_protocol::parse_response(void)
                  * such key as well as non existing key or existing key without data
                  * in the requested range
                  */
-                if (m_bulk_len > 0) {
+                // Suppress hit accounting while draining a push frame; the
+                // bulk belongs to an out-of-band message, not the reply.
+                if (m_bulk_len > 0 && !m_push) {
                     m_last_response.incr_hits();
                 }
 
@@ -674,7 +718,14 @@ int redis_protocol::parse_response(void)
             }
             break;
         case rs_end_bulk:
-            if (m_keep_value) {
+            // Push-frame drain: read+discard the bulk bytes without
+            // touching m_last_response so the reply remains clean.
+            if (m_push) {
+                if (m_bulk_len >= 0) {
+                    int ret = evbuffer_drain(m_read_buf, m_bulk_len + 2);
+                    assert(ret != -1);
+                }
+            } else if (m_keep_value) {
                 /*
                  * keep bulk value - in case we need to save bulk value it depends
                  * if it's inside a mbulk or not.

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -527,6 +527,7 @@ bool redis_protocol::response_ended()
     // and do NOT signal a complete reply for the push.
     if (m_push) {
         m_push = false;
+        m_response_len = 0; // reset: push bytes don't count toward the next reply
         return false;
     }
 

--- a/protocol.h
+++ b/protocol.h
@@ -116,7 +116,7 @@ public:
 class bulk_el : public mbulk_element
 {
 public:
-    bulk_el() : mbulk_element(mbulk_element_bulk), value(NULL), value_len(0) { ; }
+    bulk_el() : mbulk_element(mbulk_element_bulk), value(NULL), value_len(0), is_resp3_null(false) { ; }
     virtual ~bulk_el()
     {
         free(value);
@@ -129,6 +129,11 @@ public:
 
     char *value;
     unsigned int value_len;
+    // True only when this element was produced by the single_type parser
+    // branch for the RESP3 null type byte '_'. Distinguishes a genuine
+    // RESP3 null from a legitimate bulk string whose content happens to be
+    // the single character '_' (parsed via blob_type / rs_read_bulk).
+    bool is_resp3_null;
 };
 
 struct protocol_response

--- a/tests/test_arbitrary_command_misses.py
+++ b/tests/test_arbitrary_command_misses.py
@@ -376,6 +376,89 @@ def test_arbitrary_xread_keyword_spec_evaluates_correctly(env):
                    message="expected XREAD misses on missing streams")
 
 
+def _server_supports_resp3(env):
+    """Return True if the Redis server accepts HELLO 3 (Redis 6+)."""
+    try:
+        conn = env.getConnection()
+        # HELLO 3 switches the connection to RESP3 and returns a server map.
+        # Older servers return an error.  We reset back to RESP2 afterwards.
+        resp = conn.execute_command("HELLO", "3")
+        conn.execute_command("HELLO", "2")
+        return resp is not None
+    except Exception:
+        return False
+
+
+def test_arbitrary_get_resp3_nil_counted_as_miss(env):
+    """GET under --protocol=resp3 returns '_\\r\\n' (RESP3 null) for missing
+    keys.  Before the fix the SingleNullBulk sentinel did not include '_' so
+    every RESP3 nil was counted as a hit, silently understating the miss rate.
+
+    Gated by capability detection: the test is skipped when the test Redis
+    does not support HELLO 3 (Redis < 6).
+    """
+    env.skipOnCluster()
+    if not _server_supports_resp3(env):
+        env.skip()
+        return
+
+    _preload_strings(env)
+
+    test_dir = tempfile.mkdtemp()
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--command-stats-breakdown=line",
+            "--command-miss-tracking=auto",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+            "--hide-histogram",
+            "--protocol=resp3",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=1, clients=2, requests=_REQUESTS)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(config, env)
+    env.assertTrue(memtier_ok)
+
+    with open("{}/mb.json".format(config.results_dir)) as fh:
+        result = json.load(fh)
+
+    per_key = result["ALL STATS"].get("Per-Key Misses", {})
+    env.assertContains("GET", per_key,
+                       message="Per-Key Misses section missing GET entry under resp3")
+    cmd_stats = per_key["GET"]
+
+    total_ops = cmd_stats["Total Hits"] + cmd_stats["Total Misses"]
+    env.assertEqual(total_ops, _REQUESTS * 2)
+    # Keys 4..10 do not exist.  With ~70% miss rate expected we insist on at
+    # least one miss so that a zero-miss result (as produced by the pre-fix
+    # code that counted RESP3 nil as a hit) is a test failure.
+    env.assertTrue(
+        cmd_stats["Total Misses"] > 0,
+        message=(
+            "GET under resp3: Total Misses=0 (RESP3 nil '_' not recognised "
+            "as miss sentinel — fix regression in SingleNullBulk handler)"
+        ),
+    )
+    # Basic sanity: total hits must also be non-zero (keys 1..3 do exist).
+    env.assertTrue(
+        cmd_stats["Total Hits"] > 0,
+        message="GET under resp3: Total Hits=0 unexpectedly (keys 1..3 were pre-loaded)",
+    )
+
+
 def test_arbitrary_eval_keynum_spec_runs_cleanly(env):
     """EVAL has Keynum begin_search; verify resolve_command_meta doesn't crash.
 

--- a/tests/test_arbitrary_command_misses.py
+++ b/tests/test_arbitrary_command_misses.py
@@ -482,3 +482,97 @@ def test_arbitrary_eval_keynum_spec_runs_cleanly(env):
     eval_entry = all_stats.get("Evals", {})
     env.assertTrue(eval_entry.get("Count", 0) > 0,
                    message="expected EVAL to run (Keynum spec evaluation)")
+
+
+def test_arbitrary_get_resp3_literal_underscore_not_counted_as_miss(env):
+    """GET under --protocol=resp3 must NOT count a literal '_' value as a miss.
+
+    Bugbot LOW on PR #435: the ArrayPerElementNulls walker used a content
+    heuristic (value_len==1 && value[0]=='_') that could not distinguish
+    a RESP3 null (parsed by single_type as strdup("_")) from a legitimate
+    bulk string whose content is the single character '_' (parsed via
+    blob_type from '$1\\r\\n_\\r\\n').  Both produced identical bulk_el
+    value/value_len before the fix.
+
+    The fix adds a bulk_el::is_resp3_null flag set only by single_type when
+    the type byte is '_', so blob_type-constructed elements (real data) are
+    never mistaken for nulls.
+
+    This test pre-populates keys with the literal value '_', then runs GET
+    under resp3 and asserts that Total Misses < total operations (i.e. at
+    least the pre-populated keys are counted as hits, not as nulls).
+    """
+    env.skipOnCluster()
+    if not _server_supports_resp3(env):
+        env.skip()
+        return
+
+    # Populate ALL keys in the range with the literal value "_"
+    # so that every GET in the benchmark hits an existing key.
+    env.flush()
+    conn = env.getConnection()
+    for i in range(1, _KEY_RANGE_MAX + 1):
+        conn.set("{}{}".format(_KEY_PREFIX, i), "_")
+
+    test_dir = tempfile.mkdtemp()
+    benchmark_specs = {
+        "name": env.testName,
+        "args": [
+            "--command=GET __key__",
+            "--command-key-pattern=R",
+            "--command-stats-breakdown=line",
+            "--command-miss-tracking=auto",
+            "--key-prefix={}".format(_KEY_PREFIX),
+            "--key-minimum=1",
+            "--key-maximum={}".format(_KEY_RANGE_MAX),
+            "--hide-histogram",
+            "--protocol=resp3",
+        ],
+    }
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=1, clients=2, requests=_REQUESTS)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+    debugPrintMemtierOnError(config, env)
+    env.assertTrue(memtier_ok)
+
+    with open("{}/mb.json".format(config.results_dir)) as fh:
+        result = json.load(fh)
+
+    per_key = result["ALL STATS"].get("Per-Key Misses", {})
+    env.assertContains("GET", per_key,
+                       message="Per-Key Misses section missing GET entry under resp3")
+    cmd_stats = per_key["GET"]
+
+    total_ops = cmd_stats["Total Hits"] + cmd_stats["Total Misses"]
+    env.assertEqual(total_ops, _REQUESTS * 2)
+
+    # Every key in [1, KEY_RANGE_MAX] was populated with "_".  With the
+    # content-heuristic bug, all of these would be counted as RESP3 nulls
+    # (misses).  With the is_resp3_null flag fix, the blob_type-constructed
+    # bulk_el carries is_resp3_null=false, so they are correctly counted as
+    # hits.  Assert that Total Misses is strictly less than total_ops
+    # (i.e. at least one hit was observed) and that Total Hits > 0.
+    env.assertTrue(
+        cmd_stats["Total Hits"] > 0,
+        message=(
+            "GET resp3 with literal '_' values: Total Hits=0 — the content "
+            "heuristic is falsely counting real '_' values as RESP3 nulls "
+            "(is_resp3_null flag fix not applied or not working)"
+        ),
+    )
+    env.assertEqual(
+        cmd_stats["Total Misses"],
+        0,
+        message=(
+            "GET resp3 with literal '_' values: Total Misses={} but all keys "
+            "are populated — '_' bulk values are being wrongly counted as "
+            "RESP3 null misses".format(cmd_stats["Total Misses"])
+        ),
+    )


### PR DESCRIPTION
## Summary

Two RESP3 correctness bugs surfaced by the 2.4 readiness review (findings #25 and #27). This PR is targeted at milestone **2.4**.

### Bug #27 — RESP3 push type `>` silently dropped the connection

`aggregate_type()` in `protocol.cpp` accepted `%` (map), `~` (set), and `|` (attribute) for RESP3, but **not** `>` (push). When a Redis 7+ server emitted a server-pushed message (pubsub, keyspace notifications, client-tracking invalidation) on a `--protocol=resp3` connection, the parser hit the "unsupported response" path and returned `-1`, dropping the connection.

**Fix:** Added `>` to `aggregate_type()`. Push frames are structurally identical to arrays (`>N\r\n` + N elements) so they are parsed and drained inline. A TODO is left for future out-of-band routing.

The existing fixture `tests/fixtures/resp_payloads/resp3_push_unsolicited.bin` (`>2\r\n+pubsub\r\n+msg\r\n+OK\r\n`) and test `test_resp3_push_unsolicited` in `tests/test_resp_response_fuzzer.py` already covered this case and will now pass.

### Bug #25 — RESP3 nil `_\r\n` miscounted as hit in arbitrary-command miss tracking

Two miss-tracking sentinels in `client.cpp` only recognised RESP2 nil shapes:

- **`SingleNullBulk` handler** (line ~801): checked `$-1`, `*-1`, `*0` — but not RESP3 nil `_`. The RESP3 nil is parsed via `single_type` and stored verbatim as the status string `"_"`, so it was classified as a hit.

- **`ArrayPerElementNulls` walker** (line ~856): checked `bel->value != NULL` to detect a hit. RESP3 nil inside an mbulk is stored as a `bulk_el` with `value=strdup("_")` (non-NULL), so it was also classified as a hit.

Both paths silently understated the miss rate and suppressed `--miss-rate-threshold` warnings when running against RESP3 connections.

**Fix:**
- Added `"_"` to the `SingleNullBulk` sentinel set.
- Added a `value_len==1 && value[0]=='_'` check in the `ArrayPerElementNulls` walker.

**New test:** `test_arbitrary_get_resp3_nil_counted_as_miss` in `tests/test_arbitrary_command_misses.py` runs `GET __key__ --protocol=resp3` against pre-populated keys and asserts `Total Misses > 0`. Gated by `HELLO 3` capability detection so it skips cleanly on Redis < 6.

## Test plan

- [ ] `test_resp3_push_unsolicited` (existing, `tests/test_resp_response_fuzzer.py`) — was a confirmed bug, now passes with the `aggregate_type()` fix
- [ ] `test_arbitrary_get_resp3_nil_counted_as_miss` (new, `tests/test_arbitrary_command_misses.py`) — asserts misses > 0 under `--protocol=resp3`; skips on Redis < 6
- [ ] All existing `test_arbitrary_command_misses.py` tests continue to pass (no regression in RESP2 nil handling)
- [ ] All existing `test_resp_response_fuzzer.py` fixtures continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RESP3 parsing and per-key miss accounting on live benchmark connections; incorrect push or null handling could skew stats or affect long-running RESP3 workloads, though scope is limited and covered by new tests.
> 
> **Overview**
> This PR hardens **RESP3** handling in the Redis protocol parser and in **arbitrary-command miss tracking** when `--protocol=resp3` is used.
> 
> **Push frames (`>`):** The parser now treats RESP3 push aggregates like other aggregates instead of failing as unsupported. While a push is active, it **drains** the frame (advancing the read buffer) without writing status, mbulk trees, values, or hit counts into the in-flight command reply—so pubsub/keyspace/tracking pushes no longer tear down the connection or masquerade as command replies. A TODO remains for routing pushes to an out-of-band listener.
> 
> **RESP3 null (`_`) in miss stats:** `SingleNullBulk` miss detection now treats status `"_"` as a miss alongside `$-1`, `*-1`, and `*0`. For array walks, `bulk_el::is_resp3_null` is set only when the null type is parsed via `single_type`, so a real bulk string whose payload is a single `_` is still counted as a hit.
> 
> **Tests:** Integration tests run `GET` under RESP3 (skipped when `HELLO 3` is unavailable) to assert nil misses are recorded and literal `"_"` values are not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9183f522c26db5cbb29ca0d231826f6c0ee7221c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->