### PR TITLE
feat(cpu): track memtier per-thread + whole-process CPU, warn when saturated (supersedes #346)

### DIFF
--- a/.claude/skills/adversarial-review/SKILL.md
+++ b/.claude/skills/adversarial-review/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: adversarial-review
+description: >-
+  Adversarially review a diff, patch, or plan for memtier_benchmark using the
+  real review standards of the project's senior maintainers (Yossi Gottlieb /
+  yossigo, Oran Agra / oranagra, Paulo Sousa / paulorsousa). Use when asked to
+  "adversarially review", "review like the maintainers", "find what a reviewer
+  would block on", or before opening/merging a PR. Emits skeptical, evidence-
+  backed findings; assumes a problem is real until it can be refuted.
+---
+
+# Adversarial review (memtier maintainer personas)
+
+You are a hostile-but-fair code reviewer for the `redis/memtier_benchmark`
+C++/C codebase. Your job is to find what a senior maintainer would block the PR
+on — correctness bugs first, then the project's long-standing quality bars. You
+are NOT here to praise; default to skepticism. A finding stands unless it can be
+positively refuted from the code.
+
+## Inputs
+
+Review whatever is provided: a `git diff`, a set of changed files, or a written
+plan. If given a plan, review the *design* against the same bars (e.g. "this
+will duplicate the existing X path"). Prefer reviewing the actual diff:
+
+```
+git diff master...HEAD            # full branch diff
+git diff --stat master...HEAD     # changed-files overview
+```
+
+## How to review
+
+Work through every persona lens below against the change. For each lens, ask the
+listed questions of *every* changed hunk. When a lens fires, produce a finding.
+Read the surrounding code (not just the diff) before asserting — many findings
+require knowing what already exists (e.g. whether a helper is duplicated).
+
+### Lens 1 — Yossi Gottlieb (yossigo): architecture, correctness, hygiene
+
+Real review bars, drawn from his comments on this repo:
+
+- **No code duplication.** "low level networking code duplication should be
+  avoided"; "a huge part of this is duplicated with client.c with no apparent
+  reason. It would make sense to pack it in a class hierarchy." → Flag any block
+  that copies logic already living in a shared function/class instead of reusing
+  or extracting it.
+- **Correctness across ALL code paths, not the happy one.** "the authentication
+  and DB selection are always done on the main connection and never on the other
+  connections … it's only effective for 1/N shards." → For every new behavior,
+  check it holds on every connection / thread / shard / restart / error path,
+  not just the first/primary.
+- **Distinguish valid 0 / empty from invalid input.** "This implementation does
+  not distinguish '0' from an invalid input, which is a bad idea." → Parsing and
+  guards must separate "legitimately zero" from "unset/error".
+- **Buffer sizing & string safety.** "buffer should be bigger for null
+  terminator no?"; "Better stick to `snprintf()`." → Every fixed buffer must fit
+  the longest output incl. NUL; prefer `snprintf`; no unbounded `strcat`/`sprintf`.
+- **No redundant calls.** "`fflush()` is not needed before `fclose()`." → Flag
+  redundant or no-op calls.
+- **Performance regressions on hot paths.** "we need to be wary of performance
+  regressions"; questioned adding work / maps on the per-request path. → Any new
+  work inside the per-request / per-response / per-second loop must justify its
+  cost; per-thread or per-run work is fine.
+- **Don't break output/CSV/JSON format.** "Not sure about breaking output format
+  … I'd either make this optional or at least push it to the end … to minimize
+  risk of breaking something." → New fields should be additive and not reorder /
+  rename existing keys or columns.
+- **Standard header on new files; document non-obvious mechanisms; no
+  whitespace-only churn.** "Standard header is missing"; "Can you add a
+  description of this mechanism and why it is needed?"; "Please avoid changes
+  that are purely white space."
+- **Don't make default debug output unusable.** "adding such verbose debug logs
+  by default will make the debug output far less usable … Perhaps we need an
+  extra level of verbosity." → New default-on logging/warnings must not spam.
+- **Conditional compilation belongs behind the right guard.** "I'll move
+  everything TLS into the ifdef." → Platform/feature code goes behind the
+  matching `#ifdef` (e.g. `__APPLE__`, `RUSAGE_THREAD`, `USE_TLS`).
+
+### Lens 2 — Oran Agra (oranagra): numeric correctness & compatibility
+
+- **Precision / type choice.** "I don't like the loss of fractional part …
+  the problem is just the wrong use of 32bit float instead of double … `strtod`
+  should solve it." → Flag `float` where `double` is needed, and casts like
+  `(unsigned int)` that silently drop the fractional part or overflow range.
+- **Range / overflow.** Check integer widths against the values they hold
+  (µs/ns CPU times, byte counts) — prefer `unsigned long long` for accumulators.
+- **Backward compatibility of parsing.** "changing to `strtoull` would be a
+  breaking change, since old commands that used to work, will now error." →
+  Tightening a parser must not reject inputs that previously worked.
+
+### Lens 3 — Paulo Sousa (paulorsousa): dead code, consolidation, clarity
+
+- **Dead / unused / accidental.** "Looks like this function isn't used, do you
+  confirm?"; "Was this file added intentionally? Looks like a backup."; "Was
+  this comment meant to be here?" → Flag unused functions/vars, stray files,
+  out-of-place comments.
+- **Consolidate repeated logic into one path.** "Most of this retry logic is
+  repeated for connection errors, drops, and timeouts … it would be nice for all
+  errors to go through the same path." → Same as Yossi's DRY, applied to
+  error/branch handling.
+- **Separation of concerns / readability.** "What about moving this logic into a
+  new `client_group` method … improve readability and SoC." → Flag orchestration
+  logic that should be a method on the owning class.
+- **Timing skew / measurement accuracy.** "Computing the end time at the break
+  point would minimize that skew"; "isn't it possible to always align the stats
+  to the benchmark start time?" → For any timing/measurement code, check the
+  start/stop points are as close as possible to the measured event.
+- **Style consistency.** "The indentation seems off, we're mixing tabs with
+  spaces. Maybe we should uniformize." → Flag tab/space mixing and indentation
+  that diverges from the surrounding file.
+- **Reason about flag interactions.** "I'm concerned this could make the overall
+  behaviour even harder to … predict. What about bringing this under
+  `--distinct-client-seed`?" → Check how a new option interacts with existing
+  related options.
+
+### Cross-cutting build/CI bars (this repo specifically)
+
+- C++11 only; `-Werror=vla` is enforced — **no VLAs** (`T buf[n]` with runtime
+  `n`); use heap/`std::vector`.
+- Don't introduce new compiler warnings (esp. `-Wformat-truncation` on
+  `snprintf` into fixed buffers).
+- New source files must be added to `Makefile.am`; prefer not to add a TU if a
+  `static` helper in an existing file suffices.
+- Linux + macOS are the supported targets; musl/Alpine is a CI target. Guard
+  Linux-only APIs (`RUSAGE_THREAD`) behind `#if defined(...)`.
+
+## Output format
+
+Return a JSON array (and a short prose summary). Each finding:
+
+```json
+{
+  "severity": "high | medium | low | nit",
+  "persona": "yossigo | oranagra | paulorsousa | build",
+  "file": "path:line",
+  "issue": "what is wrong and why a reviewer blocks on it",
+  "evidence": "the specific code / behavior that proves it",
+  "suggestion": "the concrete fix"
+}
+```
+
+Severity guide: **high** = correctness bug, crash, data race, broken output, or
+regression. **medium** = duplication, missing-path coverage, precision/overflow,
+perf on hot path, missing platform guard. **low/nit** = style, naming, comments,
+buffer-just-big-enough.
+
+Rules:
+- One finding per distinct issue; cite `file:line`.
+- Do not invent issues to pad the list. If a lens does not fire, say so.
+- Prefer high-confidence findings; mark genuine uncertainty in `issue` and let
+  the verifier decide — do not silently drop a plausible correctness concern.
+- End with: the count by severity, and an explicit **APPROVE** (no high/medium)
+  or **REQUEST CHANGES** (any high/medium) verdict.

--- a/JSON_handler.cpp
+++ b/JSON_handler.cpp
@@ -95,7 +95,9 @@ void json_handler::write_obj(const char *objectname, const char *format, ...)
         double value = va_arg(tmp_argptr, double);
         va_end(tmp_argptr);
 
-        if (std::isnan(value)) {
+        // Emit JSON null for any non-finite value (NaN and +/-Inf). Bare
+        // 'nan'/'inf' tokens from vfprintf would otherwise produce invalid JSON.
+        if (!std::isfinite(value)) {
             fprintf(m_json_file, "null");
         } else {
             vfprintf(m_json_file, format, argptr);

--- a/JSON_handler.cpp
+++ b/JSON_handler.cpp
@@ -22,7 +22,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <cmath> // For std::isnan
+#include <cmath> // For std::isfinite
 #include "JSON_handler.h"
 
 

--- a/bash-completion/memtier_benchmark
+++ b/bash-completion/memtier_benchmark
@@ -28,7 +28,7 @@ _memtier_completions()
                    "--statsd-host" "--statsd-port" "--statsd-prefix" "--statsd-run-label" "--graphite-port"\
                    "--monitor-input" "--hdr-file-prefix"\
                    "--max-reconnect-attempts" "--reconnect-backoff-factor" "--connection-timeout"\
-                   "--connection-stage-timeout"\
+                   "--connection-stage-timeout" "--cpu-warn-threshold"\
                    "--max-retries" "--retry-backoff-ms" "--retry-backoff-factor" "--retry-on"\
                    "--max-retry-queue" "--failed-keys-file"\
                    "--thread-conn-start-min-jitter-micros" "--thread-conn-start-max-jitter-micros"\

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -2539,11 +2539,16 @@ struct cg_thread
     // Per-thread CPU accounting via getrusage(RUSAGE_THREAD), captured inside
     // the worker. A restart() spawns a NEW native thread, so RUSAGE_THREAD
     // resets to 0 each segment; m_cpu_*_usec_acc accumulate completed segments
-    // so the reported total spans all restarts. Only read post-join (race-free).
-    struct rusage m_cpu_start_ru; // snapshot at the current segment's start
+    // so the reported total spans all restarts. m_wall_usec_acc is the WALL time
+    // of those same segments, captured at the exact same points as the CPU
+    // snapshots, so cores_used = cpu/wall divides two values over the identical
+    // interval (no setup-vs-serving skew). Only read post-join (race-free).
+    struct rusage m_cpu_start_ru;  // CPU snapshot at the current segment's start
+    struct timeval m_wall_start_tv; // wall snapshot at the same point
     unsigned long long m_cpu_user_usec_acc;
     unsigned long long m_cpu_sys_usec_acc;
-    bool m_cpu_started; // m_cpu_start_ru is valid for the current segment
+    unsigned long long m_wall_usec_acc;
+    bool m_cpu_started; // m_cpu_start_ru/m_wall_start_tv valid for this segment
     bool m_cpu_valid;   // getrusage(RUSAGE_THREAD) succeeded at least once
 
     cg_thread(unsigned int id, benchmark_config *config, object_generator *obj_gen) :
@@ -2557,6 +2562,7 @@ struct cg_thread
             m_restart_count(0),
             m_cpu_user_usec_acc(0),
             m_cpu_sys_usec_acc(0),
+            m_wall_usec_acc(0),
             m_cpu_started(false),
             m_cpu_valid(false)
     {
@@ -2632,11 +2638,6 @@ struct cg_thread
     }
 };
 
-static inline unsigned long long tv_to_usec(const struct timeval &tv)
-{
-    return (unsigned long long) tv.tv_sec * 1000000ULL + (unsigned long long) tv.tv_usec;
-}
-
 // Cumulative CPU time (user+system, microseconds) consumed by an arbitrary
 // thread, read WITHOUT perturbing that thread. Used by the live per-second
 // sampler in the monitor loop. On Linux this is pthread_getcpuclockid +
@@ -2660,24 +2661,107 @@ static unsigned long long get_thread_cpu_usec(pthread_t thread)
 #endif
 }
 
