### PR TITLE
perf(miss-tracking): alloc-free per-position tracking for ArrayPerElementNulls (HMGET) [RED-200840]

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -85,30 +85,29 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
         MAIN_CONNECTION->get_protocol()->set_keep_value(true);
     }
 
-    // Enable value keeping for arbitrary-command miss tracking only when a
-    // configured command needs per-element reply inspection. Only
-    // ArrayPerElementNulls (HMGET/MGET/ZMSCORE/GEOPOS/...) requires walking the
-    // materialized reply array to attribute hits/misses per position.
-    // EmptyCollection (HGETALL/SMEMBERS/LRANGE) only needs to know whether the
-    // top-level array is empty, which it reads from the parser's running hit
-    // counter (response->get_hits()) with zero materialization -- keeping
-    // values there would malloc+memcpy every element of every reply on the hot
-    // path for no benefit. SingleNullBulk and IntegerMembership use the
-    // parser's scalar counters / status line, so no materialization either.
+    // Enable per-element miss tracking only when a configured command needs
+    // per-position reply inspection. Only ArrayPerElementNulls
+    // (HMGET/MGET/ZMSCORE/GEOPOS/...) attributes hits/misses per position; the
+    // parser records a per-top-level-element hit bitmap directly
+    // (set_track_elem_misses), with zero reply materialization -- no malloc /
+    // memcpy of element values, no mbulk tree. EmptyCollection
+    // (HGETALL/SMEMBERS/LRANGE) only needs the top-level array length
+    // (response->get_top_array_len()); SingleNullBulk and IntegerMembership use
+    // the parser's scalar counters / status line. None of them keep values.
     if (config->arbitrary_commands->is_defined()) {
-        bool needs_array_walk = false;
+        bool needs_elem_tracking = false;
         for (size_t i = 0; i < config->arbitrary_commands->size(); ++i) {
             const arbitrary_command &cmd = config->arbitrary_commands->at(i);
             if (!cmd.miss_tracking_enabled || cmd.spec == NULL) continue;
             using memtier::command_meta::ReplyShape;
             if (cmd.spec->reply_shape == ReplyShape::ArrayPerElementNulls) {
-                needs_array_walk = true;
+                needs_elem_tracking = true;
                 break;
             }
         }
-        if (needs_array_walk) {
+        if (needs_elem_tracking) {
             for (size_t i = 0; i < m_connections.size(); ++i) {
-                m_connections[i]->get_protocol()->set_keep_value(true);
+                m_connections[i]->get_protocol()->set_track_elem_misses(true);
             }
         }
     }
@@ -828,77 +827,38 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp, req
                 break;
             }
             case ReplyShape::ArrayPerElementNulls: {
-                // Walk the top-level mbulk array. Bucket count is the reply
-                // element count, not the spec key count: HMGET / ZMSCORE
+                // The parser recorded a per-top-level-element hit/miss bitmap at
+                // parse time (set_track_elem_misses) with no materialization --
+                // no value malloc/memcpy, no mbulk tree. Bucket count is the
+                // reply element count, not the spec key count: HMGET / ZMSCORE
                 // have 1 Redis key but produce one reply element per
-                // field/member, so capping to num_keys (==1) would lose all
-                // but the first position. MGET (multi-key spec) naturally
-                // matches reply size 1:1.
-                mbulk_size_el *top = response->get_mbulk_value();
-                if (top != NULL) {
-                    size_t n = top->mbulks_elements.size();
-                    per_key_hit.assign(n, false);
-                    num_keys = (unsigned int) n;
-                    for (size_t i = 0; i < n; ++i) {
-                        mbulk_element *el = top->mbulks_elements[i];
-                        bool h = false;
-                        if (el != NULL) {
-                            // ArrayPerElementNulls covers two reply shapes:
-                            //   - array of (bulk | null bulk): MGET, HMGET,
-                            //     ZMSCORE. Null bulk ($-1) materializes as a
-                            //     bulk_el with value==NULL/value_len==0.
-                            //   - array of (nested-array | null array):
-                            //     GEOPOS, COMMAND INFO, SORT_RO. Null array
-                            //     (*-1) materializes as an mbulk_size_el with
-                            //     no children (indistinguishable from *0,
-                            //     which is also "no value here" in practice).
-                            // is_bulk()/is_mbulk_size() avoid the assert that
-                            // as_bulk()/as_mbulk_size() raise on the wrong
-                            // kind.
-                            if (el->is_bulk()) {
-                                bulk_el *bel = el->as_bulk();
-                                // Hit = the bulk slot carries a value. Use
-                                // value!=NULL (the parser zero-allocates the
-                                // pointer only for $-1 null bulks) so that
-                                // empty-string values ($0\r\n\r\n) count as
-                                // hits when the parser is later extended to
-                                // preserve them. Today the redis_protocol
-                                // parser collapses $0 and $-1 into the same
-                                // representation (value=NULL, value_len=0),
-                                // matching the existing GET path's m_hits
-                                // convention; the value-pointer check is the
-                                // semantically correct one and is forward-
-                                // compatible with a parser that distinguishes.
-                                //
-                                // RESP3 nil "_\r\n" goes through single_type
-                                // and is stored as a bulk_el with is_resp3_null
-                                // set to true. Using the flag (set at parse time)
-                                // avoids false positives from a legitimate bulk
-                                // string whose content happens to be the single
-                                // character '_' (parsed via blob_type, which
-                                // never sets is_resp3_null). Treat it as a miss.
-                                if (bel != NULL && bel->value != NULL && !bel->is_resp3_null) {
-                                    h = true;
-                                }
-                            } else if (el->is_mbulk_size()) {
-                                mbulk_size_el *sub = el->as_mbulk_size();
-                                if (sub != NULL && !sub->mbulks_elements.empty()) {
-                                    h = true;
-                                }
-                            }
-                        }
-                        per_key_hit[i] = h;
-                        if (h) hits++;
-                    }
-                    misses = (num_keys > hits) ? (num_keys - hits) : 0;
-                } else {
-                    // Top-level reply isn't an mbulk (could be +OK, -ERR, a
-                    // single bulk for a misshape, or any non-array reply).
-                    // Account uniformly: a single miss bucket so per-key and
-                    // aggregate counters stay in sync.
+                // field/member; MGET (multi-key spec) matches reply size 1:1.
+                //
+                // The bitmap reproduces the old materialized walk's semantics:
+                //   - bulk leaf: hit iff $N with N>0 (null $-1 and empty $0 are
+                //     misses); RESP3 null '_' is a miss; other single types are
+                //     hits (see track_leaf in protocol.cpp).
+                //   - nested sub-array element (GEOPOS/SORT_RO/...): hit iff the
+                //     sub-array is non-empty (*0 / *-1 are misses).
+                if (response->get_top_array_len() < 0) {
+                    // Top-level reply isn't an array (+OK, -ERR, a single bulk,
+                    // or any non-array misshape). One miss bucket, matching the
+                    // previous get_mbulk_value()==NULL guard.
                     per_key_hit.assign(1, false);
                     num_keys = 1;
                     misses = 1;
+                } else {
+                    const std::vector<uint8_t> &eh = response->get_elem_hits();
+                    size_t n = eh.size();
+                    per_key_hit.assign(n, false);
+                    num_keys = (unsigned int) n;
+                    for (size_t i = 0; i < n; ++i) {
+                        if (eh[i]) {
+                            per_key_hit[i] = true;
+                            hits++;
+                        }
+                    }
+                    misses = (num_keys > hits) ? (num_keys - hits) : 0;
                 }
                 break;
             }

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -33,7 +33,10 @@
 
 /////////////////////////////////////////////////////////////////////////
 
-abstract_protocol::abstract_protocol() : m_read_buf(NULL), m_write_buf(NULL), m_keep_value(false) {}
+abstract_protocol::abstract_protocol() :
+        m_read_buf(NULL), m_write_buf(NULL), m_keep_value(false), m_track_elem_misses(false)
+{
+}
 
 abstract_protocol::~abstract_protocol() {}
 
@@ -46,6 +49,11 @@ void abstract_protocol::set_buffers(struct evbuffer *read_buf, struct evbuffer *
 void abstract_protocol::set_keep_value(bool flag)
 {
     m_keep_value = flag;
+}
+
+void abstract_protocol::set_track_elem_misses(bool flag)
+{
+    m_track_elem_misses = flag;
 }
 
 void abstract_protocol::reset_state()
@@ -141,6 +149,21 @@ int protocol_response::get_top_array_len(void)
     return m_top_array_len;
 }
 
+void protocol_response::elem_hits_reserve(size_t n)
+{
+    m_elem_hits.reserve(n);
+}
+
+void protocol_response::elem_hit_push(bool hit)
+{
+    m_elem_hits.push_back(hit ? 1 : 0);
+}
+
+const std::vector<uint8_t> &protocol_response::get_elem_hits(void)
+{
+    return m_elem_hits;
+}
+
 void protocol_response::clear(void)
 {
     if (m_status != NULL) {
@@ -161,6 +184,7 @@ void protocol_response::clear(void)
     m_hits = 0;
     m_error = 0;
     m_top_array_len = -1;
+    m_elem_hits.clear();
 }
 
 void protocol_response::set_mbulk_value(mbulk_size_el *element)
@@ -202,11 +226,32 @@ protected:
     // TODO: full out-of-band routing — surface push frames to a
     // listener instead of silently dropping them.
     bool m_push;
+    // Per-response state for alloc-free ArrayPerElementNulls miss tracking
+    // (m_track_elem_misses). m_tracking turns true once the reply's top-level
+    // array header is seen. m_nested_remaining counts leaf/element slots still
+    // to consume inside the current top-level element's subtree: while >0 we
+    // are below the top level and skip recording; when it returns to 0 the next
+    // element is again a direct child of the top array. This handles arbitrary
+    // nesting depth without a frame stack.
+    bool m_tracking;
+    int m_nested_remaining;
 
     bool aggregate_type(char c);
     bool blob_type(char c);
     bool single_type(char c);
     bool response_ended();
+    // Record one leaf element (bulk / single type) for alloc-free miss
+    // tracking: pushes a hit/miss flag when the leaf is a direct child of the
+    // top-level array, otherwise just consumes a slot of the current nested
+    // subtree. No-op unless tracking is active for this reply.
+    inline void track_leaf(bool hit)
+    {
+        if (!m_track_elem_misses || m_push || !m_tracking) return;
+        if (m_nested_remaining == 0)
+            m_last_response.elem_hit_push(hit);
+        else
+            m_nested_remaining--;
+    }
 
 public:
     redis_protocol() :
@@ -217,7 +262,9 @@ public:
             m_current_mbulk(NULL),
             m_resp3(false),
             m_attribute(false),
-            m_push(false)
+            m_push(false),
+            m_tracking(false),
+            m_nested_remaining(0)
     {
     }
     virtual redis_protocol *clone(void) { return new redis_protocol(); }
@@ -266,6 +313,8 @@ void redis_protocol::reset_state()
     m_bulk_len = 0;
     m_response_len = 0;
     m_current_mbulk = NULL;
+    m_tracking = false;
+    m_nested_remaining = 0;
 }
 
 int redis_protocol::select_db(int db)
@@ -619,6 +668,8 @@ int redis_protocol::parse_response(void)
             m_total_bulks_count = 0;
             m_attribute = 0;
             m_push = 0;
+            m_tracking = false;
+            m_nested_remaining = 0;
             m_response_state = rs_read_line;
 
             break;
@@ -681,6 +732,25 @@ int redis_protocol::parse_response(void)
                     m_last_response.set_top_array_len(count);
                 }
 
