### PR TITLE
ci: fix 3 nightly failures (soak timeout, differential runner, fuzz progress)

### DIFF
--- a/.github/workflows/differential.yml
+++ b/.github/workflows/differential.yml
@@ -32,7 +32,12 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'run-differential')
-    runs-on: ubuntu-22.04
+    # ubuntu-22.04 ships redis-tools 6.0.16, whose `redis-benchmark --csv`
+    # output does not yet expose the `p99_latency_ms` column that the
+    # differential parser depends on (tests/differential_redis_benchmark.py
+    # raises IndexError when that column is missing). ubuntu-24.04 ships
+    # redis-tools 7.x with the new CSV schema.
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/tests/fuzz/fuzz_monitor_input.py
+++ b/tests/fuzz/fuzz_monitor_input.py
@@ -28,6 +28,7 @@ import random
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -254,8 +255,22 @@ def main() -> int:
         return 2
     failures = 0
     total = 0
+    grand_total = FUZZ_ITER * len(seeds)
+    t0 = time.time()
+    # Emit per-iteration progress so a preempted / killed GH-hosted run
+    # still tells us which seed and iteration were in flight. Without this
+    # the driver only prints the startup banner and final summary, leaving
+    # an opaque gap whenever the runner is yanked mid-run.
+    progress_every = int(os.environ.get("FUZZ_PROGRESS_EVERY", "50"))
     for name, payload in seeds.items():
         for i in range(FUZZ_ITER):
+            if progress_every > 0 and total % progress_every == 0:
+                sys.stderr.write(
+                    "fuzz_monitor_input: iter {}/{} elapsed={}s seed={}\n".format(
+                        total, grand_total, int(time.time() - t0), name
+                    )
+                )
+                sys.stderr.flush()
             total += 1
             mutated = mutate(payload)
             ok = run_one(name, mutated)

--- a/tests/soak/test_slow_network.py
+++ b/tests/soak/test_slow_network.py
@@ -115,7 +115,11 @@ def test_slow_network_smooth(env):
         ensure_clean_benchmark_folder(config.results_dir)
 
         benchmark = Benchmark.from_json(config, benchmark_specs)
-        memtier_ok = benchmark.run()
+        # Benchmark.run() defaults to timeout=240s. Soak runs with
+        # test_time>=300s would be killed before they could write a
+        # summary, so we pass an explicit upper bound that leaves
+        # ~90s of slack for graceful shutdown.
+        memtier_ok = benchmark.run(timeout=test_time + 90)
 
         if not memtier_ok:
             debugPrintMemtierOnError(config, env)


### PR DESCRIPTION
Triage of yesterday's nightly failures on master b4b18c0:

1. **Soak S7 `test_slow_network_smooth`** — `Benchmark.run()` default `timeout=240s` < soak `test_time=300s`; memtier killed before summary, asserts at lines 122/133 fail. Fix: pass explicit `timeout=test_time+90` from soak tests. Also audited other soak tests that exceed 240s.

2. **Differential `test_diff_p99_latency_get`** — `IndexError` because Ubuntu 22.04 ships redis-tools 6.0.16 whose `redis-benchmark --csv` lacks the `p99_latency_ms` column. Bump runner to ubuntu-24.04 (noble carries redis-tools 7.x with the new CSV schema).

3. **Monitor-Input Fuzz** — GH-hosted runner preempted at 2-8 min into a 2000-iter run. Not deterministic, but the fuzz driver had no per-iteration progress, leaving us blind to which seed was in flight. Adds per-iter progress emit every 50 iterations.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-harness only; no production benchmark or protocol logic changes.
> 
> **Overview**
> Addresses three nightly CI failures without changing memtier core behavior.
> 
> **Differential workflow** moves the job from `ubuntu-22.04` to **`ubuntu-24.04`** so `redis-benchmark --csv` includes the `p99_latency_ms` column the differential parser expects (redis-tools 6.x on 22.04 caused `IndexError` in `test_diff_p99_latency_get`).
> 
> **Soak S7** (`test_slow_network_smooth`) passes **`timeout=test_time + 90`** into `Benchmark.run()` so 300s soak runs are not cut off by the default 240s harness timeout before memtier can write a summary.
> 
> **Monitor-input fuzz driver** logs **per-iteration progress** (default every 50 iterations via `FUZZ_PROGRESS_EVERY`) with seed name and elapsed time so preempted GitHub runners leave a visible last-known position.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59dd457e6979525e91e8b42282bc1d0b33bb811f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->