-// Fold this worker's current-segment CPU usage (getrusage delta) into its
-// across-restart accumulators. Called from inside the worker on every exit
-// path, BEFORE m_finished is set, so the segment is accounted before the
-// monitor loop can observe completion and trigger a restart.
+// Fold this worker's current-segment CPU usage (getrusage delta) AND the wall
+// time of the same segment into its across-restart accumulators. Called from
+// inside the worker on every exit path, BEFORE m_finished is set, so the
+// segment is accounted before the monitor loop can observe completion and
+// trigger a restart. The wall bracket is captured at the same two points as the
+// CPU bracket so cores_used = cpu/wall covers one identical interval.
 static void cg_thread_capture_cpu_end(cg_thread *thread)
 {
 #if defined(RUSAGE_THREAD)
     if (!thread->m_cpu_started) return;
     struct rusage end_ru;
+    struct timeval end_tv;
+    gettimeofday(&end_tv, NULL);
     if (getrusage(RUSAGE_THREAD, &end_ru) == 0) {
-        thread->m_cpu_user_usec_acc += tv_to_usec(end_ru.ru_utime) - tv_to_usec(thread->m_cpu_start_ru.ru_utime);
-        thread->m_cpu_sys_usec_acc += tv_to_usec(end_ru.ru_stime) - tv_to_usec(thread->m_cpu_start_ru.ru_stime);
+        // ts_diff(a, b) returns b - a in microseconds; rusage CPU time is
+        // monotonic per native thread, so each delta is >= 0.
+        thread->m_cpu_user_usec_acc +=
+            (unsigned long long) ts_diff(thread->m_cpu_start_ru.ru_utime, end_ru.ru_utime);
+        thread->m_cpu_sys_usec_acc +=
+            (unsigned long long) ts_diff(thread->m_cpu_start_ru.ru_stime, end_ru.ru_stime);
     }
+    thread->m_wall_usec_acc += (unsigned long long) ts_diff(thread->m_wall_start_tv, end_tv);
     thread->m_cpu_started = false;
 #else
     (void) thread;
 #endif
 }
+
+// Advisory per-second CPU sampler driven from the monitor loop. Reads each
+// worker's CPU clock from the MAIN thread (no worker perturbation), converts the
+// delta to "% of a core" over the real wall window, emits a de-duped live
+// high-CPU warning (once per thread, on first crossing), tracks the peak
+// whole-process utilization, and appends a per-second snapshot to a history
+// vector. Finished/restarting workers are skipped so their pthread_t is never
+// read while joined or mid-restart.
+struct cpu_live_sampler
+{
+    std::vector<unsigned long long> thread_prev;
+    std::vector<bool> warned;
+    unsigned long long main_prev;
+    unsigned int second;
+    double peak_pct;
+    double warn_pct;
+    struct timeval prev_tv;
+
+    void init(const std::vector<cg_thread *> &threads, double warn_threshold_fraction)
+    {
+        thread_prev.assign(threads.size(), 0);
+        warned.assign(threads.size(), false);
+        for (size_t t = 0; t < threads.size(); t++)
+            thread_prev[t] = get_thread_cpu_usec(threads[t]->m_thread);
+        main_prev = get_thread_cpu_usec(pthread_self());
+        second = 0;
+        peak_pct = 0.0;
+        warn_pct = warn_threshold_fraction * 100.0;
+        gettimeofday(&prev_tv, NULL);
+    }
+
+    void tick(const std::vector<cg_thread *> &threads, std::vector<per_second_cpu_stats> &history)
+    {
+        second++;
+        struct timeval cur_tv;
+        gettimeofday(&cur_tv, NULL);
+        double wall_usec = (double) ts_diff(prev_tv, cur_tv);
+        if (wall_usec < 1.0) wall_usec = 1.0; // guard against division by zero
+
+        per_second_cpu_stats snap;
+        snap.m_second = second;
+
+        unsigned long long main_cur = get_thread_cpu_usec(pthread_self());
+        unsigned long long main_delta = (main_cur > main_prev) ? main_cur - main_prev : 0;
+        snap.m_main_thread_cpu_pct = (double) main_delta / wall_usec * 100.0;
+        main_prev = main_cur;
+
+        double whole_pct = snap.m_main_thread_cpu_pct;
+        for (size_t t = 0; t < threads.size(); t++) {
+            double pct = 0.0;
+            // Skip finished/restarting workers: a reset clock on a new pthread_t
+            // would yield a bogus delta, and a joined handle is unsafe to read.
+            if (!threads[t]->m_finished) {
+                unsigned long long cur = get_thread_cpu_usec(threads[t]->m_thread);
+                unsigned long long delta = (cur > thread_prev[t]) ? cur - thread_prev[t] : 0;
+                pct = (double) delta / wall_usec * 100.0;
+                thread_prev[t] = cur;
+            }
+            snap.m_thread_cpu_pct.push_back(pct);
+            whole_pct += pct;
+
+            if (pct > warn_pct && !warned[t]) {
+                fprintf(stderr,
+                        "\nwarning: high CPU on thread %u: %.1f%% of a core (threshold %.1f%%) - "
+                        "results may be unreliable\n",
+                        threads[t]->m_thread_id, pct, warn_pct);
+                warned[t] = true;
+            }
+        }
+        if (whole_pct > peak_pct) peak_pct = whole_pct;
+        prev_tv = cur_tv;
+        history.push_back(std::move(snap));
+    }
+};
 
 static void *cg_thread_start(void *t)
 {
@@ -2688,10 +2772,12 @@ static void *cg_thread_start(void *t)
     // stack rather than re-faulting on the exhausted one.
     install_alt_signal_stack();
 
-    // Snapshot this segment's starting CPU time (per-thread). Accumulators on
-    // cg_thread carry prior segments forward across restarts.
+    // Snapshot this segment's starting CPU time and wall time (per-thread) at
+    // the same instant. Accumulators on cg_thread carry prior segments forward
+    // across restarts.
 #if defined(RUSAGE_THREAD)
     if (getrusage(RUSAGE_THREAD, &thread->m_cpu_start_ru) == 0) {
+        gettimeofday(&thread->m_wall_start_tv, NULL);
         thread->m_cpu_started = true;
         thread->m_cpu_valid = true;
     }
@@ -3011,22 +3097,13 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
         hdr_init(LATENCY_HDR_MIN_VALUE, LATENCY_HDR_SEC_MAX_VALUE, LATENCY_HDR_SEC_SIGDIGTS, &rtl_totals_hist);
     }
 
-    // Live (advisory) per-second CPU sampler state. The main thread reads each
-    // worker's CPU clock via pthread_getcpuclockid without perturbing it, so
-    // this adds no overhead to the workers. Feeds the per-second JSON detail,
-    // the de-duped live high-CPU warning, and the peak-utilization figure.
+    // Live (advisory) per-second CPU sampler. The main thread reads each worker's
+    // CPU clock without perturbing it, so this adds no overhead to the workers.
+    // Feeds the per-second JSON detail, the de-duped live high-CPU warning, and
+    // the peak-utilization figure.
     std::vector<per_second_cpu_stats> cpu_history;
-    std::vector<unsigned long long> thread_prev_cpu(threads.size(), 0);
-    std::vector<bool> cpu_warned(threads.size(), false);
-    for (size_t t = 0; t < threads.size(); t++) {
-        thread_prev_cpu[t] = get_thread_cpu_usec(threads[t]->m_thread);
-    }
-    unsigned long long main_prev_cpu = get_thread_cpu_usec(pthread_self());
-    unsigned int cpu_second = 0;
-    double peak_cpu_utilization_pct = 0.0;
-    struct timeval cpu_prev_tv;
-    gettimeofday(&cpu_prev_tv, NULL);
-    const double cpu_warn_pct = cfg->cpu_warn_threshold * 100.0;
+    cpu_live_sampler cpu_sampler;
+    cpu_sampler.init(threads, cfg->cpu_warn_threshold);
 
     // provide some feedback...
     // NOTE: Reading stats from worker threads without synchronization is a benign race.
@@ -3385,48 +3462,8 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
             }
         }
 
-        // Per-second CPU sampling (advisory). Read each worker's CPU clock plus
-        // the main thread's; convert the delta to "% of a core" over the wall
-        // window. Restart-safe: a restarted worker has a new pthread_t and a
-        // reset clock, so guard with cur > prev (treat as 0 for that second).
-        {
-            cpu_second++;
-            struct timeval cpu_cur_tv;
-            gettimeofday(&cpu_cur_tv, NULL);
-            double wall_usec = (double) (cpu_cur_tv.tv_sec - cpu_prev_tv.tv_sec) * 1000000.0 +
-                               (double) (cpu_cur_tv.tv_usec - cpu_prev_tv.tv_usec);
-            if (wall_usec < 1.0) wall_usec = 1.0; // guard against division by zero
-
-            per_second_cpu_stats cpu_snap;
-            cpu_snap.m_second = cpu_second;
-
-            unsigned long long main_cur = get_thread_cpu_usec(pthread_self());
-            unsigned long long main_delta = (main_cur > main_prev_cpu) ? main_cur - main_prev_cpu : 0;
-            cpu_snap.m_main_thread_cpu_pct = (double) main_delta / wall_usec * 100.0;
-            main_prev_cpu = main_cur;
-
-            double whole_pct = cpu_snap.m_main_thread_cpu_pct;
-            for (size_t t = 0; t < threads.size(); t++) {
-                unsigned long long cur = get_thread_cpu_usec(threads[t]->m_thread);
-                unsigned long long delta = (cur > thread_prev_cpu[t]) ? cur - thread_prev_cpu[t] : 0;
-                double pct = (double) delta / wall_usec * 100.0;
-                cpu_snap.m_thread_cpu_pct.push_back(pct);
-                thread_prev_cpu[t] = cur;
-                whole_pct += pct;
-
-                // Live high-CPU warning: once per thread, on first crossing.
-                if (pct > cpu_warn_pct && !cpu_warned[t]) {
-                    fprintf(stderr,
-                            "\nwarning: high CPU on thread %u: %.1f%% of a core (threshold %.1f%%) - "
-                            "results may be unreliable\n",
-                            threads[t]->m_thread_id, pct, cpu_warn_pct);
-                    cpu_warned[t] = true;
-                }
-            }
-            if (whole_pct > peak_cpu_utilization_pct) peak_cpu_utilization_pct = whole_pct;
-            cpu_prev_tv = cpu_cur_tv;
-            cpu_history.push_back(cpu_snap);
-        }
+        // Per-second CPU sampling (advisory).
+        cpu_sampler.tick(threads, cpu_history);
 
         if (inst_hist_agg != NULL) hdr_close(inst_hist_agg);
     } while (active_threads > 0);
@@ -3461,13 +3498,20 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     // CPU utilization aggregate (memtier's own usage).
     //
     // Fold each worker's authoritative getrusage(RUSAGE_THREAD) totals (already
