### PR TITLE
docs(monitor-input): NUL/CR-only follow-up (code comment + README + downstream NUL issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,11 @@ OK
 
 You can pipe this output and filter specific patterns with tools such as `grep`, then save it to a file and use it as a `--monitor-input` source. For more details, see the official Redis documentation on [monitoring commands executed in Redis](https://redis.io/docs/latest/develop/tools/cli/#monitor-commands-executed-in-redis).
 
-**Binary payloads** are preserved end-to-end inside `monitor_command_list` (no NUL truncation as of 2.4). The file loader uses an explicit byte-count constructor so that embedded `\0` bytes in command arguments survive the load-from-file path.
-
-**CR-only line endings** (classic Mac `\r`, and some Windows export tools that emit bare `\r` without a following `\n`) parse correctly as of 2.4; previously such files were read as one giant line and no commands were replayed.
+> **What's new in 2.4**
+>
+> **Binary payloads** — the monitor capture loader preserves binary payloads (including embedded NUL bytes) end-to-end into `monitor_command_list`. **However**, dispatch via `arbitrary_command(const char *)` currently re-truncates at the first NUL — full binary blob support through replay is tracked as #439.
+>
+> **CR-only line endings** (classic Mac `\r`, and some Windows export tools that emit bare `\r` without a following `\n`) parse correctly; previously the whole file would be read as one giant line and no commands were replayed.
 
 ### Command statistics breakdown
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ OK
 
 You can pipe this output and filter specific patterns with tools such as `grep`, then save it to a file and use it as a `--monitor-input` source. For more details, see the official Redis documentation on [monitoring commands executed in Redis](https://redis.io/docs/latest/develop/tools/cli/#monitor-commands-executed-in-redis).
 
+**Binary payloads** are preserved end-to-end inside `monitor_command_list` (no NUL truncation as of 2.4). The file loader uses an explicit byte-count constructor so that embedded `\0` bytes in command arguments survive the load-from-file path.
+
+**CR-only line endings** (classic Mac `\r`, and some Windows export tools that emit bare `\r` without a following `\n`) parse correctly as of 2.4; previously such files were read as one giant line and no commands were replayed.
+
 ### Command statistics breakdown
 
 By default, when using arbitrary commands (`--command`), statistics are aggregated by command type (e.g., all SET commands are grouped together, all GET commands are grouped together). You can control this behavior with the `--command-stats-breakdown` option:

--- a/config_types.cpp
+++ b/config_types.cpp
@@ -299,13 +299,8 @@ static int hex_digit_to_int(char c)
     }
 }
 
-// NOTE: this constructor stores cmd as a C-string (std::string(const char*)),
-// so any embedded NUL bytes from a monitor-input payload are truncated at
-// this layer. load_from_file preserves them in the std::string it builds, but
-// the dispatch path calls this ctor via .c_str() and re-truncates.
-// Tracked as a separate follow-up: change to a (data, len) interface and
-// propagate through split_command_to_args / send so that binary blobs
-// replayed from MONITOR output survive end-to-end.
+// Stored as a C-string. Embedded NULs from monitor-input get truncated here —
+// full binary blob support requires a (data, len) refactor, tracked as #439.
 arbitrary_command::arbitrary_command(const char *cmd) :
         command(cmd),
         key_pattern('R'),

--- a/config_types.cpp
+++ b/config_types.cpp
@@ -299,6 +299,13 @@ static int hex_digit_to_int(char c)
     }
 }
 
+// NOTE: this constructor stores cmd as a C-string (std::string(const char*)),
+// so any embedded NUL bytes from a monitor-input payload are truncated at
+// this layer. load_from_file preserves them in the std::string it builds, but
+// the dispatch path calls this ctor via .c_str() and re-truncates.
+// Tracked as a separate follow-up: change to a (data, len) interface and
+// propagate through split_command_to_args / send so that binary blobs
+// replayed from MONITOR output survive end-to-end.
 arbitrary_command::arbitrary_command(const char *cmd) :
         command(cmd),
         key_pattern('R'),
@@ -539,6 +546,10 @@ bool arbitrary_command::set_ratio(const char *ratio_str)
 
 bool arbitrary_command::split_command_to_args()
 {
+    // command.c_str() yields a NUL-terminated view: any embedded \0 bytes
+    // (e.g. from a binary MONITOR payload preserved by load_from_file) will
+    // terminate the pointer-walk in the loop below. Full binary blob support
+    // requires moving to a (data, len) interface throughout this path.
     const char *p = command.c_str();
     size_t command_len = command.length();
 
@@ -738,7 +749,10 @@ bool monitor_command_list::load_from_file(const char *filename)
             size_t seg_len = seg_end ? (size_t) (seg_end - seg_start) : (size_t) (line + line_len - seg_start);
 
             total_lines++;
-            // Find the first quote - this is where the command starts
+            // Find the first quote - this is where the command starts.
+            // memchr respects the explicit byte count so NUL bytes in the
+            // metadata prefix don't cause early termination (strchr stopped
+            // at \0).
             char *first_quote = (char *) memchr(seg_start, '"', seg_len);
             if (!first_quote) {
                 seg_start = seg_end ? seg_end + 1 : line + line_len;


### PR DESCRIPTION
## Summary

- Adds an inline `memchr` code comment in `config_types.cpp` explaining why byte-count search replaced `strchr` (NUL bytes in the metadata prefix don't terminate the search early).
- Adds README paragraphs documenting the 2.4 capability changes: binary payloads are now preserved end-to-end inside `monitor_command_list`, and CR-only line endings (classic Mac / some Windows exporters) now parse correctly.
- Adds code comments near `arbitrary_command::arbitrary_command(const char *cmd)` and inside `split_command_to_args` flagging that **downstream `.c_str()` still re-truncates embedded NUL bytes** — the load-from-file fix from PR #434 preserves NULs in `std::string`, but command dispatch re-truncates. This is tracked as a separate follow-up.

## Follow-up issue

Full end-to-end binary blob support is tracked in: https://github.com/redis/memtier_benchmark/issues/439

## Test plan

- [ ] Review inline comments in `config_types.cpp` for accuracy and clarity.
- [ ] Review new README paragraphs under `### Using monitor input files` for accuracy.
- [ ] Verify issue #439 captures the downstream NUL truncation correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and README-only changes; no runtime logic modified.
> 
> **Overview**
> Documents **2.4 monitor-input behavior** in the README: binary payloads are kept through `monitor_command_list`, **CR-only** (`\r`) line endings parse correctly, and replay still **truncates at embedded NUL** when commands go through `arbitrary_command(const char *)` / `.c_str()` — called out as follow-up **#439**.
> 
> Adds matching **inline comments** in `config_types.cpp` at the `arbitrary_command` ctor, `split_command_to_args`, and the `memchr` quote search (why byte-count search avoids stopping on NUL in the MONITOR metadata prefix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cada2da64e99e8ef52da4946e79d3a1b25cb84e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->