### PR TITLE
perf(miss-tracking): drop reply materialization for EmptyCollection arbitrary commands [RED-200840]

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -85,18 +85,23 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
         MAIN_CONNECTION->get_protocol()->set_keep_value(true);
     }
 
-    // Enable value keeping for arbitrary-command miss tracking when any
-    // configured command needs reply-array inspection (ArrayPerElementNulls or
-    // EmptyCollection). SingleNullBulk and IntegerMembership use the parser's
-    // existing scalar counters so no materialization is required for them.
+    // Enable value keeping for arbitrary-command miss tracking only when a
+    // configured command needs per-element reply inspection. Only
+    // ArrayPerElementNulls (HMGET/MGET/ZMSCORE/GEOPOS/...) requires walking the
+    // materialized reply array to attribute hits/misses per position.
+    // EmptyCollection (HGETALL/SMEMBERS/LRANGE) only needs to know whether the
+    // top-level array is empty, which it reads from the parser's running hit
+    // counter (response->get_hits()) with zero materialization -- keeping
+    // values there would malloc+memcpy every element of every reply on the hot
+    // path for no benefit. SingleNullBulk and IntegerMembership use the
+    // parser's scalar counters / status line, so no materialization either.
     if (config->arbitrary_commands->is_defined()) {
         bool needs_array_walk = false;
         for (size_t i = 0; i < config->arbitrary_commands->size(); ++i) {
             const arbitrary_command &cmd = config->arbitrary_commands->at(i);
             if (!cmd.miss_tracking_enabled || cmd.spec == NULL) continue;
             using memtier::command_meta::ReplyShape;
-            if (cmd.spec->reply_shape == ReplyShape::ArrayPerElementNulls ||
-                cmd.spec->reply_shape == ReplyShape::EmptyCollection) {
+            if (cmd.spec->reply_shape == ReplyShape::ArrayPerElementNulls) {
                 needs_array_walk = true;
                 break;
             }
@@ -901,8 +906,24 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp, req
                 // Heuristic: empty array == missing key. EmptyCollection
                 // commands (SMEMBERS, LRANGE, HGETALL, ...) virtually always
                 // carry exactly 1 key.
-                mbulk_size_el *top = response->get_mbulk_value();
-                bool empty = (top == NULL || top->mbulks_elements.empty());
+                //
+                // We only need the top-level element count, not the element
+                // values, so we avoid set_keep_value() materialization (see the
+                // keep_value gate in setup_client) and read the declared
+                // aggregate length the parser captured from the reply header.
+                // get_top_array_len() is:
+                //   >0  for a populated array/map/set  -> hit (regardless of
+                //       whether the elements are zero-length: the count comes
+                //       from the *N/%N/~N header, not a per-value walk),
+                //    0  for an empty (*0) or null (*-1) collection -> miss,
+                //   -1  when the reply was not a top-level aggregate at all
+                //       (a scalar/bulk misshape) -> miss, matching the previous
+                //       get_mbulk_value()==NULL guard.
+                // This reproduces the old structural check exactly while
+                // staying alloc-free, and is independent of keep_value (it is
+                // captured whether or not an ArrayPerElementNulls command on
+                // the same connection forced materialization on).
+                bool empty = (response->get_top_array_len() <= 0);
                 per_key_hit.assign(num_keys, !empty);
                 hits = empty ? 0 : num_keys;
                 misses = empty ? num_keys : 0;

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -60,7 +60,13 @@ void abstract_protocol::reset_state()
 /////////////////////////////////////////////////////////////////////////
 
 protocol_response::protocol_response() :
-        m_status(NULL), m_mbulk_value(NULL), m_value(NULL), m_value_len(0), m_hits(0), m_error(false)
+        m_status(NULL),
+        m_mbulk_value(NULL),
+        m_value(NULL),
+        m_value_len(0),
+        m_hits(0),
+        m_error(false),
+        m_top_array_len(-1)
 {
 }
 
@@ -125,6 +131,16 @@ unsigned int protocol_response::get_hits(void)
     return m_hits;
 }
 
+void protocol_response::set_top_array_len(int len)
+{
+    m_top_array_len = len;
+}
+
+int protocol_response::get_top_array_len(void)
+{
+    return m_top_array_len;
+}
+
 void protocol_response::clear(void)
 {
     if (m_status != NULL) {
@@ -144,6 +160,7 @@ void protocol_response::clear(void)
     m_total_len = 0;
     m_hits = 0;
     m_error = 0;
+    m_top_array_len = -1;
 }
 
 void protocol_response::set_mbulk_value(mbulk_size_el *element)
@@ -619,6 +636,15 @@ int redis_protocol::parse_response(void)
             if (aggregate_type(line[0])) {
                 int count = strtol(line + 1, NULL, 10);
 
+                // The reply's top-level aggregate is the one parsed while no
+                // bulks are still outstanding. Capture its declared length so
+                // miss-tracking can tell an empty collection from a populated
+                // one without materializing values (see EmptyCollection in
+                // client::handle_response). Out-of-band frames are excluded:
+                // attribute (|) is a prefix to the real reply, push (>) is not
+                // a reply at all.
+                bool top_level_aggregate = (m_total_bulks_count == 0);
+
                 // in case of nested mbulk, the mbulk is one of the total bulks
                 if (m_total_bulks_count > 0) {
                     m_total_bulks_count--;
@@ -646,6 +672,13 @@ int redis_protocol::parse_response(void)
                 // Map or Attribute contain key-value pair
                 if (line[0] == '%' || line[0] == '|') {
                     count *= 2;
+                }
+
+                // Record the reply body's declared element count (count is now
+                // null-clamped to >=0 and map-doubled). '|' is the attribute
+                // prefix, not the reply body; '>' (m_push) is out-of-band.
+                if (top_level_aggregate && !m_push && line[0] != '|') {
+                    m_last_response.set_top_array_len(count);
                 }
 
                 // Suppress mbulk allocation while draining a push frame:

--- a/protocol.h
+++ b/protocol.h
@@ -146,6 +146,13 @@ protected:
     unsigned int m_total_len;
     unsigned int m_hits;
     bool m_error;
+    // Declared element count of the reply's top-level aggregate (* array, %
+    // map, ~ set), captured once per response from the header line. -1 means
+    // the top-level reply was not such an aggregate (a scalar, bulk, error, or
+    // unparsed). Lets miss-tracking classify empty vs non-empty collections
+    // without materializing element values via set_keep_value(). A null array
+    // ($-1/*-1) and an empty array (*0) both record 0.
+    int m_top_array_len;
 
 public:
     protocol_response();
@@ -165,6 +172,9 @@ public:
 
     void incr_hits(void);
     unsigned int get_hits(void);
+
+    void set_top_array_len(int len);
+    int get_top_array_len(void);
 
     void clear();
 

--- a/tests/test_arbitrary_command_misses.py
+++ b/tests/test_arbitrary_command_misses.py
@@ -151,6 +151,39 @@ def test_arbitrary_smembers_empty_collection(env):
                    message="expected SMEMBERS misses on missing keys")
 
 
+def test_arbitrary_smembers_zero_length_member_is_hit(env):
+    """Regression: a set whose only member is the empty string returns a
+    non-empty array (*1 $0) and must count as a HIT, not a miss.
+
+    EmptyCollection miss-tracking classifies emptiness from the reply's
+    declared top-level array length (get_top_array_len()), not from a per-value
+    hit walk. An earlier approach keyed on the parser's non-null-bulk hit
+    counter, which skips zero-length bulks and so misreported this populated
+    set as empty/missing. This test pins the declared-length behaviour."""
+    env.skipOnCluster()
+    set_prefix = "memtier-emptyset-"
+    env.flush()
+    conn = env.getConnection()
+    # Keys 1..3 each hold a single zero-length member; 4..10 stay missing.
+    for i in range(1, _PRELOADED_KEYS + 1):
+        conn.sadd("{}{}".format(set_prefix, i), "")
+
+    result = _run_benchmark(env, "SMEMBERS __key__", key_prefix=set_prefix)
+    per_key = result["ALL STATS"].get("Per-Key Misses", {})
+    env.assertContains("SMEMBERS", per_key)
+    cmd_stats = per_key["SMEMBERS"]
+
+    total_ops = cmd_stats["Total Hits"] + cmd_stats["Total Misses"]
+    env.assertEqual(total_ops, _REQUESTS * 2)
+    # The populated (zero-length-member) sets must register as hits.
+    env.assertTrue(cmd_stats["Total Hits"] > 0,
+                   message="zero-length set member must count as a hit, got "
+                           "{} hits".format(cmd_stats["Total Hits"]))
+    # And the missing keys 4..10 must still register as misses.
+    env.assertTrue(cmd_stats["Total Misses"] > 0,
+                   message="expected misses on missing keys")
+
+
 def test_arbitrary_exists_integer_membership(env):
     """EXISTS — IntegerMembership; integer reply N == hit count."""
     env.skipOnCluster()


### PR DESCRIPTION
## Summary

Arbitrary-command miss-tracking (`--command-miss-tracking=auto`, default-on since v2.4.x) forced `set_keep_value(true)` for `EmptyCollection`-shaped replies — **HGETALL / SMEMBERS / LRANGE / ...**. That makes the protocol parser `malloc` + `memcpy` every element of every reply just to later check whether the top-level array was empty, costing **5–11% throughput** on the hash datapath nightly and producing false 3%-baseline failures since build 7384 (**RED-200840**).

`EmptyCollection` only needs to know whether the reply's top-level aggregate is empty — not its contents. This PR captures the **declared top-level aggregate length** (`*N` / `%N` / `~N` header) once per response in the parser (alloc-free, independent of `keep_value`) and classifies emptiness from it:

| `get_top_array_len()` | reply | verdict |
|---|---|---|
| `> 0` | populated array/map/set | hit |
| `0` | empty (`*0`) or null (`*-1`) | miss |
| `-1` | not a top-level aggregate (scalar/bulk misshape) | miss |

This reproduces the previous `get_mbulk_value()` structural semantics **exactly**, while dropping the materialization.

## Correctness

An interim `get_hits()==0` approach was caught (by adversarial review) to regress two cases; the declared-length approach handles both correctly:
- a collection of only **zero-length elements** (e.g. a set whose member is `""`) → **hit**, not miss (count comes from the header, not a per-value walk);
- a **non-array misshape** → miss, matching the old `top == NULL` guard.

`ArrayPerElementNulls` (HMGET / MGET / ZMSCORE / GEOPOS) still materializes — it needs per-position nulls.

## Testing

- Builds clean.
- Verified with the real binary against live redis: zero-length-member sets count as hits (~30% hit rate over keys 1–10 with 3 populated), missing keys as misses; populated HGETALL likewise.
- Adds `test_arbitrary_smembers_zero_length_member_is_hit` regression test.

## Notes / follow-ups

- This is the first half of RED-200840. The residual ~3–4% on HMGET comes from the `fill_pipeline` `bufferevent_enable`/`BEV_LOCK` (see #448) and is out of scope here.
- A deeper follow-up could make HMGET's per-position tracking alloc-free too (structure-only parse), and/or gate per-key JSON behind an opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the benchmark hot path and arbitrary-command miss accounting; behavior is intended to match prior semantics but parser edge cases (RESP3 push/attribute frames) are involved.
> 
> **Overview**
> **EmptyCollection** miss tracking (e.g. **SMEMBERS**, **HGETALL**, **LRANGE**) no longer turns on **`set_keep_value(true)`**, so those replies are not fully materialized on the hot path. Only **ArrayPerElementNulls** commands still force value keeping.
> 
> The RESP parser records the **declared top-level aggregate length** from the reply header (`*N` / `%N` / `~N`) on **`protocol_response`** via **`get_top_array_len()`**. **EmptyCollection** hit/miss logic uses that count instead of walking **`get_mbulk_value()`**, so empty vs populated collections stay correct (including sets whose only member is an empty string) without malloc/memcpy per element.
> 
> Adds **`test_arbitrary_smembers_zero_length_member_is_hit`** to lock in declared-length behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14320681b65b2202e0b3b9f82469ae74abad2394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->