### PR TITLE
fix(run_stats): normalize through int64_t microseconds in timeval_factorial_average (#463)

### DIFF
--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -115,10 +115,15 @@ inline unsigned long int ts_diff_now(struct timeval a)
 
 inline timeval timeval_factorial_average(timeval a, timeval b, unsigned int weight)
 {
+    // Convert both to total microseconds, average via integer math, split back.
+    // Averaging tv_sec/tv_usec independently truncates each -> loses precision
+    // when aggregate spans < 1ms. See issue #463.
+    int64_t a_usec = (int64_t) a.tv_sec * 1000000 + a.tv_usec;
+    int64_t b_usec = (int64_t) b.tv_sec * 1000000 + b.tv_usec;
+    int64_t avg_usec = (a_usec * (weight - 1) + b_usec) / weight;
     timeval tv;
-    double factor = ((double) weight - 1) / weight;
-    tv.tv_sec = factor * a.tv_sec + (double) b.tv_sec / weight;
-    tv.tv_usec = factor * a.tv_usec + (double) b.tv_usec / weight;
+    tv.tv_sec = (time_t) (avg_usec / 1000000);
+    tv.tv_usec = (suseconds_t) (avg_usec % 1000000);
     return (tv);
 }
 


### PR DESCRIPTION
Closes #463.

`run_stats::timeval_factorial_average` averaged `tv_sec` and `tv_usec` independently with double→`time_t`/`suseconds_t` truncation. For aggregate durations < ~1ms across multiple clients, the diff could round to 0 µs, causing `run_stats::summarize()` to emit `Ops/sec = 0` (and `Hits/sec`, `KB/sec`, …) even when `Count > 0` and `Avg Latency > 0`.

This regression surfaced in two CI tests:
- `test_monitor_cluster_backpressure:test_monitor_cluster_completes_and_routes` (worked around in commit 1033e0d by bumping requests)
- `test_miss_rate_tracking:test_json_totals_hits_sec_consistent` (coverage-ubuntu fail on master 36f878e)

**Fix**: normalize both timevals to int64_t microseconds, average via integer math, then split back. No precision loss for any aggregate duration > 0 µs.

The round-40 test workaround (requests=4000) can be reverted in a follow-up once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single helper used when merging run timings; localized stats math fix with no auth or I/O behavior changes.
> 
> **Overview**
> Fixes **#463** by changing how merged benchmark runs compute averaged start/end times when multiple clients’ `run_stats` are combined.
> 
> **`timeval_factorial_average`** no longer averages `tv_sec` and `tv_usec` separately with doubles and truncation. It now converts each `timeval` to **total microseconds** (`int64_t`), applies the weighted average in integer math, then splits back into `tv_sec` / `tv_usec`. That avoids sub‑millisecond merged durations rounding to **0 µs**, which made **`run_stats::summarize()`** report **Ops/sec**, **Hits/sec**, and **KB/sec** as **0** despite **Count > 0** and positive average latency (notably in multi-client / CI scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb1485f6c918b0e5d6270516929b91c7c89a961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->