### PR TITLE
perf(fill_pipeline): make bufferevent_enable conditional on m_bev_paused

### DIFF
--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -236,7 +236,8 @@ shard_connection::shard_connection(unsigned int id, connections_manager *conns_m
         m_replay_queue(NULL),
         m_retry_drain_timer(NULL),
         m_current_retry_backoff_ms(0.0),
-        m_deferred_fill_timer(NULL)
+        m_deferred_fill_timer(NULL),
+        m_bev_paused(false)
 {
     m_id = id;
     m_conns_manager = conns_man;
@@ -346,6 +347,10 @@ void shard_connection::setup_event(int sockfd)
     if (m_bev) {
         bufferevent_free(m_bev);
     }
+    // Fresh bufferevent below starts enabled by default (after we call
+    // bufferevent_enable in handle_event on BEV_EVENT_CONNECTED); reset the
+    // pause flag so we don't carry stale state from a prior socket.
+    m_bev_paused = false;
 
 #ifdef USE_TLS
     if (m_config->openssl_ctx) {
@@ -467,6 +472,8 @@ void shard_connection::disconnect()
         bufferevent_free(m_bev);
         m_bev = NULL;
     }
+    // After free, any future bufferevent starts in the default (enabled) state.
+    m_bev_paused = false;
 
     if (m_event_timer != NULL) {
         event_free(m_event_timer);
@@ -1030,8 +1037,13 @@ void shard_connection::fill_pipeline(void)
 
     // Re-enable I/O in case a prior idle period disabled the bufferevent
     // (e.g. a --transaction non-pin connection that was held by hold_pipeline).
-    if (m_bev != NULL && get_connection_state() == conn_connected) {
+    // Gate on m_bev_paused so this lock-taking libevent call only fires when
+    // we actually need to undo a prior pause -- fill_pipeline runs per
+    // response received, so an unconditional enable here showed up as a ~4%
+    // ops/sec regression in the canonical SET/GET micro-bench.
+    if (m_bev != NULL && m_bev_paused && get_connection_state() == conn_connected) {
         bufferevent_enable(m_bev, EV_READ | EV_WRITE);
+        m_bev_paused = false;
     }
 
     while (!m_conns_manager->finished() && m_pipeline->size() < m_config->pipeline) {
@@ -1072,6 +1084,7 @@ void shard_connection::fill_pipeline(void)
                 m_conns_manager->disconnect_all();
             } else if (!m_config->request_rate) {
                 bufferevent_disable(m_bev, EV_WRITE | EV_READ);
+                m_bev_paused = true;
             }
         }
     }
@@ -1086,6 +1099,7 @@ void shard_connection::handle_event(short events)
     if ((get_connection_state() == conn_in_progress) && (events & BEV_EVENT_CONNECTED)) {
         m_connection_state = conn_connected;
         bufferevent_enable(m_bev, EV_READ | EV_WRITE);
+        m_bev_paused = false;
 
 #ifdef USE_TLS
         // Log the negotiated TLS version and cipher exactly once for the whole
@@ -1195,6 +1209,7 @@ void shard_connection::schedule_fill(void)
     // Re-enable I/O in case fill_pipeline silenced this connection while it
     // was blocked by transaction-mode hold_pipeline.
     bufferevent_enable(m_bev, EV_READ | EV_WRITE);
+    m_bev_paused = false;
     if (m_deferred_fill_timer == NULL) {
         m_deferred_fill_timer = event_new(m_event_base, -1, 0, deferred_fill_pipeline_cb, this);
         if (m_deferred_fill_timer == NULL) {

--- a/shard_connection.h
+++ b/shard_connection.h
@@ -279,6 +279,15 @@ private:
     // Cancelable timer for deferred fill_pipeline (replaces event_base_once to
     // avoid UAF when the connection is freed before the callback fires).
     struct event *m_deferred_fill_timer;
+
+    // Tracks whether the bufferevent was paused via bufferevent_disable(EV_READ|
+    // EV_WRITE) by fill_pipeline's idle-disable branch. fill_pipeline used to
+    // call bufferevent_enable() unconditionally on every invocation to recover
+    // from a --transaction hold_pipeline pause; that fired per-response and
+    // took libevent's BEV_LOCK in the hot path. The flag lets the resume be
+    // conditional. Invariant: m_bev_paused == true iff m_bev is currently in
+    // the EV_READ|EV_WRITE-disabled state.
+    bool m_bev_paused;
 };
 
 #endif // MEMTIER_BENCHMARK_SHARD_CONNECTION_H


### PR DESCRIPTION
## Summary

2.4 regression flagged by micro-bench: ~4% ops/sec drop on the canonical SET/GET workload vs 2.3.1.

**Root cause:** `bufferevent_enable(m_bev, EV_READ | EV_WRITE)` was added at the top of `shard_connection::fill_pipeline()` in #390 / #400 to recover from `--transaction`'s `hold_pipeline` disable. But `fill_pipeline` runs **per response received**, so this lock-taking libevent call (it takes `BEV_LOCK` internally even on a no-op) fires at the request rate.

**Fix:** Track pause state with a `bool m_bev_paused` flag. Only call `bufferevent_enable` when the flag indicates the bufferevent was actually paused.

- Invariant: `m_bev_paused == true` iff `m_bev` is in the `EV_READ|EV_WRITE`-disabled state.
- Flag is **set** at the lone `bufferevent_disable` site (idle-disable branch in `fill_pipeline`).
- Flag is **cleared** at every existing `bufferevent_enable` site (`fill_pipeline` resume branch, `handle_event` on `BEV_EVENT_CONNECTED`, `schedule_fill`), and on bev (re)creation / teardown (`setup_event`, `disconnect`).

## Validation

### Functional (`--transaction`)
Verified against a manual 3-node OSS cluster with `--cluster-mode --transaction --command="MULTI" --command="SET tx_{tag}_key __key__" --command="EXEC"` at pipeline=4, clients=4, threads=2:

| Binary  | Multis ops/sec | Sets ops/sec | Execs ops/sec |
|---------|----------------|--------------|---------------|
| master  | 382.69         | 382.69       | 382.69        |
| perffix | 428.36         | 428.18       | 428.18        |

1:1:1 Multis:Sets:Execs ratio preserved (no transactions torn apart, no server-side errors).

### Performance
Local micro-bench on a 14-core Intel Core Ultra 7 155U against a single localhost Redis 8.6.0. The canonical `pipeline=32 clients=50 threads=4 ratio=1:1` run is **server-bound** on this hardware (~605K-620K ops/sec is the Redis ceiling on one core), so the client-side improvement is masked by Redis saturation:

| Run (3 iters mean) | Before (master) | After (perffix) | Delta   |
|--------------------|-----------------|-----------------|---------|
| `--pipeline=32 --clients=50 --threads=4 --requests=300K` | 617,729 ops/sec | 619,599 ops/sec | +0.30%  |
| `--pipeline=1 --clients=50 --threads=4 --requests=100K`  | 124,999 ops/sec | 125,121 ops/sec | +0.10%  |

To exercise the client side, pinned memtier to 2 cores (`taskset -c 0,1`) to make the client the bottleneck:

| Run (3 iters mean) | Before (master) | After (perffix) | Delta   |
|--------------------|-----------------|-----------------|---------|
| `taskset -c 0,1 --pipeline=32 --clients=100 --threads=2 --requests=200K` | 322,237 ops/sec | 363,517 ops/sec | **+12.81%** |

The fix recovers the regression on client-bound workloads; the original 4% reported on the benchmark farm corresponds to a setup where the client is closer to the bottleneck than my localhost test rig.

## Test plan

- [x] Clean build, no new warnings (`autoreconf -ivf && ./configure && make -j`)
- [x] `--transaction` smoke against 3-node OSS cluster: 1:1:1 ratio preserved at pipeline=4
- [x] `--transaction` smoke against standalone (no-op warning + normal execution)
- [x] Micro-bench on client-bound workload (`taskset -c 0,1`): +12.81% recovery
- [x] Format check passes (`make format-check-staged`)
- [ ] CI: full transaction RLTest suite (`test_cluster_transaction.py`, `test_transaction_pipeline.py`)

Refs: 2.4 review #28 (Review 18 MED finding); regression introduced by #390 / #400.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized libevent I/O gating in `shard_connection` with an explicit pause flag; behavior change is skipping redundant enables on the steady-state path.
> 
> **Overview**
> Fixes a **~4% ops/sec regression** on high-throughput SET/GET by stopping `fill_pipeline()` from calling `bufferevent_enable()` on **every** response. That unconditional resume was added to undo idle/`--transaction` `hold_pipeline` pauses but runs in the hot path and takes libevent’s `BEV_LOCK` even when I/O was already enabled.
> 
> The change adds **`m_bev_paused`**, set when `fill_pipeline` disables read/write on an idle connection and cleared on connect, `schedule_fill`, and other real enable paths. **`bufferevent_enable` now runs only when the connection was actually paused**, preserving transaction and idle-disable behavior without per-response overhead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04db2218faeabc7108aaafe1c7cd672f74ee8476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->