### PR TITLE
test(monitor-fuzz): bump FUZZ_GROW_MAX + FUZZ_INCLUDE_HUGE defaults now #405 landed

### DIFF
--- a/tests/fuzz/fuzz_monitor_input.py
+++ b/tests/fuzz/fuzz_monitor_input.py
@@ -40,15 +40,17 @@ REDIS_PORT = os.environ.get("REDIS_PORT", "6379")
 MEMTIER = Path(os.environ.get("MEMTIER", str(DEFAULT_MEMTIER)))
 FUZZ_TIMEOUT = int(os.environ.get("FUZZ_TIMEOUT", "60"))
 SEED = int(os.environ.get("FUZZ_SEED", str(int.from_bytes(os.urandom(4), "big"))))
-# Max bytes for the `grow` mutator. The issue spec mentioned 8 MiB, but on
-# master (pre-PR #405) lines above ~1 MiB reliably trip a VLA stack overflow in
-# arbitrary_command::split_command_to_args(). Once #405 lands, bump the default
-# (or override with FUZZ_GROW_MAX=8388608 on a master that has the fix).
-GROW_MAX = int(os.environ.get("FUZZ_GROW_MAX", str(256 * 1024)))
+# Max bytes for the `grow` mutator. PR #405 (heap-vector fix for
+# arbitrary_command::split_command_to_args) has landed, so the old 256 KiB cap
+# that guarded against the VLA stack-overflow is no longer needed. The workflow
+# uses -max_len=33554432 (32 MiB); 8 MiB is a sensible default that exercises
+# multi-MB monitor lines without blowing the per-run time budget.
+GROW_MAX = int(os.environ.get("FUZZ_GROW_MAX", str(8 * 1024 * 1024)))
 # Whether to also fuzz the synthetic >16 MiB single-line and 1M-line seeds. These
-# exercise the heap-allocated split-token buffer and loader memory pressure paths
-# but require the PR #405 fix to be present, hence opt-in for now.
-INCLUDE_HUGE_SYNTHETIC = os.environ.get("FUZZ_INCLUDE_HUGE", "0") == "1"
+# exercise the heap-allocated split-token buffer and loader memory pressure paths.
+# PR #405 (the VLA stack-overflow fix) has landed, so these are now enabled by
+# default.
+INCLUDE_HUGE_SYNTHETIC = os.environ.get("FUZZ_INCLUDE_HUGE", "1") == "1"
 
 CRASH_PATTERNS = (
     b"stack smashing detected",
@@ -138,8 +140,9 @@ def mutate(seed_bytes: bytes) -> bytes:
 def generate_synthetic_seeds() -> dict:
     """Build the >16 MiB and million-line seeds that are too big to check in.
 
-    Gated behind FUZZ_INCLUDE_HUGE=1 until PR #405 (the VLA stack-overflow fix
-    for arbitrary_command::split_command_to_args) lands on master.
+    Enabled by default now that PR #405 (the VLA stack-overflow fix for
+    arbitrary_command::split_command_to_args) has landed. Suppress with
+    FUZZ_INCLUDE_HUGE=0 if needed.
     """
     if not INCLUDE_HUGE_SYNTHETIC:
         return {}


### PR DESCRIPTION
## Summary

- `FUZZ_GROW_MAX` default bumped from 256 KiB to 8 MiB (`8 * 1024 * 1024`). The old cap was a temporary guard against the VLA stack-overflow in `arbitrary_command::split_command_to_args()` that PR #405 fixed. The nightly workflow already caps absolute mutation size at 32 MiB.
- `FUZZ_INCLUDE_HUGE` default flipped from `0` to `1`. The synthetic >16 MiB single-line and 1M-line seeds (the exact regression path #405 fixed) are now included in every nightly run by default.
- All three "temporary until #405 lands" comments updated to reflect that #405 has landed.
- `.github/workflows/monitor-fuzz.yml` had no explicit overrides for either env var — nothing to remove there.

## Test plan

- [ ] Smoke-checked locally: `FUZZ_ITER=20 MEMTIER=<path> python3 tests/fuzz/fuzz_monitor_input.py` — no crashes (SIGSEGV/ASAN/sanitizer). Timeouts from huge-payload mutations confirmed as expected behaviour (the fuzzer is now exercising multi-MB paths as intended).
- [ ] Nightly CI (`monitor-fuzz.yml`) will now exercise the full intended coverage including `15_huge_single_line` and `16_million_tiny_lines` seeds.

Refs: 2.4 review #21 (Review 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes fuzz harness defaults and comments in tests/fuzz; no production or CI workflow file edits in the diff.
> 
> **Overview**
> Now that PR **#405** fixed the VLA stack overflow in `arbitrary_command::split_command_to_args`, the monitor-input fuzz driver **raises default coverage** instead of staying in a pre-fix safety mode.
> 
> **`FUZZ_GROW_MAX`** default goes from **256 KiB** to **8 MiB**, so the `grow` mutator can stress multi-megabyte monitor lines (still capped at 32 MiB per mutation). **`FUZZ_INCLUDE_HUGE`** defaults to **on**, so synthetic seeds `15_huge_single_line` and `16_million_tiny_lines` run in every fuzz session unless `FUZZ_INCLUDE_HUGE=0`. Comments and docstrings are updated to describe the new defaults and how to opt out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf0d34c95812463d670f4ea3fd1f09cf9bebdca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->