### PR TITLE
test(cli-fuzz): tighten --connection-stage-timeout in fuzz harness

### DIFF
--- a/tests/cli_fuzz.py
+++ b/tests/cli_fuzz.py
@@ -390,6 +390,13 @@ def _run_memtier(extra_args):
         "--threads=1",
         "--clients=1",
         "--hide-histogram",
+        # Tighten the connection-stage supervisor (#431) so it fires well
+        # inside the subprocess timeout below; the default (30 s) is too
+        # large for the 10 s hang threshold, letting cases like
+        # `--authenticate ''` against a no-auth server look like hangs to
+        # the fuzzer. `extra_args` is appended after, so a fuzzed
+        # `--connection-stage-timeout=` value still wins (last flag wins).
+        "--connection-stage-timeout=3",
     ] + list(extra_args)
     return subprocess.run(
         cmd,


### PR DESCRIPTION
## Summary

The nightly CLI fuzz on master (`03ef76e8`) failed with:
\`\`\`
Failed: memtier_benchmark hung (>10s) on argv=['--authenticate', '']
\`\`\`

PR #445 re-broadened the fuzz strategy to include `--authenticate` (and other flags the connection-stage supervisor #431 is meant to bound). But the harness left `--connection-stage-timeout` at its 30s default while the subprocess timeout is 10s — so cases like `--authenticate ''` against a no-auth server hit the harness timeout before the supervisor could fire.

Pass `--connection-stage-timeout=3` in the canonical args so the supervisor reliably terminates within the 10s harness window. `extra_args` is appended after, so any fuzzed value of the same flag still wins (last-flag-wins).

## Test plan

- [ ] Nightly fuzz no longer reports spurious hangs on the `--authenticate ''` shape
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness tweak with no production or runtime behavior changes.
> 
> **Overview**
> The CLI fuzz harness in `tests/cli_fuzz.py` now passes **`--connection-stage-timeout=3`** in the canonical `memtier_benchmark` argv built by `_run_memtier`, so the connection-stage supervisor (#431) can abort stuck connect/auth loops **before** the harness’s **10s** `subprocess` timeout.
> 
> That closes a gap where the binary’s **30s** default let cases such as **`--authenticate ''`** against a no-auth server run long enough to be reported as false **hangs**. Fuzzed flags are still appended **after** this default, so a generated **`--connection-stage-timeout=`** value continues to win via last-flag-wins semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522eea0385dee57f7aa99a163a44c9d065b50504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->