### PR TITLE
feat(read-pref) [A2] CLI flags + JSON config + --command-is-read modifier (prep)

### DIFF
--- a/config_types.cpp
+++ b/config_types.cpp
@@ -308,7 +308,8 @@ arbitrary_command::arbitrary_command(const char *cmd) :
         ratio(1),
         stats_only(false),
         spec(NULL),
-        miss_tracking_enabled(false)
+        miss_tracking_enabled(false),
+        is_read_override(-1)
 {
     // command name is the first word in the command
     size_t pos = command.find(" ");

--- a/config_types.h
+++ b/config_types.h
@@ -191,6 +191,13 @@ struct arbitrary_command
     // Set by resolve_command_meta() (true iff spec exists and reply_shape is
     // miss-bearing). May be cleared later by the --command-miss-tracking flag.
     bool miss_tracking_enabled;
+
+    // Per-command read classification override set by --command-is-read.
+    // -1 = not set (inherit global read_preference classification),
+    //  0 = force treat as a write,
+    //  1 = force treat as a read.
+    // C++11-compatible replacement for std::optional<bool>.
+    int is_read_override; // -1 / 0 / 1
 };
 
 struct arbitrary_command_list

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -682,6 +682,42 @@ static void config_print_to_json(json_handler *jsonhandler, struct benchmark_con
         jsonhandler->write_obj("step_duration", "%u", cfg->step_duration);
     }
 
+    // Read-preference configuration
+    {
+        const char *rp_str = "primary";
+        switch (cfg->read_preference) {
+        case rp_secondary:
+            rp_str = "secondary";
+            break;
+        case rp_secondary_preferred:
+            rp_str = "secondaryPreferred";
+            break;
+        case rp_nearest:
+            rp_str = "nearest";
+            break;
+        default:
+            rp_str = "primary";
+            break;
+        }
+        jsonhandler->write_obj("read_preference", "\"%s\"", rp_str);
+
+        const char *rpf_str = "error";
+        switch (cfg->read_preference_fallback) {
+        case rpf_queue:
+            rpf_str = "queue";
+            break;
+        case rpf_primary:
+            rpf_str = "primary";
+            break;
+        default:
+            rpf_str = "error";
+            break;
+        }
+        jsonhandler->write_obj("read_preference_fallback", "\"%s\"", rpf_str);
+        jsonhandler->write_obj("replica_clients", "%u", cfg->replica_clients);
+        jsonhandler->write_obj("replicas_per_shard", "%u", cfg->replicas_per_shard);
+    }
+
     jsonhandler->close_nesting();
 }
 
@@ -1037,6 +1073,12 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_clients_start,
         o_clients_step,
         o_step_duration,
+        o_read_preference,
+        o_read_server,
+        o_command_is_read,
+        o_replica_clients,
+        o_replicas_per_shard,
+        o_read_preference_fallback,
         o_help
     };
 
@@ -1140,6 +1182,12 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         {"clients-start", 1, 0, o_clients_start},
         {"clients-step", 1, 0, o_clients_step},
         {"step-duration", 1, 0, o_step_duration},
+        {"read-preference", 1, 0, o_read_preference},
+        {"read-server", 1, 0, o_read_server},
+        {"command-is-read", 0, 0, o_command_is_read},
+        {"replica-clients", 1, 0, o_replica_clients},
+        {"replicas-per-shard", 1, 0, o_replicas_per_shard},
+        {"read-preference-fallback", 1, 0, o_read_preference_fallback},
         {NULL, 0, 0, 0}};
 
     int option_index;
@@ -1975,6 +2023,112 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                 return -1;
             }
             break;
