### PR TITLE
fix(opts): reject negative -c/-t/-n/--test-time; guard Hits/sec from /0

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1279,7 +1279,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                 cfg->requests = -1;
             else {
                 if (optarg_is_negative(optarg)) {
-                    fprintf(stderr, "error: requests must be a positive integer.\n");
+                    fprintf(stderr, "error: requests must be greater than zero.\n");
                     return -1;
                 }
                 errno = 0;
@@ -1297,7 +1297,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         case 'c':
             endptr = NULL;
             if (optarg_is_negative(optarg)) {
-                fprintf(stderr, "error: clients must be a positive integer.\n");
+                fprintf(stderr, "error: clients must be greater than zero.\n");
                 return -1;
             }
             errno = 0;
@@ -1310,7 +1310,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         case 't':
             endptr = NULL;
             if (optarg_is_negative(optarg)) {
-                fprintf(stderr, "error: threads must be a positive integer.\n");
+                fprintf(stderr, "error: threads must be greater than zero.\n");
                 return -1;
             }
             errno = 0;
@@ -1323,7 +1323,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         case o_test_time:
             endptr = NULL;
             if (optarg_is_negative(optarg)) {
-                fprintf(stderr, "error: test time must be a positive integer.\n");
+                fprintf(stderr, "error: test time must be greater than zero.\n");
                 return -1;
             }
             errno = 0;

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1278,8 +1278,13 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
             if (strcmp(optarg, "allkeys") == 0)
                 cfg->requests = -1;
             else {
+                if (optarg_is_negative(optarg)) {
+                    fprintf(stderr, "error: requests must be a positive integer.\n");
+                    return -1;
+                }
+                errno = 0;
                 cfg->requests = (unsigned long long) strtoull(optarg, &endptr, 10);
-                if (!cfg->requests || !endptr || *endptr != '\0') {
+                if (errno == ERANGE || !cfg->requests || !endptr || *endptr != '\0') {
                     fprintf(stderr, "error: requests must be greater than zero.\n");
                     return -1;
                 }
@@ -1291,24 +1296,39 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
             break;
         case 'c':
             endptr = NULL;
+            if (optarg_is_negative(optarg)) {
+                fprintf(stderr, "error: clients must be a positive integer.\n");
+                return -1;
+            }
+            errno = 0;
             cfg->clients = (unsigned int) strtoul(optarg, &endptr, 10);
-            if (!cfg->clients || !endptr || *endptr != '\0') {
+            if (errno == ERANGE || !cfg->clients || !endptr || *endptr != '\0') {
                 fprintf(stderr, "error: clients must be greater than zero.\n");
                 return -1;
             }
             break;
         case 't':
             endptr = NULL;
+            if (optarg_is_negative(optarg)) {
+                fprintf(stderr, "error: threads must be a positive integer.\n");
+                return -1;
+            }
+            errno = 0;
             cfg->threads = (unsigned int) strtoul(optarg, &endptr, 10);
-            if (!cfg->threads || !endptr || *endptr != '\0') {
+            if (errno == ERANGE || !cfg->threads || !endptr || *endptr != '\0') {
                 fprintf(stderr, "error: threads must be greater than zero.\n");
                 return -1;
             }
             break;
         case o_test_time:
             endptr = NULL;
+            if (optarg_is_negative(optarg)) {
+                fprintf(stderr, "error: test time must be a positive integer.\n");
+                return -1;
+            }
+            errno = 0;
             cfg->test_time = (unsigned int) strtoul(optarg, &endptr, 10);
-            if (!cfg->test_time || !endptr || *endptr != '\0') {
+            if (errno == ERANGE || !cfg->test_time || !endptr || *endptr != '\0') {
                 fprintf(stderr, "error: test time must be greater than zero.\n");
                 return -1;
             }

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -1005,8 +1005,9 @@ void run_stats::summarize(totals &result) const
     result.m_ar_commands.summarize(totals.m_ar_commands, test_duration_usec);
 
     // hits,misses / sec
-    result.m_hits_sec = (double) totals.m_get_cmd.m_hits / test_duration_usec * 1000000;
-    result.m_misses_sec = (double) totals.m_get_cmd.m_misses / test_duration_usec * 1000000;
+    result.m_hits_sec = test_duration_usec > 0 ? (double) totals.m_get_cmd.m_hits / test_duration_usec * 1000000 : 0.0;
+    result.m_misses_sec =
+        test_duration_usec > 0 ? (double) totals.m_get_cmd.m_misses / test_duration_usec * 1000000 : 0.0;
 
     // total/sec
     result.m_ops_sec = (double) result.m_ops / test_duration_usec * 1000000;

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -1004,13 +1004,14 @@ void run_stats::summarize(totals &result) const
     result.m_wait_cmd.summarize(totals.m_wait_cmd, test_duration_usec);
     result.m_ar_commands.summarize(totals.m_ar_commands, test_duration_usec);
 
+    // Guard against zero-duration runs (sub-microsecond or Ctrl-C at startup) which would produce +Inf/nan in the JSON.
     // hits,misses / sec
     result.m_hits_sec = test_duration_usec > 0 ? (double) totals.m_get_cmd.m_hits / test_duration_usec * 1000000 : 0.0;
     result.m_misses_sec =
         test_duration_usec > 0 ? (double) totals.m_get_cmd.m_misses / test_duration_usec * 1000000 : 0.0;
 
     // total/sec
-    result.m_ops_sec = (double) result.m_ops / test_duration_usec * 1000000;
+    result.m_ops_sec = (test_duration_usec > 0) ? (double) result.m_ops / test_duration_usec * 1000000 : 0.0;
     const unsigned long long int total_latency_sum =
         totals.m_set_cmd.m_total_latency + totals.m_get_cmd.m_total_latency + totals.m_wait_cmd.m_total_latency +
         totals.m_ar_commands.total_latency();
@@ -1021,15 +1022,24 @@ void run_stats::summarize(totals &result) const
         result.m_latency = 0;
     }
 
-    result.m_bytes_sec = ((result.m_bytes_rx + result.m_bytes_tx) / 1024.0) / test_duration_usec * 1000000;
-    result.m_bytes_sec_rx = (result.m_bytes_rx / 1024.0) / test_duration_usec * 1000000;
-    result.m_bytes_sec_tx = (result.m_bytes_tx / 1024.0) / test_duration_usec * 1000000;
-    result.m_moved_sec = (double) (totals.m_set_cmd.m_moved + totals.m_get_cmd.m_moved) / test_duration_usec * 1000000;
-    result.m_ask_sec = (double) (totals.m_set_cmd.m_ask + totals.m_get_cmd.m_ask) / test_duration_usec * 1000000;
+    result.m_bytes_sec = (test_duration_usec > 0)
+                             ? ((result.m_bytes_rx + result.m_bytes_tx) / 1024.0) / test_duration_usec * 1000000
+                             : 0.0;
+    result.m_bytes_sec_rx =
+        (test_duration_usec > 0) ? (result.m_bytes_rx / 1024.0) / test_duration_usec * 1000000 : 0.0;
+    result.m_bytes_sec_tx =
+        (test_duration_usec > 0) ? (result.m_bytes_tx / 1024.0) / test_duration_usec * 1000000 : 0.0;
+    result.m_moved_sec = (test_duration_usec > 0) ? (double) (totals.m_set_cmd.m_moved + totals.m_get_cmd.m_moved) /
+                                                        test_duration_usec * 1000000
+                                                  : 0.0;
+    result.m_ask_sec = (test_duration_usec > 0)
+                           ? (double) (totals.m_set_cmd.m_ask + totals.m_get_cmd.m_ask) / test_duration_usec * 1000000
+                           : 0.0;
 
     // connection errors/sec
     result.m_connection_errors = totals.m_connection_errors;
-    result.m_connection_errors_sec = (double) totals.m_connection_errors / test_duration_usec * 1000000;
+    result.m_connection_errors_sec =
+        (test_duration_usec > 0) ? (double) totals.m_connection_errors / test_duration_usec * 1000000 : 0.0;
 }
 
 void result_print_to_json(json_handler *jsonhandler, const char *type, double ops_sec, double hits, double miss,

--- a/tests/test_cli_validation_count_flags.py
+++ b/tests/test_cli_validation_count_flags.py
@@ -1,0 +1,201 @@
+"""
+CLI validation regression tests for -c / -t / -n / --test-time count flags.
+
+Covers 2.4 release-readiness review finding #24:
+
+  ``strtoul`` was called WITHOUT ``errno=0`` checking and WITHOUT
+  ``optarg_is_negative()`` on the four older count flags (-c, -t, -n,
+  --test-time).  Negative input like ``-c -1`` wrapped through the
+  unsigned cast (strtoul("-1") -> ULONG_MAX -> (unsigned int) UINT_MAX =
+  4294967295) and the run loop then tried to spawn ~4 billion clients,
+  producing an OOM / SIGABRT.
+
+Same crash class as merged phases #428 / #429 which fixed --pipeline,
+--data-size, and --run-count.
+
+After the fix, negative and zero inputs must be rejected at parse time
+with exit code 2 and a readable message on stderr.  No live Redis
+connection is required for any of these tests.
+
+Run with:
+  TEST=test_cli_validation_count_flags.py OSS_STANDALONE=1 ./tests/run_tests.sh
+"""
+
+import subprocess
+
+from include import MEMTIER_BINARY
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _run_memtier(args):
+    """Run memtier_benchmark with *args* and return the CompletedProcess.
+
+    No --server is supplied: validation must reject the bad value before
+    any connection attempt is made.
+    """
+    return subprocess.run(
+        [MEMTIER_BINARY] + args,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# -c / --clients
+# ---------------------------------------------------------------------------
+
+
+def test_clients_negative_rejected(env):
+    """-c -1 must be rejected (was OOM / SIGABRT via strtoul wrap)."""
+    result = _run_memtier(["-c", "-1"])
+
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="-c -1 must exit non-zero (was OOM / SIGABRT via strtoul wrap)",
+    )
+    env.assertTrue(
+        "clients must be" in result.stderr,
+        message=(
+            "Expected 'clients must be' in stderr, got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+def test_clients_zero_rejected(env):
+    """-c 0 must be rejected with a clear error."""
+    result = _run_memtier(["-c", "0"])
+
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="-c 0 must exit non-zero",
+    )
+    env.assertTrue(
+        "clients must be" in result.stderr,
+        message=(
+            "Expected 'clients must be' in stderr, got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# -t / --threads
+# ---------------------------------------------------------------------------
+
+
+def test_threads_negative_rejected(env):
+    """-t -1 must be rejected (was OOM / SIGABRT via strtoul wrap)."""
+    result = _run_memtier(["-t", "-1"])
+
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="-t -1 must exit non-zero (was OOM / SIGABRT via strtoul wrap)",
+    )
+    env.assertTrue(
+        "threads must be" in result.stderr,
+        message=(
+            "Expected 'threads must be' in stderr, got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+def test_threads_zero_rejected(env):
+    """-t 0 must be rejected with a clear error."""
+    result = _run_memtier(["-t", "0"])
+
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="-t 0 must exit non-zero",
+    )
+    env.assertTrue(
+        "threads must be" in result.stderr,
+        message=(
+            "Expected 'threads must be' in stderr, got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# -n / --requests  (note: -n -1 / -n allkeys is a valid sentinel — test -n -2)
+# ---------------------------------------------------------------------------
+
+
+def test_requests_negative_two_rejected(env):
+    """-n -2 must be rejected; only the literal string 'allkeys' is a valid sentinel."""
+    result = _run_memtier(["-n", "-2"])
+
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="-n -2 must exit non-zero (only 'allkeys' is a valid non-numeric value)",
+    )
+    env.assertTrue(
+        "requests must be" in result.stderr,
+        message=(
+            "Expected 'requests must be' in stderr, got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+def test_requests_zero_rejected(env):
+    """-n 0 must be rejected with a clear error."""
+    result = _run_memtier(["-n", "0"])
+
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="-n 0 must exit non-zero",
+    )
+    env.assertTrue(
+        "requests must be" in result.stderr,
+        message=(
+            "Expected 'requests must be' in stderr, got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# --test-time
+# ---------------------------------------------------------------------------
+
+
+def test_test_time_negative_rejected(env):
+    """--test-time=-1 must be rejected (was OOM / SIGABRT via strtoul wrap)."""
+    result = _run_memtier(["--test-time=-1"])
+
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="--test-time=-1 must exit non-zero (was OOM / SIGABRT via strtoul wrap)",
+    )
+    env.assertTrue(
+        "test time must be" in result.stderr,
+        message=(
+            "Expected 'test time must be' in stderr, got: {!r}".format(result.stderr)
+        ),
+    )
+
+
+def test_test_time_zero_rejected(env):
+    """--test-time=0 must be rejected with a clear error."""
+    result = _run_memtier(["--test-time=0"])
+
+    env.assertNotEqual(
+        result.returncode,
+        0,
+        message="--test-time=0 must exit non-zero",
+    )
+    env.assertTrue(
+        "test time must be" in result.stderr,
+        message=(
+            "Expected 'test time must be' in stderr, got: {!r}".format(result.stderr)
+        ),
+    )


### PR DESCRIPTION
## Summary

Two small hygiene fixes flagged in the 2.4 release-readiness review.

**1. Reject negative `-c/-t/-n/--test-time`** (`memtier_benchmark.cpp`)

The merged phase-2 sweep (#428/#429) added `optarg_is_negative` + `errno=ERANGE` guards to `--pipeline`, `--data-size`, `--run-count` etc., but missed the four older count flags. `-c -1` → `strtoul` wraps → `(unsigned int)UINT_MAX = 4294967295` → ~4 billion clients spawned. Same crash class.

Adds the existing pattern to all four cases. Preserves the `-n allkeys` sentinel.

**2. Guard `Hits/sec` from divide-by-zero** (`run_stats.cpp:1008-1009`)

The legacy GET path's `summarize()` was the lone holdout missing a `test_duration_usec > 0` guard. Sub-microsecond runs (or Ctrl-C at startup) produced `+Inf` / `nan` in the JSON. Adds the guard; matches the pattern every other 2.4 hits/sec computation already uses.

## Test plan

- [ ] New parser tests assert exit-2 + descriptive error for `-c -1`, `-c 0`, `-t -1`, `-t 0`, `-n -2`, `-n 0`, `--test-time -1`, `--test-time 0`
- [ ] Existing test_json_output_integrity.py catches any regression in the legacy GET stats path
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input validation and defensive math in stats reporting; no auth, networking protocol, or persistence changes.
> 
> **Overview**
> Hardens **CLI parsing** for `-c`, `-t`, `-n`, and `--test-time` so negative or zero values fail at startup with a clear stderr message instead of `strtoul` wrapping to huge counts and OOM (same pattern as earlier fixes for `--pipeline` / `--data-size` / `--run-count`). A new **`tests/test_cli_validation_count_flags.py`** exercises those rejections without Redis.
> 
> In **`run_stats::summarize`**, all per-second rates that divide by `test_duration_usec` (hits/misses, ops, KB/s, MOVED/ASK, connection errors) now return **0.0** when duration is zero, avoiding `+Inf`/`nan` in JSON on sub-microsecond runs or immediate interrupt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8bd230f87bd1f372723b07bfaced8428219a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->