### PR TITLE
fix(json): redact TLS cert/key/cacert paths to basename in mb.json

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -91,6 +91,16 @@
 
 int log_level = 0;
 
+// Return the basename of a file path (everything after the last '/' or '\').
+// Used to redact directory layout from JSON output (e.g. cert/key paths).
+static std::string basename_only(const char *p)
+{
+    if (!p || !*p) return "";
+    std::string s(p);
+    size_t i = s.find_last_of("/\\");
+    return (i == std::string::npos) ? s : s.substr(i + 1);
+}
+
 // Upper bound for --run-count.  main() allocates several per-run vectors
 // (run_stats, cmd_stats histograms, HDR histograms) that grow linearly with
 // run_count; values in the tens of thousands push tens of MiB of metadata
@@ -611,9 +621,9 @@ static void config_print_to_json(json_handler *jsonhandler, struct benchmark_con
     jsonhandler->write_obj("out_file", "\"%s\"", cfg->out_file);
 #ifdef USE_TLS
     jsonhandler->write_obj("tls", "\"%s\"", cfg->tls ? "true" : "false");
-    jsonhandler->write_obj("cert", "\"%s\"", cfg->tls_cert);
-    jsonhandler->write_obj("key", "\"%s\"", cfg->tls_key);
-    jsonhandler->write_obj("cacert", "\"%s\"", cfg->tls_cacert);
+    jsonhandler->write_obj("cert", "\"%s\"", basename_only(cfg->tls_cert).c_str());
+    jsonhandler->write_obj("key", "\"%s\"", basename_only(cfg->tls_key).c_str());
+    jsonhandler->write_obj("cacert", "\"%s\"", basename_only(cfg->tls_cacert).c_str());
     jsonhandler->write_obj("tls_skip_verify", "\"%s\"", cfg->tls_skip_verify ? "true" : "false");
     jsonhandler->write_obj("sni", "\"%s\"", cfg->tls_sni);
 #endif

--- a/tests/test_tls_logging.py
+++ b/tests/test_tls_logging.py
@@ -1,5 +1,5 @@
 """
-Tests for the one-shot negotiated-TLS log line.
+Tests for the one-shot negotiated-TLS log line and related JSON output hygiene.
 
 When --tls is enabled, memtier_benchmark logs the agreed TLS protocol version
 and ciphersuite exactly ONCE for the whole run (not per connection / thread /
@@ -11,6 +11,12 @@ These tests run across the full CI matrix:
 - TLS cells (standalone or cluster): assert the line appears EXACTLY once and
   carries a protocol + cipher, even with many connections.
 - Plaintext cells: assert the line does NOT appear.
+
+Path-redaction test (test_tls_paths_redacted_in_json):
+- When --tls is used, the configuration block in mb.json must contain only the
+  basename of cert/key/cacert paths, not the full absolute path.  This prevents
+  directory-layout details (e.g. /etc/ssl/private/client.key) from leaking into
+  benchmark artifacts that operators share.  Pre-existing in 2.3; fixed in 2.4.
 """
 
 import json
@@ -18,6 +24,9 @@ import os
 import tempfile
 
 from include import (
+    TLS_CACERT,
+    TLS_CERT,
+    TLS_KEY,
     add_required_env_arguments,
     addTLSArgs,
     debugPrintMemtierOnError,
@@ -85,6 +94,62 @@ def test_tls_negotiated_logged_once(env):
             env.assertEqual(len(lines), 0,
                             message="TLS line should not appear without --tls: {}".format(lines))
             env.assertNotContains("TLS", js)
+    finally:
+        if env.getNumberOfFailedAssertion() > failed:
+            debugPrintMemtierOnError(run_config, env)
+
+
+def test_tls_paths_redacted_in_json(env):
+    """mb.json configuration.cert/key/cacert must be basename-only, not full paths.
+
+    Absolute paths like /etc/ssl/private/client.key leak directory-layout
+    details into every benchmark artifact operators share.  The fix (2.4)
+    strips to basename before emitting JSON.  This test verifies that:
+
+    - In TLS cells: the JSON values equal os.path.basename(TLS_CERT/KEY/CACERT)
+      and contain no directory separator.
+    - In plaintext cells: the configuration block emits empty strings for those
+      fields (no path leakage in either case).
+    """
+    ok, run_config, _stderr, js = _run(env, threads=1, clients=2, requests=20)
+
+    failed = env.getNumberOfFailedAssertion()
+    try:
+        env.assertTrue(ok, message="memtier did not complete")
+        env.assertContains("configuration", js,
+                           message="mb.json must contain a 'configuration' block")
+        cfg = js["configuration"]
+
+        if env.useTLS:
+            # Each emitted value must be a pure basename (no slash of any kind).
+            for field, full_path in (("cert", TLS_CERT),
+                                     ("key", TLS_KEY if TLS_KEY else ""),
+                                     ("cacert", TLS_CACERT)):
+                emitted = cfg.get(field, None)
+                env.assertFalse(emitted is None,
+                                message="configuration.{} missing from mb.json".format(field))
+                # No directory separator must appear in the emitted value.
+                env.assertFalse("/" in emitted,
+                                message="configuration.{} leaks a path separator: {!r}".format(
+                                    field, emitted))
+                env.assertFalse("\\" in emitted,
+                                message="configuration.{} leaks a backslash path separator: {!r}".format(
+                                    field, emitted))
+                # When the full path is known, the basename must match exactly.
+                if full_path:
+                    expected = os.path.basename(full_path)
+                    env.assertEqual(emitted, expected,
+                                    message="configuration.{} is {!r}, expected basename {!r} "
+                                            "(full path was {!r})".format(
+                                                field, emitted, expected, full_path))
+        else:
+            # Without --tls the fields are emitted as empty strings; confirm no
+            # accidental path leaks (e.g. from a misconfigured non-TLS build).
+            for field in ("cert", "key", "cacert"):
+                emitted = cfg.get(field, "")
+                env.assertFalse("/" in emitted,
+                                message="configuration.{} contains a slash in non-TLS run: {!r}".format(
+                                    field, emitted))
     finally:
         if env.getNumberOfFailedAssertion() > failed:
             debugPrintMemtierOnError(run_config, env)


### PR DESCRIPTION
## Summary

The `configuration` block in `mb.json` emitted `--cert` / `--key` / `--cacert` values verbatim, leaking absolute paths (e.g., `/etc/ssl/private/client.key`) into every benchmark artifact ops shared. Pre-existing in 2.3; flagged by the 2.4 readiness review (Review 14).

Strips to basename only, preserving enough for the operator to identify which cert was used. POSIX `/` and Windows `\\` both handled.

## Test plan

- [ ] New `test_tls_paths_redacted_in_json` asserts `os.path.basename(TLS_CERT)` is what lands in JSON; no directory separator
- [ ] Existing TLS tests still pass
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON output hygiene only; TLS loading and handshake behavior are unchanged. Residual leak risk remains in stderr `--show-config`, not in mb.json.
> 
> **Overview**
> **mb.json** no longer writes full `--cert`, `--key`, and `--cacert` paths in the `configuration` block. Those fields are emitted as **basenames only** (POSIX `/` and Windows `\`), so shared benchmark artifacts do not expose directory layout while still identifying which files were used.
> 
> A small `basename_only` helper performs the strip at JSON serialization time. **Text** `--show-config` output is unchanged and can still print full paths.
> 
> **`test_tls_paths_redacted_in_json`** checks TLS matrix cells match `os.path.basename` with no path separators, and non-TLS runs keep empty cert/key/cacert without accidental leaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8824b354ea54d545a5f9eed35b4f67efe47ffe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->