+        case o_read_preference: {
+            if (!optarg) {
+                fprintf(stderr, "error: --read-preference requires a value.\n");
+                return -1;
+            }
+            if (strcasecmp(optarg, "primary") == 0) {
+                cfg->read_preference = rp_primary;
+            } else if (strcasecmp(optarg, "secondary") == 0) {
+                cfg->read_preference = rp_secondary;
+            } else if (strcasecmp(optarg, "secondaryPreferred") == 0) {
+                cfg->read_preference = rp_secondary_preferred;
+            } else if (strcasecmp(optarg, "nearest") == 0) {
+                cfg->read_preference = rp_nearest;
+            } else {
+                fprintf(stderr,
+                        "error: --read-preference must be one of: primary, secondary, "
+                        "secondaryPreferred, nearest (got '%s').\n",
+                        optarg);
+                return -1;
+            }
+            break;
+        }
+        case o_read_server: {
+            if (!optarg || !*optarg) {
+                fprintf(stderr, "error: --read-server requires a HOST:PORT argument.\n");
+                return -1;
+            }
+            // Parse HOST:PORT.  IPv6 addresses may be bracketed: [::1]:6380.
+            // Find the colon after any closing bracket.
+            const char *rsp = optarg;
+            const char *rscolon = NULL;
+            if (*rsp == '[') {
+                const char *bracket = strchr(rsp, ']');
+                if (!bracket) {
+                    fprintf(stderr, "error: --read-server: unterminated IPv6 bracket in '%s'.\n", optarg);
+                    return -1;
+                }
+                rscolon = strchr(bracket, ':');
+            } else {
+                rscolon = strrchr(rsp, ':');
+            }
+            if (!rscolon || rscolon == rsp || !*(rscolon + 1)) {
+                fprintf(stderr, "error: --read-server: expected HOST:PORT, got '%s'.\n", optarg);
+                return -1;
+            }
+            endptr = NULL;
+            unsigned long rport = strtoul(rscolon + 1, &endptr, 10);
+            if (!endptr || *endptr != '\0' || rport == 0 || rport > 65535) {
+                fprintf(stderr, "error: --read-server: invalid port in '%s'.\n", optarg);
+                return -1;
+            }
+            std::string rhost(rsp, (size_t) (rscolon - rsp));
+            // Strip IPv6 brackets from the stored hostname
+            if (!rhost.empty() && rhost[0] == '[' && rhost[rhost.size() - 1] == ']') {
+                rhost = rhost.substr(1, rhost.size() - 2);
+            }
+            cfg->read_servers.push_back(read_server_spec(rhost, (unsigned short) rport));
+            break;
+        }
+        case o_command_is_read: {
+            if (!cfg->arbitrary_commands || cfg->arbitrary_commands->size() == 0) {
+                fprintf(stderr, "error: --command-is-read must follow a --command.\n");
+                return -1;
+            }
+            arbitrary_command &ircmd = cfg->arbitrary_commands->get_last_command();
+            ircmd.is_read_override = 1;
+            break;
+        }
+        case o_replica_clients: {
+            endptr = NULL;
+            cfg->replica_clients = (unsigned int) strtoul(optarg, &endptr, 10);
+            if (!endptr || *endptr != '\0') {
+                fprintf(stderr, "error: --replica-clients must be a non-negative integer.\n");
+                return -1;
+            }
+            break;
+        }
+        case o_replicas_per_shard: {
+            endptr = NULL;
+            cfg->replicas_per_shard = (unsigned int) strtoul(optarg, &endptr, 10);
+            if (!endptr || *endptr != '\0') {
+                fprintf(stderr, "error: --replicas-per-shard must be a non-negative integer.\n");
+                return -1;
+            }
+            break;
+        }
+        case o_read_preference_fallback: {
+            if (!optarg) {
+                fprintf(stderr, "error: --read-preference-fallback requires a value.\n");
+                return -1;
+            }
+            if (strcasecmp(optarg, "error") == 0) {
+                cfg->read_preference_fallback = rpf_error;
+            } else if (strcasecmp(optarg, "queue") == 0) {
+                cfg->read_preference_fallback = rpf_queue;
+            } else if (strcasecmp(optarg, "primary") == 0) {
+                cfg->read_preference_fallback = rpf_primary;
+            } else {
+                fprintf(stderr,
+                        "error: --read-preference-fallback must be one of: error, queue, primary "
+                        "(got '%s').\n",
+                        optarg);
+                return -1;
+            }
+            break;
+        }
         default:
             return -1;
             break;
@@ -2000,6 +2154,30 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
                 return -1;
             }
         }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Read-preference post-parse validation