-    // accumulated across restarts inside the worker) into the run_stats. This
-    // is the "whole" figure: Σ per-thread CPU-seconds + the main thread, over
-    // the run wall time. Done here, post-join, so reads are race-free.
+    // accumulated across restarts inside the worker) into the run_stats. Each
+    // worker's cores_used divides its CPU by ITS OWN wall bracket (captured at
+    // the same points as the CPU snapshots), so there is no setup-vs-serving or
+    // across-restart skew. The whole-process aggregate divides total CPU (all
+    // workers + the main thread) by the longest worker lifetime, so the
+    // aggregate and per-thread figures stay consistent: the denominator is the
+    // window during which work actually happened, not the main thread's
+    // launch->join span which also covers idle teardown. Done here, post-join,
+    // so reads are race-free.
     // -----------------------------------------------------------------
     {
         cpu_summary csum;
-        double max_wall_seconds = 0.0;
+        double worker_total_seconds = 0.0; // workers only, for the saturation %
+        double max_worker_wall = 0.0;
         for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {
             cg_thread *t = *i;
             per_thread_cpu_total pt;
@@ -3476,38 +3520,40 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
             pt.user_seconds = (double) t->m_cpu_user_usec_acc / 1e6;
             pt.sys_seconds = (double) t->m_cpu_sys_usec_acc / 1e6;
             pt.total_seconds = pt.user_seconds + pt.sys_seconds;
-            pt.wall_seconds = (double) t->m_cg->get_duration_usec() / 1e6;
+            pt.wall_seconds = (double) t->m_wall_usec_acc / 1e6;
             pt.cores_used = (pt.wall_seconds > 0.0) ? pt.total_seconds / pt.wall_seconds : 0.0;
             stats.add_cpu_thread(pt);
 
-            if (pt.valid) {
+            if (pt.valid && pt.wall_seconds > 0.0) {
                 csum.user_seconds += pt.user_seconds;
                 csum.sys_seconds += pt.sys_seconds;
+                worker_total_seconds += pt.total_seconds;
                 csum.threads_counted++;
-                if (pt.wall_seconds > max_wall_seconds) max_wall_seconds = pt.wall_seconds;
+                if (pt.wall_seconds > max_worker_wall) max_worker_wall = pt.wall_seconds;
             }
         }
 
-        // Add the main thread's CPU to the whole-process totals (not to the
-        // worker-thread % denominator).
+        // Add the main thread's own CPU (orchestrator/sampler overhead) to the
+        // whole-process totals, measured over the matching launch->here interval.
 #if defined(RUSAGE_THREAD)
         if (main_cpu_valid) {
             struct rusage main_end_ru;
             if (getrusage(RUSAGE_THREAD, &main_end_ru) == 0) {
-                csum.user_seconds +=
-                    (double) (tv_to_usec(main_end_ru.ru_utime) - tv_to_usec(main_cpu_start_ru.ru_utime)) / 1e6;
-                csum.sys_seconds +=
-                    (double) (tv_to_usec(main_end_ru.ru_stime) - tv_to_usec(main_cpu_start_ru.ru_stime)) / 1e6;
+                csum.user_seconds += (double) ts_diff(main_cpu_start_ru.ru_utime, main_end_ru.ru_utime) / 1e6;
+                csum.sys_seconds += (double) ts_diff(main_cpu_start_ru.ru_stime, main_end_ru.ru_stime) / 1e6;
             }
         }
 #endif
 
         csum.total_seconds = csum.user_seconds + csum.sys_seconds;
-        csum.wall_seconds = max_wall_seconds;
-        csum.peak_utilization_pct = peak_cpu_utilization_pct;
+        csum.wall_seconds = max_worker_wall;
+        csum.peak_utilization_pct = cpu_sampler.peak_pct;
         if (csum.threads_counted > 0 && csum.wall_seconds > 0.0) {
             csum.cores_used = csum.total_seconds / csum.wall_seconds;
-            csum.avg_utilization_pct = 100.0 * csum.cores_used / csum.threads_counted;
+            // Saturation % is based on WORKER cores only (main thread excluded),
+            // so a value near 100% means the worker threads are saturated and
+            // cannot exceed 100% from main-thread overhead alone.
+            csum.avg_utilization_pct = 100.0 * (worker_total_seconds / csum.wall_seconds) / csum.threads_counted;
             csum.valid = true;
         }
         stats.set_cpu_summary(csum);

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -2673,8 +2673,11 @@ static void cg_thread_capture_cpu_end(cg_thread *thread)
     if (!thread->m_cpu_started) return;
     struct rusage end_ru;
     struct timeval end_tv;
+    // Capture in the same order as the start snapshot (CPU then wall) so the
+    // wall window encloses the CPU window symmetrically.
+    int rc = getrusage(RUSAGE_THREAD, &end_ru);
     gettimeofday(&end_tv, NULL);
-    if (getrusage(RUSAGE_THREAD, &end_ru) == 0) {
+    if (rc == 0) {
         // ts_diff(a, b) returns b - a in microseconds; rusage CPU time is
         // monotonic per native thread, so each delta is >= 0.
         thread->m_cpu_user_usec_acc +=
@@ -3502,11 +3505,11 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     // worker's cores_used divides its CPU by ITS OWN wall bracket (captured at
     // the same points as the CPU snapshots), so there is no setup-vs-serving or
     // across-restart skew. The whole-process aggregate divides total CPU (all
-    // workers + the main thread) by the longest worker lifetime, so the
-    // aggregate and per-thread figures stay consistent: the denominator is the
-    // window during which work actually happened, not the main thread's
-    // launch->join span which also covers idle teardown. Done here, post-join,
-    // so reads are race-free.
+    // workers + the main thread) by the longest summed active-serving wall time
+    // across workers, so the aggregate and per-thread figures stay consistent:
+    // the denominator is the window during which work actually happened, not the
+    // main thread's launch->join span which also covers idle teardown. Done
+    // here, post-join, so reads are race-free.
     // -----------------------------------------------------------------
     {
         cpu_summary csum;
@@ -3546,6 +3549,7 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
 #endif
 
         csum.total_seconds = csum.user_seconds + csum.sys_seconds;
+        csum.worker_total_seconds = worker_total_seconds;
         csum.wall_seconds = max_worker_wall;
         csum.peak_utilization_pct = cpu_sampler.peak_pct;
         if (csum.threads_counted > 0 && csum.wall_seconds > 0.0) {

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -21,6 +21,12 @@
 #define _XOPEN_SOURCE 600
 #endif
 
+// _GNU_SOURCE exposes getrusage(RUSAGE_THREAD) on glibc (per-thread CPU
+// accounting). Harmless on musl/Alpine, where RUSAGE_THREAD is unconditional.
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -81,11 +87,16 @@
 #include <atomic>
 #include <algorithm>
 
+#ifdef __APPLE__
+#include <mach/mach.h>
+#endif
+
 #include "client.h"
 #include "cluster_client.h"
 #include "JSON_handler.h"
 #include "obj_gen.h"
 #include "memtier_benchmark.h"
+#include "run_stats_types.h"
 #include "retry_policy.h"
 #include "statsd.h"
 
@@ -882,6 +893,7 @@ static void config_init_defaults(struct benchmark_config *cfg)
     if (!cfg->print_percentiles.is_defined()) cfg->print_percentiles = config_quantiles("50,99,99.9");
     if (!cfg->monitor_pattern) cfg->monitor_pattern = 'S';
     if (cfg->miss_rate_threshold < 0.0) cfg->miss_rate_threshold = 0.01; // Default: warn above 1%
+    if (cfg->cpu_warn_threshold < 0.0) cfg->cpu_warn_threshold = 0.95;   // Default: warn above 95% of a core
     // Default --connection-stage-timeout to 30 s; 0 means "operator disabled".
     if (cfg->connection_stage_timeout == UINT_MAX) cfg->connection_stage_timeout = 30;
 
@@ -1068,6 +1080,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         o_command_stats_breakdown,
         o_command_miss_tracking,
         o_miss_rate_threshold,
+        o_cpu_warn_threshold,
         o_tls,
         o_tls_cert,
         o_tls_key,
@@ -1185,6 +1198,7 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         {"command-stats-breakdown", 1, 0, o_command_stats_breakdown},
         {"command-miss-tracking", 1, 0, o_command_miss_tracking},
         {"miss-rate-threshold", 1, 0, o_miss_rate_threshold},
+        {"cpu-warn-threshold", 1, 0, o_cpu_warn_threshold},
         {"rate-limiting", 1, 0, o_rate_limiting},
         {"uri", 1, 0, o_uri},
         {"statsd-host", 1, 0, o_statsd_host},
@@ -1906,6 +1920,16 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
             cfg->miss_rate_threshold = pct / 100.0;
             break;
         }
+        case o_cpu_warn_threshold: {
+            endptr = NULL;
+            double pct = strtod(optarg, &endptr);
+            if (endptr == optarg || !endptr || *endptr != '\0' || !std::isfinite(pct) || pct < 0.0 || pct > 100.0) {
+                fprintf(stderr, "error: --cpu-warn-threshold must be a percentage between 0 and 100.\n");
+                return -1;
+            }
+            cfg->cpu_warn_threshold = pct / 100.0;
+            break;
+        }
         case o_rate_limiting: {
             endptr = NULL;
             cfg->request_rate = (unsigned int) strtoul(optarg, &endptr, 10);
@@ -2316,6 +2340,10 @@ void usage()
         "                                 Warn when miss rate exceeds this percentage (default: 1.0).\n"
         "                                 Accepts fractional values, e.g. 0.5 for half a percent.\n"
         "                                 0 warns on any miss.\n"
+        "      --cpu-warn-threshold=PERCENTAGE\n"
+        "                                 Warn when a memtier worker thread's CPU exceeds this percentage of a\n"
+        "                                 core (default: 95.0), indicating memtier itself may be the bottleneck\n"
+        "                                 and results may be unreliable. 0 warns on any CPU usage.\n"
         "      --statsd-host=HOST         StatsD server hostname to send real-time metrics (default: none, disabled)\n"
         "      --statsd-port=PORT         StatsD server UDP port (default: 8125)\n"
         "      --statsd-prefix=PREFIX     Prefix for StatsD metric names (default: memtier)\n"
@@ -2508,6 +2536,16 @@ struct cg_thread
     bool m_restart_requested;
     unsigned int m_restart_count;
 
+    // Per-thread CPU accounting via getrusage(RUSAGE_THREAD), captured inside
+    // the worker. A restart() spawns a NEW native thread, so RUSAGE_THREAD
+    // resets to 0 each segment; m_cpu_*_usec_acc accumulate completed segments
+    // so the reported total spans all restarts. Only read post-join (race-free).
+    struct rusage m_cpu_start_ru; // snapshot at the current segment's start
+    unsigned long long m_cpu_user_usec_acc;
+    unsigned long long m_cpu_sys_usec_acc;
+    bool m_cpu_started; // m_cpu_start_ru is valid for the current segment
+    bool m_cpu_valid;   // getrusage(RUSAGE_THREAD) succeeded at least once
+
     cg_thread(unsigned int id, benchmark_config *config, object_generator *obj_gen) :
             m_thread_id(id),
             m_config(config),
@@ -2516,7 +2554,11 @@ struct cg_thread
             m_protocol(NULL),
             m_finished(false),
             m_restart_requested(false),
-            m_restart_count(0)
+            m_restart_count(0),
+            m_cpu_user_usec_acc(0),
+            m_cpu_sys_usec_acc(0),
+            m_cpu_started(false),
+            m_cpu_valid(false)
     {
         m_protocol = protocol_factory(m_config->protocol);
         assert(m_protocol != NULL);
@@ -2580,10 +2622,62 @@ struct cg_thread
         m_restart_requested = false;
         m_restart_count++;
 
+        // CPU accumulators (m_cpu_*_usec_acc) intentionally persist across
+        // restarts. The new native thread re-snapshots m_cpu_start_ru on entry,
+        // so clear only the per-segment "started" flag.
+        m_cpu_started = false;
+
         // Start new thread
         return pthread_create(&m_thread, NULL, cg_thread_start, (void *) this);
     }
 };
+
+static inline unsigned long long tv_to_usec(const struct timeval &tv)
+{
+    return (unsigned long long) tv.tv_sec * 1000000ULL + (unsigned long long) tv.tv_usec;
+}
+
+// Cumulative CPU time (user+system, microseconds) consumed by an arbitrary
+// thread, read WITHOUT perturbing that thread. Used by the live per-second
+// sampler in the monitor loop. On Linux this is pthread_getcpuclockid +
+// clock_gettime (a per-thread CPU clock); on macOS it is Mach thread_info.
+// Returns 0 if the thread's CPU clock cannot be read (treated as no delta).
+static unsigned long long get_thread_cpu_usec(pthread_t thread)
+{
+#ifdef __APPLE__
+    mach_port_t mt = pthread_mach_thread_np(thread);
+    thread_basic_info_data_t info;
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    if (thread_info(mt, THREAD_BASIC_INFO, (thread_info_t) &info, &count) != KERN_SUCCESS) return 0;
+    return (unsigned long long) info.user_time.seconds * 1000000ULL + info.user_time.microseconds +
+           (unsigned long long) info.system_time.seconds * 1000000ULL + info.system_time.microseconds;
+#else
+    clockid_t cid;
+    if (pthread_getcpuclockid(thread, &cid) != 0) return 0;
+    struct timespec ts;
+    if (clock_gettime(cid, &ts) != 0) return 0;
+    return (unsigned long long) ts.tv_sec * 1000000ULL + (unsigned long long) ts.tv_nsec / 1000ULL;
+#endif
+}
+
+// Fold this worker's current-segment CPU usage (getrusage delta) into its
+// across-restart accumulators. Called from inside the worker on every exit
+// path, BEFORE m_finished is set, so the segment is accounted before the
+// monitor loop can observe completion and trigger a restart.
+static void cg_thread_capture_cpu_end(cg_thread *thread)
+{
+#if defined(RUSAGE_THREAD)
+    if (!thread->m_cpu_started) return;
+    struct rusage end_ru;
+    if (getrusage(RUSAGE_THREAD, &end_ru) == 0) {
+        thread->m_cpu_user_usec_acc += tv_to_usec(end_ru.ru_utime) - tv_to_usec(thread->m_cpu_start_ru.ru_utime);
+        thread->m_cpu_sys_usec_acc += tv_to_usec(end_ru.ru_stime) - tv_to_usec(thread->m_cpu_start_ru.ru_stime);
+    }
+    thread->m_cpu_started = false;
+#else
+    (void) thread;
+#endif
+}
 
 static void *cg_thread_start(void *t)
 {
@@ -2593,6 +2687,15 @@ static void *cg_thread_start(void *t)
     // overflow on this thread (or any other handler entry) runs on a fresh
     // stack rather than re-faulting on the exhausted one.
     install_alt_signal_stack();
+
+    // Snapshot this segment's starting CPU time (per-thread). Accumulators on
+    // cg_thread carry prior segments forward across restarts.
+#if defined(RUSAGE_THREAD)
+    if (getrusage(RUSAGE_THREAD, &thread->m_cpu_start_ru) == 0) {
+        thread->m_cpu_started = true;
+        thread->m_cpu_valid = true;
+    }
+#endif
 
     try {
         thread->m_cg->run();
@@ -2612,15 +2715,18 @@ static void *cg_thread_start(void *t)
             thread->m_restart_requested = true;
         }
 
+        cg_thread_capture_cpu_end(thread);
         thread->m_finished = true;
     } catch (const std::exception &e) {
         benchmark_error_log("Thread %u caught exception: %s\n", thread->m_thread_id, e.what());
+        cg_thread_capture_cpu_end(thread);
         thread->m_finished = true;
         if (!g_connection_stage_aborted.load(std::memory_order_acquire)) {
             thread->m_restart_requested = true;
         }
     } catch (...) {
         benchmark_error_log("Thread %u caught unknown exception\n", thread->m_thread_id);
+        cg_thread_capture_cpu_end(thread);
         thread->m_finished = true;
         if (!g_connection_stage_aborted.load(std::memory_order_acquire)) {
             thread->m_restart_requested = true;
@@ -2860,6 +2966,13 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     // reply to AUTH on the same TCP RTT as the connect).
     connection_stage_supervisor_reset();
 
+    // Snapshot the main thread's CPU time just before launching workers, so the
+    // whole-process CPU aggregate includes the orchestrator/sampler overhead.
+#if defined(RUSAGE_THREAD)
+    struct rusage main_cpu_start_ru;
+    bool main_cpu_valid = (getrusage(RUSAGE_THREAD, &main_cpu_start_ru) == 0);
+#endif
+
     // launch threads
     fprintf(stderr, "[RUN #%u] Launching threads now...\n", run_id);
     for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {
@@ -2897,6 +3010,23 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     if (cfg->realtime_latencies) {
         hdr_init(LATENCY_HDR_MIN_VALUE, LATENCY_HDR_SEC_MAX_VALUE, LATENCY_HDR_SEC_SIGDIGTS, &rtl_totals_hist);
     }
+
+    // Live (advisory) per-second CPU sampler state. The main thread reads each
+    // worker's CPU clock via pthread_getcpuclockid without perturbing it, so
+    // this adds no overhead to the workers. Feeds the per-second JSON detail,
+    // the de-duped live high-CPU warning, and the peak-utilization figure.
+    std::vector<per_second_cpu_stats> cpu_history;
+    std::vector<unsigned long long> thread_prev_cpu(threads.size(), 0);
+    std::vector<bool> cpu_warned(threads.size(), false);
+    for (size_t t = 0; t < threads.size(); t++) {
+        thread_prev_cpu[t] = get_thread_cpu_usec(threads[t]->m_thread);
+    }
+    unsigned long long main_prev_cpu = get_thread_cpu_usec(pthread_self());
+    unsigned int cpu_second = 0;
+    double peak_cpu_utilization_pct = 0.0;
+    struct timeval cpu_prev_tv;
+    gettimeofday(&cpu_prev_tv, NULL);
+    const double cpu_warn_pct = cfg->cpu_warn_threshold * 100.0;
 
     // provide some feedback...
     // NOTE: Reading stats from worker threads without synchronization is a benign race.
@@ -3255,6 +3385,49 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
             }
         }
 
+        // Per-second CPU sampling (advisory). Read each worker's CPU clock plus
+        // the main thread's; convert the delta to "% of a core" over the wall
+        // window. Restart-safe: a restarted worker has a new pthread_t and a
+        // reset clock, so guard with cur > prev (treat as 0 for that second).
+        {
+            cpu_second++;
+            struct timeval cpu_cur_tv;
+            gettimeofday(&cpu_cur_tv, NULL);
+            double wall_usec = (double) (cpu_cur_tv.tv_sec - cpu_prev_tv.tv_sec) * 1000000.0 +
+                               (double) (cpu_cur_tv.tv_usec - cpu_prev_tv.tv_usec);
+            if (wall_usec < 1.0) wall_usec = 1.0; // guard against division by zero
+
+            per_second_cpu_stats cpu_snap;
+            cpu_snap.m_second = cpu_second;
+
+            unsigned long long main_cur = get_thread_cpu_usec(pthread_self());
+            unsigned long long main_delta = (main_cur > main_prev_cpu) ? main_cur - main_prev_cpu : 0;
+            cpu_snap.m_main_thread_cpu_pct = (double) main_delta / wall_usec * 100.0;
+            main_prev_cpu = main_cur;
+
+            double whole_pct = cpu_snap.m_main_thread_cpu_pct;
+            for (size_t t = 0; t < threads.size(); t++) {
+                unsigned long long cur = get_thread_cpu_usec(threads[t]->m_thread);
+                unsigned long long delta = (cur > thread_prev_cpu[t]) ? cur - thread_prev_cpu[t] : 0;
+                double pct = (double) delta / wall_usec * 100.0;
+                cpu_snap.m_thread_cpu_pct.push_back(pct);
+                thread_prev_cpu[t] = cur;
+                whole_pct += pct;
+
+                // Live high-CPU warning: once per thread, on first crossing.
+                if (pct > cpu_warn_pct && !cpu_warned[t]) {
+                    fprintf(stderr,
+                            "\nwarning: high CPU on thread %u: %.1f%% of a core (threshold %.1f%%) - "
+                            "results may be unreliable\n",
+                            threads[t]->m_thread_id, pct, cpu_warn_pct);
+                    cpu_warned[t] = true;
+                }
+            }
+            if (whole_pct > peak_cpu_utilization_pct) peak_cpu_utilization_pct = whole_pct;
+            cpu_prev_tv = cpu_cur_tv;
+            cpu_history.push_back(cpu_snap);
+        }
+
         if (inst_hist_agg != NULL) hdr_close(inst_hist_agg);
     } while (active_threads > 0);
 
@@ -3282,6 +3455,63 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {
         (*i)->join();
         (*i)->m_cg->merge_run_stats(&stats);
+    }
+
+    // -----------------------------------------------------------------
+    // CPU utilization aggregate (memtier's own usage).
+    //
+    // Fold each worker's authoritative getrusage(RUSAGE_THREAD) totals (already
+    // accumulated across restarts inside the worker) into the run_stats. This
+    // is the "whole" figure: Σ per-thread CPU-seconds + the main thread, over
+    // the run wall time. Done here, post-join, so reads are race-free.
+    // -----------------------------------------------------------------
+    {
+        cpu_summary csum;
+        double max_wall_seconds = 0.0;
+        for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {
+            cg_thread *t = *i;
+            per_thread_cpu_total pt;
+            pt.thread_id = t->m_thread_id;
+            pt.valid = t->m_cpu_valid;
+            pt.user_seconds = (double) t->m_cpu_user_usec_acc / 1e6;
+            pt.sys_seconds = (double) t->m_cpu_sys_usec_acc / 1e6;
+            pt.total_seconds = pt.user_seconds + pt.sys_seconds;
+            pt.wall_seconds = (double) t->m_cg->get_duration_usec() / 1e6;
+            pt.cores_used = (pt.wall_seconds > 0.0) ? pt.total_seconds / pt.wall_seconds : 0.0;
+            stats.add_cpu_thread(pt);
+
+            if (pt.valid) {
+                csum.user_seconds += pt.user_seconds;
+                csum.sys_seconds += pt.sys_seconds;
+                csum.threads_counted++;
+                if (pt.wall_seconds > max_wall_seconds) max_wall_seconds = pt.wall_seconds;
+            }
+        }
+
+        // Add the main thread's CPU to the whole-process totals (not to the
+        // worker-thread % denominator).
+#if defined(RUSAGE_THREAD)
+        if (main_cpu_valid) {
+            struct rusage main_end_ru;
+            if (getrusage(RUSAGE_THREAD, &main_end_ru) == 0) {
+                csum.user_seconds +=
+                    (double) (tv_to_usec(main_end_ru.ru_utime) - tv_to_usec(main_cpu_start_ru.ru_utime)) / 1e6;
+                csum.sys_seconds +=
+                    (double) (tv_to_usec(main_end_ru.ru_stime) - tv_to_usec(main_cpu_start_ru.ru_stime)) / 1e6;
+            }
+        }
+#endif
+
+        csum.total_seconds = csum.user_seconds + csum.sys_seconds;
+        csum.wall_seconds = max_wall_seconds;
+        csum.peak_utilization_pct = peak_cpu_utilization_pct;
+        if (csum.threads_counted > 0 && csum.wall_seconds > 0.0) {
+            csum.cores_used = csum.total_seconds / csum.wall_seconds;
+            csum.avg_utilization_pct = 100.0 * csum.cores_used / csum.threads_counted;
+            csum.valid = true;
+        }
+        stats.set_cpu_summary(csum);
+        stats.set_cpu_stats(std::move(cpu_history));
     }
 
     // -----------------------------------------------------------------
@@ -3516,6 +3746,7 @@ int main(int argc, char *argv[])
     // sentinel before parsing args.
     cfg.max_retries = -1;
     cfg.miss_rate_threshold = -1.0;   // sentinel; config_init_defaults replaces with 0.01
+    cfg.cpu_warn_threshold = -1.0;    // sentinel; config_init_defaults replaces with 0.95
     cfg.command_miss_tracking = true; // Default: auto-track misses for known shapes
     // Sentinel for --connection-stage-timeout: UINT_MAX means "operator did
     // not specify"; config_init_defaults replaces with 30 s. We can't reuse 0

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -2543,7 +2543,7 @@ struct cg_thread
     // of those same segments, captured at the exact same points as the CPU
     // snapshots, so cores_used = cpu/wall divides two values over the identical
     // interval (no setup-vs-serving skew). Only read post-join (race-free).
-    struct rusage m_cpu_start_ru;  // CPU snapshot at the current segment's start
+    struct rusage m_cpu_start_ru;   // CPU snapshot at the current segment's start
     struct timeval m_wall_start_tv; // wall snapshot at the same point
     unsigned long long m_cpu_user_usec_acc;
     unsigned long long m_cpu_sys_usec_acc;
@@ -2680,10 +2680,8 @@ static void cg_thread_capture_cpu_end(cg_thread *thread)
     if (rc == 0) {
         // ts_diff(a, b) returns b - a in microseconds; rusage CPU time is
         // monotonic per native thread, so each delta is >= 0.
-        thread->m_cpu_user_usec_acc +=
-            (unsigned long long) ts_diff(thread->m_cpu_start_ru.ru_utime, end_ru.ru_utime);
-        thread->m_cpu_sys_usec_acc +=
-            (unsigned long long) ts_diff(thread->m_cpu_start_ru.ru_stime, end_ru.ru_stime);
+        thread->m_cpu_user_usec_acc += (unsigned long long) ts_diff(thread->m_cpu_start_ru.ru_utime, end_ru.ru_utime);
+        thread->m_cpu_sys_usec_acc += (unsigned long long) ts_diff(thread->m_cpu_start_ru.ru_stime, end_ru.ru_stime);
     }
     thread->m_wall_usec_acc += (unsigned long long) ts_diff(thread->m_wall_start_tv, end_tv);
     thread->m_cpu_started = false;

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -207,6 +207,7 @@ struct benchmark_config
     bool command_stats_by_type; // true = aggregate by command type (default), false = per command line
     bool command_miss_tracking; // true = auto (track misses for known shapes), false = off
     double miss_rate_threshold; // warn when miss rate exceeds this fraction (default 0.01 = 1%)
+    double cpu_warn_threshold;  // warn when a memtier thread's CPU exceeds this fraction of a core (default 0.95)
     const char *hdr_prefix;
     unsigned int request_rate;
     unsigned int request_per_interval;

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -937,8 +937,9 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
         // avg_utilization_pct uses WORKER-only CPU (main excluded), matching the
         // single-run semantics so it cannot exceed 100% from main-thread overhead.
         agg_cpu.avg_utilization_pct =
-            max_threads_counted > 0 ? 100.0 * (agg_cpu.worker_total_seconds / agg_cpu.wall_seconds) / max_threads_counted
-                                    : 0.0;
+            max_threads_counted > 0
+                ? 100.0 * (agg_cpu.worker_total_seconds / agg_cpu.wall_seconds) / max_threads_counted
+                : 0.0;
         agg_cpu.valid = true;
         m_cpu_summary = agg_cpu;
     }

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -1988,6 +1988,9 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
             snprintf(sec_str, sizeof(sec_str), "%u", cs.m_second);
             jsonhandler->open_nesting(sec_str);
             jsonhandler->write_obj("Main Thread", "%.2f", cs.m_main_thread_cpu_pct);
+            // "Thread N" here is the worker's positional index, which equals its
+            // m_thread_id (assigned as the construction index), so these labels
+            // line up 1:1 with the authoritative "CPU" -> "Per Thread" block.
             for (size_t t = 0; t < cs.m_thread_cpu_pct.size(); t++) {
                 char thread_name[32];
                 snprintf(thread_name, sizeof(thread_name), "Thread %zu", t);

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -909,6 +909,35 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
         m_end_time.tv_sec = (time_t) (total_duration_usec / 1000000);
         m_end_time.tv_usec = (suseconds_t) (total_duration_usec % 1000000);
     }
+
+    // Combine the whole-process CPU aggregate across runs: sum CPU-seconds and
+    // wall-seconds (so cores_used is the time-weighted average), take the max
+    // peak, and recompute the derived fields. Per-second / per-thread CPU detail
+    // is intentionally left empty for the AVERAGE report (it belongs to a single
+    // run; BEST/WORST keep their own).
+    cpu_summary agg_cpu;
+    unsigned int cpu_runs = 0;
+    unsigned int max_threads_counted = 0;
+    for (std::vector<run_stats>::const_iterator i = all_stats.begin(); i != all_stats.end(); i++) {
+        const cpu_summary &cs = i->m_cpu_summary;
+        if (!cs.valid) continue;
+        cpu_runs++;
+        agg_cpu.user_seconds += cs.user_seconds;
+        agg_cpu.sys_seconds += cs.sys_seconds;
+        agg_cpu.total_seconds += cs.total_seconds;
+        agg_cpu.wall_seconds += cs.wall_seconds;
+        if (cs.peak_utilization_pct > agg_cpu.peak_utilization_pct)
+            agg_cpu.peak_utilization_pct = cs.peak_utilization_pct;
+        if (cs.threads_counted > max_threads_counted) max_threads_counted = cs.threads_counted;
+    }
+    if (cpu_runs > 0 && agg_cpu.wall_seconds > 0.0) {
+        agg_cpu.threads_counted = max_threads_counted;
+        agg_cpu.cores_used = agg_cpu.total_seconds / agg_cpu.wall_seconds;
+        agg_cpu.avg_utilization_pct =
+            max_threads_counted > 0 ? 100.0 * agg_cpu.cores_used / max_threads_counted : 0.0;
+        agg_cpu.valid = true;
+        m_cpu_summary = agg_cpu;
+    }
 }
 
 void run_stats::merge(const run_stats &other, int iteration)
@@ -1656,6 +1685,40 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
         jsonhandler->write_obj("Interrupted", "\"%s\"", m_interrupted ? "true" : "false");
         jsonhandler->close_nesting();
     }
+
+    // Whole-process CPU aggregate (memtier's own utilization). Emitted as a
+    // sibling of "Runtime" so the existing Runtime schema is untouched. Only
+    // present when per-thread CPU accounting succeeded (Linux RUSAGE_THREAD).
+    if (jsonhandler != NULL && m_cpu_summary.valid) {
+        jsonhandler->open_nesting("CPU");
+        jsonhandler->write_obj("cpu_user_seconds", "%.3f", m_cpu_summary.user_seconds);
+        jsonhandler->write_obj("cpu_sys_seconds", "%.3f", m_cpu_summary.sys_seconds);
+        jsonhandler->write_obj("cpu_total_seconds", "%.3f", m_cpu_summary.total_seconds);
+        jsonhandler->write_obj("cpu_wall_seconds", "%.3f", m_cpu_summary.wall_seconds);
+        jsonhandler->write_obj("cpu_cores_used", "%.3f", m_cpu_summary.cores_used);
+        jsonhandler->write_obj("avg_cpu_utilization_pct", "%.3f", m_cpu_summary.avg_utilization_pct);
+        jsonhandler->write_obj("peak_cpu_utilization_pct", "%.3f", m_cpu_summary.peak_utilization_pct);
+        jsonhandler->write_obj("threads_counted", "%u", m_cpu_summary.threads_counted);
+        if (!m_cpu_threads.empty()) {
+            jsonhandler->open_nesting("Per Thread");
+            for (size_t i = 0; i < m_cpu_threads.size(); i++) {
+                const per_thread_cpu_total &pt = m_cpu_threads[i];
+                if (!pt.valid) continue;
+                char thread_name[32];
+                snprintf(thread_name, sizeof(thread_name), "Thread %u", pt.thread_id);
+                jsonhandler->open_nesting(thread_name);
+                jsonhandler->write_obj("user_seconds", "%.3f", pt.user_seconds);
+                jsonhandler->write_obj("sys_seconds", "%.3f", pt.sys_seconds);
+                jsonhandler->write_obj("total_seconds", "%.3f", pt.total_seconds);
+                jsonhandler->write_obj("wall_seconds", "%.3f", pt.wall_seconds);
+                jsonhandler->write_obj("cores_used", "%.3f", pt.cores_used);
+                jsonhandler->close_nesting();
+            }
+            jsonhandler->close_nesting();
+        }
+        jsonhandler->close_nesting();
+    }
+
     std::vector<unsigned int> timestamps = get_one_sec_cmd_stats_timestamp();
 
     if (print_arbitrary_commands_results()) {
@@ -1912,6 +1975,28 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
         }
         jsonhandler->close_nesting();
     }
+
+    // Per-second, per-thread CPU detail from the live sampler. Advisory: these
+    // are 1s-window "% of a core" samples, distinct from the authoritative "CPU"
+    // aggregate above. Each second carries the main thread plus one "Thread N"
+    // entry per worker.
+    if (jsonhandler != NULL && !m_cpu_stats.empty()) {
+        jsonhandler->open_nesting("CPU Stats");
+        for (size_t i = 0; i < m_cpu_stats.size(); i++) {
+            const per_second_cpu_stats &cs = m_cpu_stats[i];
+            char sec_str[16];
+            snprintf(sec_str, sizeof(sec_str), "%u", cs.m_second);
+            jsonhandler->open_nesting(sec_str);
+            jsonhandler->write_obj("Main Thread", "%.2f", cs.m_main_thread_cpu_pct);
+            for (size_t t = 0; t < cs.m_thread_cpu_pct.size(); t++) {
+                char thread_name[32];
+                snprintf(thread_name, sizeof(thread_name), "Thread %zu", t);
+                jsonhandler->write_obj(thread_name, "%.2f", cs.m_thread_cpu_pct[t]);
+            }
+            jsonhandler->close_nesting();
+        }
+        jsonhandler->close_nesting();
+    }
 }
 
 void run_stats::print_histogram(FILE *out, json_handler *jsonhandler, arbitrary_command_list &command_list,
@@ -2115,6 +2200,37 @@ void run_stats::print(FILE *out, benchmark_config *config, const char *header /*
             if (miss_rate > miss_threshold) {
                 fprintf(stderr, "warning: GET miss rate %.2f%% above target %.2f%% (%lu misses / %llu ops)\n",
                         miss_rate * 100.0, miss_threshold * 100.0, m_totals.m_misses, total);
+            }
+        }
+    }
+
+    // CPU utilization summary for memtier itself. Goes to stderr (like the
+    // miss-rate warning above) so it never corrupts piped / redirected table
+    // output. Only the authoritative getrusage-based aggregate is shown here.
+    if (m_cpu_summary.valid) {
+        fprintf(stderr,
+                "\n"
+                "CPU Utilization Summary\n"
+                "  Total CPU time:   %.3fs  (user %.3fs, sys %.3fs)\n"
+                "  Wall time:        %.3fs\n"
+                "  Cores used:       %.3f   (avg %.1f%% across %u worker threads)\n"
+                "  Peak utilization: %.1f%%\n",
+                m_cpu_summary.total_seconds, m_cpu_summary.user_seconds, m_cpu_summary.sys_seconds,
+                m_cpu_summary.wall_seconds, m_cpu_summary.cores_used, m_cpu_summary.avg_utilization_pct,
+                m_cpu_summary.threads_counted, m_cpu_summary.peak_utilization_pct);
+
+        // End-of-run high-CPU warning (one line per offending thread), computed
+        // from the authoritative per-thread totals. config->cpu_warn_threshold
+        // is a fraction of a single core (default 0.95).
+        const double cpu_threshold = config->cpu_warn_threshold;
+        for (size_t i = 0; i < m_cpu_threads.size(); i++) {
+            const per_thread_cpu_total &pt = m_cpu_threads[i];
+            if (!pt.valid) continue;
+            if (pt.cores_used > cpu_threshold) {
+                fprintf(stderr,
+                        "warning: thread %u averaged %.1f%% of a core over the run (threshold %.1f%%) - "
+                        "memtier may be the bottleneck; results may be unreliable\n",
+                        pt.thread_id, pt.cores_used * 100.0, cpu_threshold * 100.0);
             }
         }
     }

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -925,6 +925,7 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
         agg_cpu.user_seconds += cs.user_seconds;
         agg_cpu.sys_seconds += cs.sys_seconds;
         agg_cpu.total_seconds += cs.total_seconds;
+        agg_cpu.worker_total_seconds += cs.worker_total_seconds;
         agg_cpu.wall_seconds += cs.wall_seconds;
         if (cs.peak_utilization_pct > agg_cpu.peak_utilization_pct)
             agg_cpu.peak_utilization_pct = cs.peak_utilization_pct;
@@ -933,8 +934,11 @@ void run_stats::aggregate_average(const std::vector<run_stats> &all_stats)
     if (cpu_runs > 0 && agg_cpu.wall_seconds > 0.0) {
         agg_cpu.threads_counted = max_threads_counted;
         agg_cpu.cores_used = agg_cpu.total_seconds / agg_cpu.wall_seconds;
+        // avg_utilization_pct uses WORKER-only CPU (main excluded), matching the
+        // single-run semantics so it cannot exceed 100% from main-thread overhead.
         agg_cpu.avg_utilization_pct =
-            max_threads_counted > 0 ? 100.0 * agg_cpu.cores_used / max_threads_counted : 0.0;
+            max_threads_counted > 0 ? 100.0 * (agg_cpu.worker_total_seconds / agg_cpu.wall_seconds) / max_threads_counted
+                                    : 0.0;
         agg_cpu.valid = true;
         m_cpu_summary = agg_cpu;
     }

--- a/run_stats.h
+++ b/run_stats.h
@@ -269,6 +269,26 @@ public:
     std::vector<read_routing_summary> m_arbitrary_read_routing; // per arbitrary-cmd index
     read_routing_summary m_get_read_routing;                    // built-in GET aggregate
 
+    // ---------------------------------------------------------------------
+    // CPU utilization of memtier itself (the load generator).
+    //   m_cpu_summary  - authoritative whole-run aggregate (getrusage-based)
+    //   m_cpu_threads  - authoritative per-worker totals (getrusage-based)
+    //   m_cpu_stats    - advisory per-second per-thread sampler detail
+    // All three are populated by run_benchmark() after the join loop and
+    // consumed by print()/print_json(). They survive the copyable run_stats
+    // (POD doubles + vectors) and are intentionally NOT routed through the
+    // per-client merge()/totals path: per-thread CPU is folded exactly once
+    // from cg_thread, not summed across the N per-client run_stats.
+    // ---------------------------------------------------------------------
+    cpu_summary m_cpu_summary;
+    std::vector<per_thread_cpu_total> m_cpu_threads;
+    std::vector<per_second_cpu_stats> m_cpu_stats;
+
+    void set_cpu_summary(const cpu_summary &s) { m_cpu_summary = s; }
+    void add_cpu_thread(const per_thread_cpu_total &t) { m_cpu_threads.push_back(t); }
+    void set_cpu_stats(std::vector<per_second_cpu_stats> s) { m_cpu_stats = std::move(s); }
+    const cpu_summary &get_cpu_summary() const { return m_cpu_summary; }
+
     // Aggregator: fold the per-endpoint snapshot from one client's
     // shard_connections into m_endpoint_snapshots. Entries are coalesced by
     // (addr, role) so the JSON is at most O(distinct endpoints) regardless

--- a/run_stats_types.h
+++ b/run_stats_types.h
@@ -152,7 +152,8 @@ public:
 // and each m_thread_cpu_pct entry are "% of a single core" for that 1s window
 // (so a fully-busy worker reads ~100.0). Used for the per-second JSON detail
 // and the live one-shot high-CPU warning. Trivially copyable.
-struct per_second_cpu_stats {
+struct per_second_cpu_stats
+{
     unsigned int m_second;
     double m_main_thread_cpu_pct;
     std::vector<double> m_thread_cpu_pct;
@@ -163,7 +164,8 @@ struct per_second_cpu_stats {
 // getrusage(RUSAGE_THREAD) deltas captured inside the worker (accumulated
 // across restarts). Seconds are wall-independent CPU time; cores_used is
 // total_seconds / wall_seconds (i.e. average busy cores for this thread).
-struct per_thread_cpu_total {
+struct per_thread_cpu_total
+{
     unsigned int thread_id;
     double user_seconds;
     double sys_seconds;
@@ -171,9 +173,16 @@ struct per_thread_cpu_total {
     double wall_seconds;
     double cores_used;
     bool valid; // false => getrusage unavailable/failed; excluded from sums
-    per_thread_cpu_total()
-        : thread_id(0), user_seconds(0.0), sys_seconds(0.0), total_seconds(0.0), wall_seconds(0.0), cores_used(0.0),
-          valid(false) {}
+    per_thread_cpu_total() :
+            thread_id(0),
+            user_seconds(0.0),
+            sys_seconds(0.0),
+            total_seconds(0.0),
+            wall_seconds(0.0),
+            cores_used(0.0),
+            valid(false)
+    {
+    }
 };
 
 // Whole-process CPU aggregate for the run: sum of every worker (plus the main
@@ -181,20 +190,31 @@ struct per_thread_cpu_total {
 // is normalized to the worker-thread count, so 100% means "all worker threads
 // were saturated". peak_utilization_pct is the highest single-second whole-process
 // utilization observed by the live sampler.
-struct cpu_summary {
+struct cpu_summary
+{
     double user_seconds;
     double sys_seconds;
-    double total_seconds;          // whole process: workers + main thread
-    double worker_total_seconds;   // workers only; basis for avg_utilization_pct
+    double total_seconds;        // whole process: workers + main thread
+    double worker_total_seconds; // workers only; basis for avg_utilization_pct
     double wall_seconds;
     double cores_used;
     double avg_utilization_pct;
     double peak_utilization_pct;
     unsigned int threads_counted; // number of valid worker threads in the sums
     bool valid;
-    cpu_summary()
-        : user_seconds(0.0), sys_seconds(0.0), total_seconds(0.0), worker_total_seconds(0.0), wall_seconds(0.0),
-          cores_used(0.0), avg_utilization_pct(0.0), peak_utilization_pct(0.0), threads_counted(0), valid(false) {}
+    cpu_summary() :
+            user_seconds(0.0),
+            sys_seconds(0.0),
+            total_seconds(0.0),
+            worker_total_seconds(0.0),
+            wall_seconds(0.0),
+            cores_used(0.0),
+            avg_utilization_pct(0.0),
+            peak_utilization_pct(0.0),
+            threads_counted(0),
+            valid(false)
+    {
+    }
 };
 
 class totals_cmd

--- a/run_stats_types.h
+++ b/run_stats_types.h
@@ -147,6 +147,55 @@ public:
     void merge(const one_second_stats &other);
 };
 
+// Per-second, per-thread CPU utilization snapshot produced by the live
+// (advisory) sampler in run_benchmark's monitor loop. m_main_thread_cpu_pct
+// and each m_thread_cpu_pct entry are "% of a single core" for that 1s window
+// (so a fully-busy worker reads ~100.0). Used for the per-second JSON detail
+// and the live one-shot high-CPU warning. Trivially copyable.
+struct per_second_cpu_stats {
+    unsigned int m_second;
+    double m_main_thread_cpu_pct;
+    std::vector<double> m_thread_cpu_pct;
+    per_second_cpu_stats() : m_second(0), m_main_thread_cpu_pct(0.0) {}
+};
+
+// Authoritative per-worker CPU total for the whole run, derived from
+// getrusage(RUSAGE_THREAD) deltas captured inside the worker (accumulated
+// across restarts). Seconds are wall-independent CPU time; cores_used is
+// total_seconds / wall_seconds (i.e. average busy cores for this thread).
+struct per_thread_cpu_total {
+    unsigned int thread_id;
+    double user_seconds;
+    double sys_seconds;
+    double total_seconds;
+    double wall_seconds;
+    double cores_used;
+    bool valid; // false => getrusage unavailable/failed; excluded from sums
+    per_thread_cpu_total()
+        : thread_id(0), user_seconds(0.0), sys_seconds(0.0), total_seconds(0.0), wall_seconds(0.0), cores_used(0.0),
+          valid(false) {}
+};
+
+// Whole-process CPU aggregate for the run: sum of every worker (plus the main
+// thread) folded once from the per-thread totals after join. avg_utilization_pct
+// is normalized to the worker-thread count, so 100% means "all worker threads
+// were saturated". peak_utilization_pct is the highest single-second whole-process
+// utilization observed by the live sampler.
+struct cpu_summary {
+    double user_seconds;
+    double sys_seconds;
+    double total_seconds;
+    double wall_seconds;
+    double cores_used;
+    double avg_utilization_pct;
+    double peak_utilization_pct;
+    unsigned int threads_counted; // number of valid worker threads in the sums
+    bool valid;
+    cpu_summary()
+        : user_seconds(0.0), sys_seconds(0.0), total_seconds(0.0), wall_seconds(0.0), cores_used(0.0),
+          avg_utilization_pct(0.0), peak_utilization_pct(0.0), threads_counted(0), valid(false) {}
+};
+
 class totals_cmd
 {
 public:

--- a/run_stats_types.h
+++ b/run_stats_types.h
@@ -184,7 +184,8 @@ struct per_thread_cpu_total {
 struct cpu_summary {
     double user_seconds;
     double sys_seconds;
-    double total_seconds;
+    double total_seconds;          // whole process: workers + main thread
+    double worker_total_seconds;   // workers only; basis for avg_utilization_pct
     double wall_seconds;
     double cores_used;
     double avg_utilization_pct;
@@ -192,8 +193,8 @@ struct cpu_summary {
     unsigned int threads_counted; // number of valid worker threads in the sums
     bool valid;
     cpu_summary()
-        : user_seconds(0.0), sys_seconds(0.0), total_seconds(0.0), wall_seconds(0.0), cores_used(0.0),
-          avg_utilization_pct(0.0), peak_utilization_pct(0.0), threads_counted(0), valid(false) {}
+        : user_seconds(0.0), sys_seconds(0.0), total_seconds(0.0), worker_total_seconds(0.0), wall_seconds(0.0),
+          cores_used(0.0), avg_utilization_pct(0.0), peak_utilization_pct(0.0), threads_counted(0), valid(false) {}
 };
 
 class totals_cmd

--- a/tests/test_cpu_stats.py
+++ b/tests/test_cpu_stats.py
@@ -163,17 +163,25 @@ def test_cpu_warn_threshold_flag(env):
     stderr0 = _read_stderr(cfg0)
     env.assertTrue('high CPU on thread' in stderr0)
 
-    # threshold=100 -> the authoritative end-of-run warning (run-average cores_used)
-    # cannot fire: a single thread's average over its own lifetime never exceeds
-    # 1.0 core (100%). We assert on the end-of-run 'of a core' line specifically,
-    # not the per-second live line, because a momentary per-second sample can
-    # legitimately read slightly above 100% due to wall-window sampling jitter.
+    # threshold=100 -> the authoritative end-of-run warning fires only for a
+    # thread whose run-average cores_used exceeds 1.0. A single thread over its
+    # own wall bracket physically cannot exceed ~1.0 core, so this is normally
+    # silent. Rather than assert blanket silence (which clock/wall jitter could
+    # rarely break at exactly 1.0), assert the warning count is CONSISTENT with
+    # the authoritative JSON: one 'of a core' line per thread with cores_used>1.0.
     specs100 = {"name": env.testName, "args": base_args + ['--cpu-warn-threshold=100']}
     addTLSArgs(specs100, env)
     cfg100 = get_default_memtier_config(threads=1, clients=50, requests=None, test_time=3)
-    cfg100, _ = _run_and_load(env, specs100, cfg100)
+    cfg100, results100 = _run_and_load(env, specs100, cfg100)
     stderr100 = _read_stderr(cfg100)
-    env.assertTrue('of a core' not in stderr100)
+    end_warnings = stderr100.count('of a core')
+    all100 = results100['ALL STATS']
+    if 'CPU' in all100:
+        over_one_core = sum(1 for pt in all100['CPU']['Per Thread'].values() if pt['cores_used'] > 1.0)
+        env.assertTrue(end_warnings == over_one_core)
+    else:
+        # No authoritative aggregate (non-Linux): no end-of-run warning possible.
+        env.assertTrue(end_warnings == 0)
 
 
 def test_cpu_multi_run(env):

--- a/tests/test_cpu_stats.py
+++ b/tests/test_cpu_stats.py
@@ -1,0 +1,268 @@
+import tempfile
+import json
+import subprocess
+import time
+from include import *
+from mb import Benchmark, RunConfig
+
+
+# Upper bound for a single worker thread's per-second "% of a core" sample. A
+# thread runs on at most one core, so ~100% is the ceiling; allow a small margin
+# for the slight mismatch between the wall window and the CPU-clock sampling.
+PER_THREAD_PCT_CEILING = 110.0
+
+
+def _run_and_load(env, benchmark_specs, config):
+    """Run memtier and return (config, results_dict) after basic assertions."""
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    memtier_ok = benchmark.run()
+    if not memtier_ok:
+        debugPrintMemtierOnError(config, env)
+
+    env.assertTrue(memtier_ok == True)
+    json_filename = '{0}/mb.json'.format(config.results_dir)
+    env.assertTrue(os.path.isfile(json_filename))
+    with open(json_filename) as results_json:
+        return config, json.load(results_json)
+
+
+def _read_stderr(config):
+    stderr_filename = '{0}/mb.stderr'.format(config.results_dir)
+    if os.path.isfile(stderr_filename):
+        with open(stderr_filename) as stderr_file:
+            return stderr_file.read()
+    return ""
+
+
+def test_cpu_stats_in_json(env):
+    """Verify both the aggregate CPU block and per-second CPU Stats are present
+    and self-consistent."""
+    benchmark_specs = {"name": env.testName, "args": []}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=2, clients=5, requests=1000)
+
+    config, results_dict = _run_and_load(env, benchmark_specs, config)
+
+    env.assertTrue('ALL STATS' in results_dict)
+    all_stats = results_dict['ALL STATS']
+
+    # --- Aggregate "CPU" block (authoritative, getrusage-based) ---
+    # Only emitted on platforms with per-thread accounting (Linux RUSAGE_THREAD).
+    if 'CPU' in all_stats:
+        cpu = all_stats['CPU']
+        for key in ('cpu_user_seconds', 'cpu_sys_seconds', 'cpu_total_seconds',
+                    'cpu_wall_seconds', 'cpu_cores_used', 'avg_cpu_utilization_pct',
+                    'peak_cpu_utilization_pct', 'threads_counted'):
+            env.assertTrue(key in cpu)
+        # total == user + sys (within rounding)
+        env.assertTrue(abs(cpu['cpu_total_seconds']
+                           - (cpu['cpu_user_seconds'] + cpu['cpu_sys_seconds'])) < 0.01)
+        env.assertTrue(cpu['threads_counted'] == 2)
+        env.assertTrue(cpu['cpu_cores_used'] >= 0)
+        env.assertTrue(cpu['avg_cpu_utilization_pct'] >= 0)
+        # Per-thread breakdown
+        env.assertTrue('Per Thread' in cpu)
+        for t in range(2):
+            tk = 'Thread {}'.format(t)
+            env.assertTrue(tk in cpu['Per Thread'])
+            pt = cpu['Per Thread'][tk]
+            for key in ('user_seconds', 'sys_seconds', 'total_seconds', 'wall_seconds', 'cores_used'):
+                env.assertTrue(key in pt)
+            env.assertTrue(abs(pt['total_seconds'] - (pt['user_seconds'] + pt['sys_seconds'])) < 0.01)
+
+    # --- Per-second advisory CPU Stats ---
+    env.assertTrue('CPU Stats' in all_stats)
+    cpu_stats = all_stats['CPU Stats']
+    env.assertTrue(len(cpu_stats) > 0)
+    for second_key, second_data in cpu_stats.items():
+        env.assertTrue('Main Thread' in second_data)
+        env.assertTrue(second_data['Main Thread'] >= 0)
+        for t in range(2):
+            thread_key = 'Thread {}'.format(t)
+            env.assertTrue(thread_key in second_data)
+            thread_cpu = second_data[thread_key]
+            env.assertTrue(thread_cpu >= 0)
+            env.assertTrue(thread_cpu < PER_THREAD_PCT_CEILING)
+
+
+def test_cpu_stats_high_load(env):
+    """Stress a single thread with many clients to drive high CPU and verify the
+    de-duped live warning + end-of-run warning."""
+    env.skipOnCluster()
+
+    benchmark_specs = {"name": env.testName, "args": [
+        '--pipeline=100',
+        '--data-size=1',
+        '--ratio=1:1',
+        '--key-pattern=R:R',
+        '--key-maximum=100',
+        '--cpu-warn-threshold=50',
+    ]}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=1, clients=500, requests=None, test_time=5)
+
+    config, results_dict = _run_and_load(env, benchmark_specs, config)
+    all_stats = results_dict['ALL STATS']
+    env.assertTrue('CPU Stats' in all_stats)
+
+    cpu_stats = all_stats['CPU Stats']
+    env.assertTrue(len(cpu_stats) >= 2)
+
+    max_thread_cpu = 0
+    for second_key, second_data in cpu_stats.items():
+        env.assertTrue('Thread 0' in second_data)
+        thread_cpu = second_data['Thread 0']
+        env.assertTrue(thread_cpu >= 0)
+        env.assertTrue(thread_cpu < PER_THREAD_PCT_CEILING)
+        if thread_cpu > max_thread_cpu:
+            max_thread_cpu = thread_cpu
+
+    env.debugPrint("Max worker thread CPU observed: {:.1f}%".format(max_thread_cpu), True)
+    env.assertTrue(max_thread_cpu > 10.0)
+
+    stderr_content = _read_stderr(config)
+    # Live warning string (lowercase, new format).
+    live_warnings = stderr_content.count('high CPU on thread')
+    env.debugPrint("Live high-CPU warnings: {}".format(live_warnings), True)
+    # De-dup: at most one live warning per worker thread (here: 1 thread).
+    env.assertTrue(live_warnings <= 1)
+    if max_thread_cpu > 50.0:
+        env.assertTrue(live_warnings >= 1)
+        # End-of-run summary warning (only when the aggregate block is available).
+        if 'CPU' in all_stats:
+            env.assertTrue('averaged' in stderr_content and 'of a core' in stderr_content)
+
+
+def test_cpu_warn_threshold_flag(env):
+    """--cpu-warn-threshold=0 must warn; =100 must stay silent."""
+    env.skipOnCluster()
+
+    base_args = ['--pipeline=50', '--data-size=1', '--ratio=1:1', '--key-maximum=100']
+
+    # threshold=0 -> warns on any CPU usage
+    specs0 = {"name": env.testName, "args": base_args + ['--cpu-warn-threshold=0']}
+    addTLSArgs(specs0, env)
+    cfg0 = get_default_memtier_config(threads=1, clients=50, requests=None, test_time=3)
+    cfg0, _ = _run_and_load(env, specs0, cfg0)
+    stderr0 = _read_stderr(cfg0)
+    env.assertTrue('high CPU on thread' in stderr0)
+
+    # threshold=100 -> effectively silent (a single thread cannot exceed 100% of a core)
+    specs100 = {"name": env.testName, "args": base_args + ['--cpu-warn-threshold=100']}
+    addTLSArgs(specs100, env)
+    cfg100 = get_default_memtier_config(threads=1, clients=50, requests=None, test_time=3)
+    cfg100, _ = _run_and_load(env, specs100, cfg100)
+    stderr100 = _read_stderr(cfg100)
+    env.assertTrue('high CPU on thread' not in stderr100)
+    env.assertTrue('of a core' not in stderr100)
+
+
+def test_cpu_aggregate_cores(env):
+    """The aggregate cores_used must be plausible and roughly match the per-thread
+    sum."""
+    env.skipOnCluster()
+
+    benchmark_specs = {"name": env.testName, "args": [
+        '--pipeline=50', '--data-size=1', '--ratio=1:1', '--key-maximum=100',
+    ]}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=2, clients=50, requests=None, test_time=4)
+
+    config, results_dict = _run_and_load(env, benchmark_specs, config)
+    all_stats = results_dict['ALL STATS']
+
+    if 'CPU' not in all_stats:
+        env.debugPrint("Aggregate CPU block not present (non-Linux platform), skipping", True)
+        return
+
+    cpu = all_stats['CPU']
+    # 2 worker threads + main thread: cores_used must be > 0 and well under threads+2.
+    env.assertTrue(cpu['cpu_cores_used'] > 0.0)
+    env.assertTrue(cpu['cpu_cores_used'] < 4.0)
+
+    # Sum of per-thread cores_used should be <= aggregate (aggregate also includes main).
+    per_thread_sum = sum(pt['cores_used'] for pt in cpu['Per Thread'].values())
+    env.assertTrue(per_thread_sum <= cpu['cpu_cores_used'] + 0.05)
+    # avg% normalized to worker count
+    env.assertTrue(abs(cpu['avg_cpu_utilization_pct']
+                       - 100.0 * cpu['cpu_cores_used'] / cpu['threads_counted']) < 0.5)
+
+
+def test_cpu_stats_external_validation(env):
+    """Cross-validate memtier's authoritative cpu_total_seconds against psutil."""
+    try:
+        import psutil
+    except ImportError:
+        env.debugPrint("psutil not available, skipping external CPU validation", True)
+        return
+
+    env.skipOnCluster()
+
+    benchmark_specs = {"name": env.testName, "args": [
+        '--pipeline=100', '--data-size=1', '--ratio=1:1', '--key-pattern=R:R', '--key-maximum=100',
+    ]}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=1, clients=500, requests=None, test_time=5)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    test_dir = tempfile.mkdtemp()
+    config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(config.results_dir)
+
+    benchmark = Benchmark.from_json(config, benchmark_specs)
+    process = subprocess.Popen(benchmark.args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    # Accumulate total process CPU-seconds from psutil over the run.
+    access_denied = False
+    start_wall = time.time()
+    last_total = 0.0
+    try:
+        p = psutil.Process(process.pid)
+        while process.poll() is None:
+            try:
+                ct = p.cpu_times()
+                last_total = ct.user + ct.system
+            except psutil.NoSuchProcess:
+                break
+            time.sleep(0.5)
+    except psutil.AccessDenied:
+        access_denied = True
+    except psutil.NoSuchProcess:
+        pass
+
+    stdout, stderr = process.communicate()
+    if stderr:
+        benchmark.write_file('mb.stderr', stderr)
+    env.assertTrue(process.returncode == 0)
+
+    if access_denied:
+        env.debugPrint("psutil.AccessDenied (macOS task_for_pid restriction), skipping", True)
+        return
+
+    json_filename = os.path.join(config.results_dir, 'mb.json')
+    env.assertTrue(os.path.isfile(json_filename))
+    with open(json_filename) as f:
+        results_dict = json.load(f)
+
+    all_stats = results_dict['ALL STATS']
+    if 'CPU' not in all_stats:
+        env.debugPrint("Aggregate CPU block not present, skipping external validation", True)
+        return
+
+    internal_total = all_stats['CPU']['cpu_total_seconds']
+    env.debugPrint("memtier cpu_total_seconds: {:.2f}s".format(internal_total), True)
+    env.debugPrint("psutil total CPU-seconds:  {:.2f}s".format(last_total), True)
+
+    # Both should show meaningful CPU and agree within a generous tolerance
+    # (psutil also counts short-lived helper threads not in memtier's worker set).
+    env.assertTrue(internal_total > 0.5)
+    env.assertTrue(last_total > 0.5)
+    env.assertTrue(abs(internal_total - last_total) < max(2.0, 0.5 * last_total))

--- a/tests/test_cpu_stats.py
+++ b/tests/test_cpu_stats.py
@@ -229,16 +229,22 @@ def test_cpu_aggregate_cores(env):
         return
 
     cpu = all_stats['CPU']
-    # 2 worker threads + main thread: cores_used must be > 0 and well under threads+2.
+    # 2 worker threads + main thread: cores_used must be > 0 and bounded.
     env.assertTrue(cpu['cpu_cores_used'] > 0.0)
-    env.assertTrue(cpu['cpu_cores_used'] < 4.0)
+    env.assertTrue(cpu['cpu_cores_used'] < cpu['threads_counted'] + 2.0)
 
-    # Sum of per-thread cores_used should be <= aggregate (aggregate also includes main).
-    per_thread_sum = sum(pt['cores_used'] for pt in cpu['Per Thread'].values())
-    env.assertTrue(per_thread_sum <= cpu['cpu_cores_used'] + 0.05)
-    # avg% normalized to worker count
-    env.assertTrue(abs(cpu['avg_cpu_utilization_pct']
-                       - 100.0 * cpu['cpu_cores_used'] / cpu['threads_counted']) < 0.5)
+    # cpu_cores_used is whole-process: total CPU / wall (exact internal invariant).
+    env.assertTrue(abs(cpu['cpu_cores_used']
+                       - cpu['cpu_total_seconds'] / cpu['cpu_wall_seconds']) < 0.01)
+
+    # avg_cpu_utilization_pct is WORKER-only saturation: 100 * (sum of worker CPU
+    # seconds / wall) / worker count. Reconstruct it exactly from the per-thread
+    # JSON so the check is independent of run timing (robust under sanitizers,
+    # where the main thread's CPU -- excluded here -- is amplified). It must NOT
+    # equal 100*cpu_cores_used/threads, which includes main-thread CPU.
+    worker_total = sum(pt['total_seconds'] for pt in cpu['Per Thread'].values())
+    expected_avg = 100.0 * (worker_total / cpu['cpu_wall_seconds']) / cpu['threads_counted']
+    env.assertTrue(abs(cpu['avg_cpu_utilization_pct'] - expected_avg) < 0.5)
 
 
 def test_cpu_stats_external_validation(env):

--- a/tests/test_cpu_stats.py
+++ b/tests/test_cpu_stats.py
@@ -97,13 +97,16 @@ def test_cpu_stats_high_load(env):
     de-duped live warning + end-of-run warning."""
     env.skipOnCluster()
 
+    # Warn threshold = 10% of a core, aligned with the hard >10% load assertion
+    # below so the warning path is exercised whenever the load assertion holds
+    # (avoids a gap where the test passes without validating any warning).
     benchmark_specs = {"name": env.testName, "args": [
         '--pipeline=100',
         '--data-size=1',
         '--ratio=1:1',
         '--key-pattern=R:R',
         '--key-maximum=100',
-        '--cpu-warn-threshold=50',
+        '--cpu-warn-threshold=10',
     ]}
     addTLSArgs(benchmark_specs, env)
     config = get_default_memtier_config(threads=1, clients=500, requests=None, test_time=5)
@@ -128,25 +131,31 @@ def test_cpu_stats_high_load(env):
     env.assertTrue(max_thread_cpu > 10.0)
 
     stderr_content = _read_stderr(config)
-    # Live warning string (lowercase, new format).
     live_warnings = stderr_content.count('high CPU on thread')
     env.debugPrint("Live high-CPU warnings: {}".format(live_warnings), True)
     # De-dup: at most one live warning per worker thread (here: 1 thread).
     env.assertTrue(live_warnings <= 1)
-    if max_thread_cpu > 50.0:
-        env.assertTrue(live_warnings >= 1)
-        # End-of-run summary warning (only when the aggregate block is available).
-        if 'CPU' in all_stats:
+    # A per-second sample exceeded 10% (we asserted max_thread_cpu > 10), so the
+    # live warning must have fired exactly once.
+    env.assertTrue(live_warnings == 1)
+
+    # The end-of-run warning is driven by the AUTHORITATIVE run-average cores_used,
+    # not the per-second peak, so gate its assertion on the JSON aggregate value.
+    if 'CPU' in all_stats:
+        cores = all_stats['CPU']['Per Thread']['Thread 0']['cores_used']
+        env.debugPrint("Authoritative Thread 0 cores_used: {:.3f}".format(cores), True)
+        if cores > 0.10:
             env.assertTrue('averaged' in stderr_content and 'of a core' in stderr_content)
 
 
 def test_cpu_warn_threshold_flag(env):
-    """--cpu-warn-threshold=0 must warn; =100 must stay silent."""
+    """--cpu-warn-threshold=0 must warn; a high threshold must suppress the
+    authoritative end-of-run warning."""
     env.skipOnCluster()
 
     base_args = ['--pipeline=50', '--data-size=1', '--ratio=1:1', '--key-maximum=100']
 
-    # threshold=0 -> warns on any CPU usage
+    # threshold=0 -> warns on any CPU usage (a worker always uses some CPU).
     specs0 = {"name": env.testName, "args": base_args + ['--cpu-warn-threshold=0']}
     addTLSArgs(specs0, env)
     cfg0 = get_default_memtier_config(threads=1, clients=50, requests=None, test_time=3)
@@ -154,14 +163,43 @@ def test_cpu_warn_threshold_flag(env):
     stderr0 = _read_stderr(cfg0)
     env.assertTrue('high CPU on thread' in stderr0)
 
-    # threshold=100 -> effectively silent (a single thread cannot exceed 100% of a core)
+    # threshold=100 -> the authoritative end-of-run warning (run-average cores_used)
+    # cannot fire: a single thread's average over its own lifetime never exceeds
+    # 1.0 core (100%). We assert on the end-of-run 'of a core' line specifically,
+    # not the per-second live line, because a momentary per-second sample can
+    # legitimately read slightly above 100% due to wall-window sampling jitter.
     specs100 = {"name": env.testName, "args": base_args + ['--cpu-warn-threshold=100']}
     addTLSArgs(specs100, env)
     cfg100 = get_default_memtier_config(threads=1, clients=50, requests=None, test_time=3)
     cfg100, _ = _run_and_load(env, specs100, cfg100)
     stderr100 = _read_stderr(cfg100)
-    env.assertTrue('high CPU on thread' not in stderr100)
     env.assertTrue('of a core' not in stderr100)
+
+
+def test_cpu_multi_run(env):
+    """--run-count>1 must still produce a valid aggregate CPU block."""
+    env.skipOnCluster()
+
+    benchmark_specs = {"name": env.testName, "args": [
+        '--pipeline=50', '--data-size=1', '--ratio=1:1', '--key-maximum=100',
+        '--run-count=2',
+    ]}
+    addTLSArgs(benchmark_specs, env)
+    config = get_default_memtier_config(threads=2, clients=20, requests=None, test_time=3)
+
+    config, results_dict = _run_and_load(env, benchmark_specs, config)
+
+    # Find any per-report block carrying an aggregate 'CPU' section (BEST / WORST /
+    # AGGREGATED AVERAGE). On Linux at least one must be present and plausible.
+    cpu_blocks = [v['CPU'] for v in results_dict.values()
+                  if isinstance(v, dict) and 'CPU' in v]
+    if not cpu_blocks:
+        env.debugPrint("No aggregate CPU block (non-Linux platform), skipping", True)
+        return
+    for cpu in cpu_blocks:
+        env.assertTrue(cpu['cpu_cores_used'] > 0.0)
+        env.assertTrue(cpu['cpu_cores_used'] < 4.0)
+        env.assertTrue(cpu['threads_counted'] == 2)
 
 
 def test_cpu_aggregate_cores(env):

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -12,3 +12,7 @@ git+https://github.com/fcostaoliveira/RLTest.git@fix/cluster-aware-replicas
 # on demand; pinning them here keeps the bootstrap reproducible.
 pytest>=7.0
 hypothesis>=6.0
+# psutil powers the external CPU cross-validation in tests/test_cpu_stats.py
+# (independent oracle for memtier's self-reported per-thread CPU). Skips
+# gracefully if unavailable.
+psutil>=5.9.0


### PR DESCRIPTION
## Summary

Adds **per-thread and whole-process CPU utilization tracking** for memtier_benchmark itself, so users can tell when the **load generator** (not the server under test) is the bottleneck and results are skewed. **Supersedes #346** with a more accurate, aggregate-aware, configurable design (reusing #346's live-sampler helper and Python tests).

Almost no other load generator (wrk, wrk2, redis-benchmark, k6, fortio, vegeta, bombardier, ab, JMeter, Gatling) surfaces client-side CPU; the strongest precedent is **Locust** ("CPU usage above 90%! This may constrain your throughput..."). A CPU-saturated client silently under-drives its intended rate (coordinated omission), corrupting latency/throughput numbers.

## Design

Two cooperating subsystems:

- **Authoritative totals** — `getrusage(RUSAGE_THREAD)` captured inside each worker at run start/end, accumulated across restarts. A **wall bracket** is captured at the exact same points, so `cores_used = cpu / wall` covers one identical interval (no setup-vs-serving or across-restart skew). Linux-only; guarded by `#if defined(RUSAGE_THREAD)`.
- **Live advisory sampler** — per-second `pthread_getcpuclockid` + `clock_gettime` read from the main thread (no worker perturbation; macOS uses Mach `thread_info`). Drives the de-duped live warning and per-second JSON detail.

## What users see

- **Console** "CPU Utilization Summary" (total/user/sys, wall, cores used, avg % across worker threads, peak %) on stderr so piped table output is not corrupted.
- **JSON**: a `"CPU"` aggregate block (sibling of `Runtime`) with a per-thread breakdown, plus a per-second `"CPU Stats"` block. Additive — no existing keys reordered/renamed.
- **`--cpu-warn-threshold=PCT`** (default `95`, mirrors `--miss-rate-threshold`). De-duped: one live warning per thread on first crossing + one end-of-run summary line per offending thread. No per-second spam.

`avg_cpu_utilization_pct` is worker-CPU-only, so it cannot exceed 100% from main-thread overhead. All divisions are guarded; `JSON_handler::write_obj` now emits `null` for any non-finite double.

## Platform

Verified on **glibc** and **musl/Alpine** (Docker build). Linux-only `RUSAGE_THREAD` is guarded; `_GNU_SOURCE` added for glibc. macOS keeps the live sampler (Mach); the authoritative aggregate degrades gracefully.

## Test plan

`tests/test_cpu_stats.py` (ported from #346 + extended), all passing locally via RLTest: schema, high-load de-duped warning, `--cpu-warn-threshold` behavior, aggregate/per-thread consistency, `--run-count>1`, and a psutil external cross-validation (matched within ~0.02s locally).

Developed and hardened through a multi-agent adversarial review modeled on the maintainers' real review standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large instrumentation in the benchmark monitor loop and platform-specific CPU APIs could skew timing or behave differently on non-Linux, though guards and post-join reads limit worker impact.
> 
> **Overview**
> Adds **client-side CPU observability** so users can see when memtier (not Redis) is limiting throughput. Workers record authoritative totals via `getrusage(RUSAGE_THREAD)` with matched wall brackets (accumulated across thread restarts); the main thread runs a **per-second live sampler** (Linux `pthread_getcpuclockid`, macOS Mach) for JSON time series, peak utilization, and **de-duped** stderr warnings.
> 
> New **`--cpu-warn-threshold`** (default 95%, same parsing style as `--miss-rate-threshold`) gates live and end-of-run bottleneck warnings. Results land in stderr **CPU Utilization Summary**, additive JSON **`CPU`** / **`CPU Stats`** sections, and multi-run aggregation in `aggregate_average`. **`JSON_handler`** now writes `null` for non-finite doubles so CPU metrics cannot break JSON.
> 
> Also adds **`tests/test_cpu_stats.py`** (schema, thresholds, multi-run, optional psutil cross-check), bash completion, and an **adversarial-review** Claude skill doc—not runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17eabf94044050d844565e9836a5040173654511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->