### PR TITLE
fix(cluster): defensive clamp on m_reqs_generated subtraction at three sites

### DIFF
--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -241,7 +241,13 @@ bool cluster_client::connect_shard_connection(shard_connection *sc, char *addres
         // Commands in the cleared staged queue were already counted in m_reqs_generated at
         // staging time. Compensate so a --requests run is not left waiting for responses
         // that will never arrive.
-        m_reqs_generated -= empty_staged.size();
+        // Defensive clamp: today entries in empty_staged are popped before m_reqs_generated
+        // is decremented so underflow cannot occur, but guard explicitly so a future
+        // refactor does not silently wrap to 2^64.  Matches the pattern at hold_pipeline.
+        {
+            const size_t n = empty_staged.size();
+            m_reqs_generated -= (m_reqs_generated >= n) ? n : m_reqs_generated;
+        }
     }
 
     // save address and port
@@ -501,7 +507,14 @@ void cluster_client::handle_cluster_slots(protocol_response *r)
             if (!m_staged_monitor_commands[i].empty()) {
                 std::queue<staged_monitor_cmd> empty_staged;
                 std::swap(m_staged_monitor_commands[i], empty_staged);
-                m_reqs_generated -= empty_staged.size();
+                // Defensive clamp: entries in empty_staged are popped before
+                // m_reqs_generated is decremented so underflow cannot occur today,
+                // but guard explicitly so a future refactor does not silently wrap
+                // to 2^64.  Matches the pattern at hold_pipeline.
+                {
+                    const size_t n = empty_staged.size();
+                    m_reqs_generated -= (m_reqs_generated >= n) ? n : m_reqs_generated;
+                }
             }
             if (m_connections[i]->get_connection_state() != conn_disconnected) {
                 m_connections[i]->disconnect();
@@ -1067,7 +1080,14 @@ void cluster_client::handle_moved(unsigned int conn_id, struct timeval timestamp
         std::swap(m_staged_monitor_commands[conn_id], empty_staged);
         // Staged commands were already counted in m_reqs_generated at staging time.
         // Compensate so a --requests run does not hang waiting for phantom responses.
-        m_reqs_generated -= empty_staged.size();
+        // Defensive clamp: entries in empty_staged are popped before m_reqs_generated
+        // is decremented so underflow cannot occur today, but guard explicitly so a
+        // future refactor does not silently wrap to 2^64.  Matches the pattern at
+        // hold_pipeline.
+        {
+            const size_t n = empty_staged.size();
+            m_reqs_generated -= (m_reqs_generated >= n) ? n : m_reqs_generated;
+        }
     }
 
     // set connection to send 'CLUSTER SLOTS' command


### PR DESCRIPTION
## Summary

- Three sites in `cluster_client.cpp` (`connect_shard_connection` L244, `handle_cluster_slots` retire-shard branch L504, `handle_moved` L1070) subtract `empty_staged.size()` from `m_reqs_generated` with no underflow guard.
- PR #399 introduced a defensive clamp at `hold_pipeline` for the same reason; this PR matches that pattern at the three sibling sites.
- Today the invariant (entries in `empty_staged` are popped before `m_reqs_generated` is decremented) prevents underflow, but it is undocumented. A future refactor could silently wrap `m_reqs_generated` to 2^64 and permanently wedge a `--requests`-bounded run.

## Fix

Each bare subtraction is replaced with:

```cpp
const size_t n = empty_staged.size();
m_reqs_generated -= (m_reqs_generated >= n) ? n : m_reqs_generated;
```

An inline comment at each site documents the invariant and references `hold_pipeline` as the canonical pattern.

## Test plan

- [ ] `autoreconf -ivf && ./configure && make -j` — clean build, no new warnings.
- [ ] Run against a live Redis cluster with `--monitor-input` and trigger topology changes (MOVED, slot rebalance, shard reconnect) to confirm no hang with `--requests`.
- [ ] Verify no behavioural change when `empty_staged` is empty (the common path).

Refs: Review 16 (analysis that the subtraction sites are safe today but unguarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive accounting change in cluster client teardown paths; no auth, protocol, or routing logic changes.
> 
> **Overview**
> When cluster topology or shard state clears **staged monitor** queues, the benchmark already subtracts those entries from `m_reqs_generated` so `--requests` runs do not wait for responses that will never arrive.
> 
> This change replaces three **unchecked** subtractions in `cluster_client.cpp`—in `connect_shard_connection`, the retire-shard path in `handle_cluster_slots`, and `handle_moved`—with the same **defensive clamp** used in `hold_pipeline`: subtract at most the current counter value so unsigned underflow cannot wrap `m_reqs_generated` and wedge a bounded run. Inline comments document the invariant and point to `hold_pipeline` as the canonical pattern.
> 
> Behavior on today's code paths should be unchanged; the guard is for future refactors that might double-compensate or skew the counter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef80e866f1b21d68849845adfa538ee73d62a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->