+    // ---------------------------------------------------------------------------
+
+    // --transaction and non-primary read-preference are mutually exclusive:
+    // the transaction pin model assumes all commands in a rotation target
+    // the same (primary) shard connection; routing reads to replicas inside
+    // a MULTI/EXEC block would break the atomicity guarantee.
+    if (cfg->transaction && cfg->read_preference != rp_primary) {
+        fprintf(stderr, "error: --transaction and --read-preference != primary are mutually exclusive. "
+                        "MULTI/EXEC blocks must run on the same primary connection; routing reads "
+                        "to replicas would break the atomicity guarantee.\n");
+        return -1;
+    }
+
+    // Warn when --read-preference is set but has no routing effect:
+    // in standalone mode (no --cluster-mode) the flag only works when at
+    // least one --read-server is given.
+    if (cfg->read_preference != rp_primary && !cfg->cluster_mode && cfg->read_servers.empty()) {
+        fprintf(stderr, "warning: --read-preference has no effect in standalone mode without "
+                        "--read-server. Specify at least one replica endpoint with --read-server "
+                        "HOST:PORT or add --cluster-mode.\n");
     }
 
     // --transaction needs at least one --command to operate on. In
@@ -2212,6 +2390,27 @@ void usage()
         "      --scan-incremental-max-iterations=NUMBER\n"
         "                                 Maximum number of continuation SCANs per iteration cycle\n"
         "                                 (default: 0, follow cursor until it returns 0).\n"
+        "      --command-is-read          Mark the preceding --command as a read operation for\n"
+        "                                 --read-preference routing (per-command override).\n"
+        "\n"
+        "Read Preference Options:\n"
+        "      --read-preference=MODE     Which node class receives read commands (default: primary).\n"
+        "                                 primary           - all reads go to the master/primary node\n"
+        "                                 secondary         - all reads go to replica nodes only\n"
+        "                                 secondaryPreferred - replicas preferred; fall back to primary\n"
+        "                                 nearest           - any node; no strict placement guarantee\n"
+        "      --read-server=HOST:PORT    Replica endpoint for standalone (non-cluster) mode.\n"
+        "                                 Repeatable; each occurrence adds one replica endpoint.\n"
+        "                                 IPv6 addresses may be given as [::1]:6380.\n"
+        "      --replica-clients=N        Connections per replica per client thread (default: 0 = inherit\n"
+        "                                 --clients).\n"
+        "      --replicas-per-shard=K     Cap on replicas used per shard (default: 0 = all).\n"
+        "      --read-preference-fallback=MODE\n"
+        "                                 What to do when the target node class is unavailable\n"
+        "                                 (default: error).\n"
+        "                                 error   - return an error\n"
+        "                                 queue   - queue the request until a suitable node appears\n"
+        "                                 primary - fall back silently to the primary\n"
         "\n"
         "Object Options:\n"
         "  -d  --data-size=SIZE           Object data size in bytes (default: 32)\n"

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -56,6 +56,37 @@ enum PROTOCOL_TYPE
     PROTOCOL_MEMCACHE_BINARY,
 };
 
+// ---------------------------------------------------------------------------
+// Read-preference enums (storage lives in benchmark_config below)
+// ---------------------------------------------------------------------------
+
+// Which node class should receive read commands.
+enum read_pref_mode
+{
+    rp_primary = 0,         // all reads go to the master/primary (default)
+    rp_secondary,           // reads go to replica nodes only
+    rp_secondary_preferred, // replicas preferred; fall back to primary
+    rp_nearest              // any node; no strict placement guarantee
+};
+
+// What to do when the target node class is unavailable.
+enum read_pref_fallback
+{
+    rpf_error = 0, // return an error to the caller (default)
+    rpf_queue,     // queue the request until a suitable node is available
+    rpf_primary    // fall back silently to the primary
+};
+
+// Lightweight representation of a --read-server HOST:PORT entry.
+// Stored at parse time; routing code converts to server_addr objects later.
+struct read_server_spec
+{
+    std::string host;
+    unsigned short port;
+
+    read_server_spec(const std::string &h, unsigned short p) : host(h), port(p) {}
+};
+
 // Shared MGET slot cache: built once (lazily, on first topology load) and
 // read concurrently by all cluster_client threads.  m_mget_slot_keys is
 // identical for every thread — only the per-slot round-robin cursors differ.