+                // Alloc-free per-element miss tracking (m_track_elem_misses).
+                // The top-level array container starts tracking; a nested
+                // aggregate is itself an element -- a hit iff it is non-empty
+                // (count>0). See the m_tracking/m_nested_remaining contract.
+                if (m_track_elem_misses && !m_push && line[0] != '|') {
+                    if (top_level_aggregate) {
+                        m_tracking = true;
+                        m_nested_remaining = 0;
+                        m_last_response.elem_hits_reserve(count);
+                    } else if (m_tracking) {
+                        if (m_nested_remaining == 0) {
+                            m_last_response.elem_hit_push(count > 0);
+                            m_nested_remaining = count; // descend into this element's subtree
+                        } else {
+                            m_nested_remaining += count - 1; // consume this slot, add its children
+                        }
+                    }
+                }
+
                 // Suppress mbulk allocation while draining a push frame:
                 // the contents are out-of-band and must not be delivered
                 // as the reply to any in-flight command.
@@ -719,6 +789,10 @@ int redis_protocol::parse_response(void)
                 }
 
                 m_bulk_len = strtol(line + 1, NULL, 10);
+                // A bulk leaf is a hit iff it carries a value ($N, N>0). A null
+                // bulk ($-1) and an empty bulk ($0) are misses -- matching the
+                // pre-existing value!=NULL convention of the materialized walk.
+                track_leaf(m_bulk_len > 0);
                 // Suppress reply mutation while draining a push frame.
                 if (!m_push) {
                     m_last_response.set_status(line);
@@ -742,6 +816,12 @@ int redis_protocol::parse_response(void)
                 if (m_total_bulks_count == 0) {
                     m_total_bulks_count++;
                 }
+
+                // A single-type leaf carries a value (+status, :int, ,double,
+                // #bool, (bignum, -error) and counts as a hit; only the RESP3
+                // null '_' is a miss. Mirrors the materialized walk, which kept
+                // a value for every single type except '_' (is_resp3_null).
+                track_leaf(line[0] != '_');
 
                 // if we are not inside mbulk, the status will be kept in m_status anyway
                 if (m_keep_value && m_current_mbulk && !m_push) {

--- a/protocol.h
+++ b/protocol.h
@@ -21,6 +21,7 @@
 
 #include <event2/buffer.h>
 #include <vector>
+#include <cstdint>
 #include "memtier_benchmark.h"
 
 enum mbulk_element_type
@@ -153,6 +154,15 @@ protected:
     // without materializing element values via set_keep_value(). A null array
     // ($-1/*-1) and an empty array (*0) both record 0.
     int m_top_array_len;
+    // Per-element hit/miss flags for the reply's top-level array, recorded at
+    // parse time when miss tracking is enabled (set_track_elem_misses). 1=hit
+    // (non-null element), 0=miss (null bulk, RESP3 null, or empty sub-array).
+    // This is the alloc-free alternative to materializing the reply tree via
+    // set_keep_value() purely to attribute per-position misses for the
+    // ArrayPerElementNulls shape (HMGET/MGET/ZMSCORE/GEOPOS/...). Only top-level
+    // elements are recorded; children of nested sub-arrays are skipped (a
+    // nested element is a hit iff its sub-array is non-empty).
+    std::vector<uint8_t> m_elem_hits;
 
 public:
     protocol_response();
@@ -175,6 +185,10 @@ public:
 
     void set_top_array_len(int len);
     int get_top_array_len(void);
+
+    void elem_hits_reserve(size_t n);
+    void elem_hit_push(bool hit);
+    const std::vector<uint8_t> &get_elem_hits(void);
 
     void clear();
 
@@ -217,6 +231,12 @@ protected:
     struct evbuffer *m_write_buf;
 
     bool m_keep_value;
+    // When set, the parser records per-top-level-element hit/miss flags into
+    // m_last_response.m_elem_hits without materializing the reply tree. Used by
+    // the ArrayPerElementNulls miss-tracking path as an alloc-free replacement
+    // for set_keep_value(). Independent of m_keep_value (both may be on if a
+    // SCAN-style command shares the connection).
+    bool m_track_elem_misses;
     struct protocol_response m_last_response;
 
 public:
@@ -225,6 +245,7 @@ public:
     virtual abstract_protocol *clone(void) = 0;
     void set_buffers(struct evbuffer *read_buf, struct evbuffer *write_buf);
     void set_keep_value(bool flag);
+    void set_track_elem_misses(bool flag);
 
     // Drop any partial-parse state that would otherwise survive a
     // bufferevent_free/reconnect cycle. The bufferevent input/output


### PR DESCRIPTION
## Summary

Follow-up to #469 (now merged). Fixes the **HMGET half** of the RED-200840 regression. (Supersedes #470, which GitHub auto-closed when #469's branch was deleted; rebased onto master so the diff is now HMGET-only.)

`ArrayPerElementNulls` replies (HMGET / MGET / ZMSCORE / GEOPOS / ...) forced `set_keep_value(true)`, materializing the whole reply tree — a `malloc`+`memcpy` per element **plus an `mbulk`/`bulk_el` node per element** — purely to attribute hits/misses per position. For small values the per-element **node allocation** dominates, so #469 (EmptyCollection/HGETALL only) left HMGET regressed.

This replaces the materialized walk with a **per-top-level-element hit bitmap** recorded directly by the parser (`set_track_elem_misses`): one `uint8_t` per element into `protocol_response::m_elem_hits` — no value copy, no node tree. Hit/miss is known at parse time:
- bulk leaf → hit iff `$N`, N>0 (null `$-1` and empty `$0` are misses);
- single-type leaf → hit unless RESP3 null `_`;
- nested sub-array element → hit iff non-empty (`*0`/`*-1` are misses).

Nesting uses a single counter (`m_nested_remaining`) tracking outstanding leaf slots in the current top-level element's subtree, so only direct children of the top array are recorded — no frame stack, any depth.

## Lab results (Granite Rapids, single-core client, pipeline=64, 40-field hashes, N=5 interleaved)

| | 2.2.1 | 2.4.1 | #469 | **this PR** |
|---|---|---|---|---|
| HMGET ops/sec | 341,542 | 215,741 (−37%) | 214,412 (−37%) | **335,293 (−1.8%)** |
| HMGET CPU µs/op | 2.58 | 4.64 (+80%) | 4.67 (+81%) | **2.92 (+13%)** |
| HGETALL ops/sec | 136,020 | 71,602 (−47%) | 132,986 (−2%) | 132,313 (−3%) |

## Correctness

Verified deterministically (`--key-maximum=1`, fixed keys) that per-position hit/miss is **identical** to the old materialized walk for **HMGET** (mixed present/absent fields), **MGET** (multi-key spec), and nested **GEOPOS** — under both **RESP2 and RESP3** (`_` null path). The existing `tests/test_arbitrary_command_misses.py` suite covers these shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RESP parsing and miss-accounting on the benchmark hot path; behavior is intended to match the prior walk but nested-array and RESP3 edge cases are subtle.
> 
> **Overview**
> **ArrayPerElementNulls** miss tracking (HMGET, MGET, ZMSCORE, GEOPOS, …) no longer turns on **`set_keep_value(true)`** to build a full reply tree. Clients that need per-position misses now enable **`set_track_elem_misses(true)`**, and the Redis parser records one **`uint8_t` per top-level reply element** in **`protocol_response::m_elem_hits`** while streaming the RESP frame.
> 
> **`client::handle_response`** for **`ReplyShape::ArrayPerElementNulls`** aggregates hits/misses from **`get_elem_hits()`** (and **`get_top_array_len()`** for non-array replies) instead of walking **`get_mbulk_value()`**. Semantics match the old materialized walk: bulk hits when length &gt; 0, RESP3 **`_`** is a miss, nested sub-arrays count as a hit when non-empty.
> 
> Nested replies use **`m_nested_remaining`** in **`redis_protocol`** so only direct children of the top array are recorded, without allocating mbulk/bulk nodes on the hot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20298d76d8afb30810123407bc0ab90cbf2885d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->