@@ -196,6 +227,21 @@ struct benchmark_config
     bool scan_incremental_iteration;
     unsigned int scan_incremental_max_iterations;
     arbitrary_command *scan_continuation_command;
+    // ---------------------------------------------------------------------------
+    // Read-preference configuration
+    //   read_preference         which node class receives reads (default: primary)
+    //   read_preference_fallback what to do when the target is unavailable
+    //   read_servers            replica endpoints for standalone mode
+    //                           (--read-server HOST:PORT, repeatable)
+    //   replica_clients         connections per replica per client thread;
+    //                           0 = inherit --clients
+    //   replicas_per_shard      cap on replicas used per shard; 0 = all
+    // ---------------------------------------------------------------------------
+    enum read_pref_mode read_preference;
+    enum read_pref_fallback read_preference_fallback;
+    std::vector<read_server_spec> read_servers;
+    unsigned int replica_clients;
+    unsigned int replicas_per_shard;
 #ifdef USE_TLS
     bool tls;
     const char *tls_cert;

--- a/tests/test_cli_validation_read_preference.py
+++ b/tests/test_cli_validation_read_preference.py
@@ -1,0 +1,226 @@
+"""
+CLI parse-time validation tests for the --read-preference family of flags.
+
+These tests exercise only the argument-parsing path and do not require a live
+Redis server — we invoke the binary with subprocess, expect a specific exit
+code and a clear message in stderr or stdout.
+
+Tests covered:
+  1. --read-preference rejects unknown modes.
+  2. --read-preference=primary (default) is accepted silently.
+  3. --read-preference=secondary without --cluster-mode or --read-server emits
+     a warning but still exits 0 (it's a warning, not an error).
+  4. --transaction + --read-preference!=primary is a hard error.
+  5. --read-server with a bad HOST:PORT is rejected.
+  6. --read-server with a valid IPv4 HOST:PORT is accepted (parse only, no
+     connection required when we print --show-config and exit before running).
+  7. --read-preference-fallback rejects unknown values.
+  8. --command-is-read without a preceding --command is rejected.
+
+Run with:
+  TEST=test_cli_validation_read_preference.py OSS_STANDALONE=1 ./tests/run_tests.sh
+"""
+import subprocess
+
+from include import MEMTIER_BINARY
+
+
+def _run(args, timeout=10):
+    """Run memtier_benchmark with *args*, return CompletedProcess."""
+    return subprocess.run(
+        [MEMTIER_BINARY] + args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Common fragments
+# ---------------------------------------------------------------------------
+
+_BASE = ["-s", "127.0.0.1", "-p", "6379", "--test-time=1"]
+
+# Use --show-config so the binary parses CLI and prints config, but we kill
+# it very quickly.  We just need parse-time behaviour; the server doesn't
+# have to be up.
+_BASE_SHOW = ["-s", "127.0.0.1", "-p", "6379", "--show-config", "--test-time=1"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Unknown --read-preference value
+# ---------------------------------------------------------------------------
+
+def test_read_preference_unknown_mode_rejected(env):
+    """--read-preference=bogus must be rejected with a clear error."""
+    result = _run(_BASE + ["--read-preference=bogus"])
+
+    env.assertNotEqual(result.returncode, 0,
+                       message="--read-preference=bogus must exit non-zero")
+    env.assertTrue(
+        "--read-preference must be one of" in result.stderr,
+        message="Expected mode-list rejection in stderr; got: {!r}".format(result.stderr),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Valid modes are accepted (just parse-time check via bad connection)
+# ---------------------------------------------------------------------------
+
+def test_read_preference_all_valid_modes_parse(env):
+    """Each valid mode name must be accepted at parse time."""
+    for mode in ("primary", "secondary", "secondaryPreferred", "nearest"):
+        # With a bad port the binary will fail at connect time (non-zero exit),
+        # but we want exit != 2 (usage error).  The parse path exits with 2 on
+        # bad options.  We just check that the binary does NOT print the
+        # mode-list rejection message.
+        result = _run(
+            ["-s", "127.0.0.1", "-p", "1", "--test-time=1",
+             "--read-preference={}".format(mode)],
+            timeout=5,
+        )
+        env.assertFalse(
+            "--read-preference must be one of" in result.stderr,
+            message="Mode '{}' should not trigger rejection; stderr: {!r}".format(
+                mode, result.stderr),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. --read-preference without cluster or read-server emits a warning
+# ---------------------------------------------------------------------------
+
+def test_read_preference_no_cluster_no_server_warns(env):
+    """--read-preference=secondary standalone (no --cluster-mode, no
+    --read-server) must emit a warning but not a hard error."""
+    result = _run(
+        ["-s", "127.0.0.1", "-p", "1", "--test-time=1",
+         "--read-preference=secondary"],
+        timeout=5,
+    )
+    env.assertTrue(
+        "--read-preference has no effect" in result.stderr,
+        message="Expected 'has no effect' warning in stderr; got: {!r}".format(
+            result.stderr),
+    )
+    # The rejection message (exit-2) must NOT appear.
+    env.assertFalse(
+        "--read-preference must be one of" in result.stderr,
+        message="Must not be a parse error; got: {!r}".format(result.stderr),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. --transaction + --read-preference != primary is a hard error
+# ---------------------------------------------------------------------------
+
+def test_transaction_with_non_primary_read_pref_rejected(env):
+    """Combining --transaction with --read-preference!=primary must fail."""
+    for mode in ("secondary", "secondaryPreferred", "nearest"):
+        result = _run(
+            ["-s", "127.0.0.1", "-p", "6379",
+             "--cluster-mode",
+             "--transaction",
+             "--command", "GET __key__",
+             "--read-preference={}".format(mode),
+             "--test-time=1"],
+        )
+        env.assertNotEqual(
+            result.returncode, 0,
+            message="--transaction + --read-preference={} must exit non-zero".format(mode),
+        )
+        env.assertTrue(
+            "mutually exclusive" in result.stderr,
+            message="Expected 'mutually exclusive' message; got: {!r}".format(
+                result.stderr),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. --read-server with bad HOST:PORT is rejected
+# ---------------------------------------------------------------------------
+
+def test_read_server_bad_format_rejected(env):
+    """--read-server without a port must be rejected."""
+    for bad in ("localhost", "localhost:", "localhost:abc", ":6379", ""):
+        result = _run(_BASE + ["--read-server={}".format(bad)])
+        env.assertNotEqual(
+            result.returncode, 0,
+            message="--read-server='{}' must exit non-zero".format(bad),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. --read-server with valid HOST:PORT is accepted (parse-time only)
+# ---------------------------------------------------------------------------
+
+def test_read_server_valid_format_accepted(env):
+    """--read-server=127.0.0.1:6380 must not trigger a parse-time error."""
+    result = _run(
+        ["-s", "127.0.0.1", "-p", "1", "--test-time=1",
+         "--read-preference=secondary",
+         "--read-server=127.0.0.1:6380"],
+        timeout=5,
+    )
+    # Parse error exits with code 2 or prints usage; a connection error
+    # does not.  We just verify there is no parse rejection message.
+    env.assertFalse(
+        "--read-server: expected HOST:PORT" in result.stderr,
+        message="Valid --read-server should not print parse error; got: {!r}".format(
+            result.stderr),
+    )
+    # Also the 'has no effect' warning must NOT appear when --read-server is
+    # supplied (the flag does have effect in that case).
+    env.assertFalse(
+        "--read-preference has no effect" in result.stderr,
+        message="Should not warn 'has no effect' when --read-server given; got: {!r}".format(
+            result.stderr),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. --read-preference-fallback rejects unknown values
+# ---------------------------------------------------------------------------
+
+def test_read_preference_fallback_unknown_value_rejected(env):
+    """--read-preference-fallback=bogus must be rejected."""
+    result = _run(_BASE + ["--read-preference-fallback=bogus"])
+
+    env.assertNotEqual(result.returncode, 0,
+                       message="--read-preference-fallback=bogus must exit non-zero")
+    env.assertTrue(
+        "--read-preference-fallback must be one of" in result.stderr,
+        message="Expected fallback-list rejection; got: {!r}".format(result.stderr),
+    )
+
+
+def test_read_preference_fallback_valid_values_accepted(env):
+    """All three valid fallback values must be accepted at parse time."""
+    for val in ("error", "queue", "primary"):
+        result = _run(
+            ["-s", "127.0.0.1", "-p", "1", "--test-time=1",
+             "--read-preference-fallback={}".format(val)],
+            timeout=5,
+        )
+        env.assertFalse(
+            "--read-preference-fallback must be one of" in result.stderr,
+            message="Fallback '{}' should not trigger rejection; stderr: {!r}".format(
+                val, result.stderr),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. --command-is-read without preceding --command
+# ---------------------------------------------------------------------------
+
+def test_command_is_read_without_command_rejected(env):
+    """--command-is-read without a preceding --command must be rejected."""
+    result = _run(_BASE + ["--command-is-read"])
+
+    env.assertNotEqual(result.returncode, 0,
+                       message="--command-is-read without --command must exit non-zero")
+    env.assertTrue(
+        "--command-is-read must follow a --command" in result.stderr,
+        message="Expected 'must follow a --command' message; got: {!r}".format(
+            result.stderr),
+    )


### PR DESCRIPTION
## Summary

This PR implements the CLI/config slice (A2) of the `--read-preference` feature.  It has no routing logic — it only wires up parse-time infrastructure that the routing (A1/foundation) and test (A3) branches depend on.

- **Enums + struct fields** (`memtier_benchmark.h`, `config_types.h/.cpp`): add `read_pref_mode`, `read_pref_fallback`, `read_server_spec`; extend `benchmark_config` with `read_preference`, `read_preference_fallback`, `read_servers`, `replica_clients`, `replicas_per_shard`; add `is_read_override` (int tri-state, C++11-compatible `optional<bool>` replacement) to `arbitrary_command`.
- **CLI flags** (`memtier_benchmark.cpp`): `--read-preference`, `--read-server`, `--command-is-read`, `--replica-clients`, `--replicas-per-shard`, `--read-preference-fallback` — all parsed in `config_parse_args` following the existing long-option pattern.
- **Parse-time validation**: `--transaction` + non-primary read-preference → hard error; `--read-preference` without `--cluster-mode`/`--read-server` → warning; bad `--read-server` HOST:PORT → error; `--command-is-read` without preceding `--command` → error.
- **JSON output**: `config_print_to_json` extended with `read_preference`, `read_preference_fallback`, `replica_clients`, `replicas_per_shard` under the `configuration` block.
- **Help text**: new "Read Preference Options" section in `usage()` plus `--command-is-read` in the Arbitrary command section.
- **CLI validation tests** (`tests/test_cli_validation_read_preference.py`): 8 subprocess-based tests; no live Redis required.

## Merge order

Must be merged **after** A1 (`feat/read-pref-A1-foundation`) since A1 adds `is_read` to `command_meta` which A2 references in comments. Can be merged independently from A3 (`feat/read-pref-A3-tests`).

## Test plan

- [ ] `make` (build) passes cleanly — verified locally
- [ ] `make format-check-staged` passes — verified locally
- [ ] `./memtier_benchmark --read-preference=bogus` → parse error
- [ ] `./memtier_benchmark --transaction --command="GET __key__" --cluster-mode --read-preference=secondary` → mutually-exclusive error
- [ ] `./memtier_benchmark --read-preference=secondary -p 1` → warning (no cluster/no read-server)
- [ ] `./memtier_benchmark --read-preference=secondary --read-server=127.0.0.1:6380 -p 1` → no warning, connection error only
- [ ] JSON output contains `read_preference`, `read_preference_fallback`, `replica_clients`, `replicas_per_shard` keys
- [ ] `tests/test_cli_validation_read_preference.py` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)