### PR TITLE
[CP 2.4] perf(miss-tracking): restore HGETALL/HMGET throughput regressed by arbitrary-command miss-tracking [RED-200840]

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -85,18 +85,23 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
         MAIN_CONNECTION->get_protocol()->set_keep_value(true);
     }
 
-    // Enable value keeping for arbitrary-command miss tracking when any
-    // configured command needs reply-array inspection (ArrayPerElementNulls or
-    // EmptyCollection). SingleNullBulk and IntegerMembership use the parser's
-    // existing scalar counters so no materialization is required for them.
+    // Enable value keeping for arbitrary-command miss tracking only when a
+    // configured command needs per-element reply inspection. Only
+    // ArrayPerElementNulls (HMGET/MGET/ZMSCORE/GEOPOS/...) requires walking the
+    // materialized reply array to attribute hits/misses per position.
+    // EmptyCollection (HGETALL/SMEMBERS/LRANGE) only needs to know whether the
+    // top-level array is empty, which it reads from the parser's running hit
+    // counter (response->get_hits()) with zero materialization -- keeping
+    // values there would malloc+memcpy every element of every reply on the hot
+    // path for no benefit. SingleNullBulk and IntegerMembership use the
+    // parser's scalar counters / status line, so no materialization either.
     if (config->arbitrary_commands->is_defined()) {
         bool needs_array_walk = false;
         for (size_t i = 0; i < config->arbitrary_commands->size(); ++i) {
             const arbitrary_command &cmd = config->arbitrary_commands->at(i);
             if (!cmd.miss_tracking_enabled || cmd.spec == NULL) continue;
             using memtier::command_meta::ReplyShape;
-            if (cmd.spec->reply_shape == ReplyShape::ArrayPerElementNulls ||
-                cmd.spec->reply_shape == ReplyShape::EmptyCollection) {
+            if (cmd.spec->reply_shape == ReplyShape::ArrayPerElementNulls) {
                 needs_array_walk = true;
                 break;
             }
@@ -892,8 +897,24 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp, req
                 // Heuristic: empty array == missing key. EmptyCollection
                 // commands (SMEMBERS, LRANGE, HGETALL, ...) virtually always
                 // carry exactly 1 key.
-                mbulk_size_el *top = response->get_mbulk_value();
-                bool empty = (top == NULL || top->mbulks_elements.empty());
+                //
+                // We only need the top-level element count, not the element
+                // values, so we avoid set_keep_value() materialization (see the
+                // keep_value gate in setup_client) and read the declared
+                // aggregate length the parser captured from the reply header.
+                // get_top_array_len() is:
+                //   >0  for a populated array/map/set  -> hit (regardless of
+                //       whether the elements are zero-length: the count comes
+                //       from the *N/%N/~N header, not a per-value walk),
+                //    0  for an empty (*0) or null (*-1) collection -> miss,
+                //   -1  when the reply was not a top-level aggregate at all
+                //       (a scalar/bulk misshape) -> miss, matching the previous
+                //       get_mbulk_value()==NULL guard.
+                // This reproduces the old structural check exactly while
+                // staying alloc-free, and is independent of keep_value (it is
+                // captured whether or not an ArrayPerElementNulls command on
+                // the same connection forced materialization on).
+                bool empty = (response->get_top_array_len() <= 0);
                 per_key_hit.assign(num_keys, !empty);
                 hits = empty ? 0 : num_keys;
                 misses = empty ? num_keys : 0;

--- a/client.cpp
+++ b/client.cpp
@@ -85,30 +85,29 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
         MAIN_CONNECTION->get_protocol()->set_keep_value(true);
     }
 
-    // Enable value keeping for arbitrary-command miss tracking only when a
-    // configured command needs per-element reply inspection. Only
-    // ArrayPerElementNulls (HMGET/MGET/ZMSCORE/GEOPOS/...) requires walking the
-    // materialized reply array to attribute hits/misses per position.
-    // EmptyCollection (HGETALL/SMEMBERS/LRANGE) only needs to know whether the
-    // top-level array is empty, which it reads from the parser's running hit
-    // counter (response->get_hits()) with zero materialization -- keeping
-    // values there would malloc+memcpy every element of every reply on the hot
-    // path for no benefit. SingleNullBulk and IntegerMembership use the
-    // parser's scalar counters / status line, so no materialization either.
+    // Enable per-element miss tracking only when a configured command needs
+    // per-position reply inspection. Only ArrayPerElementNulls
+    // (HMGET/MGET/ZMSCORE/GEOPOS/...) attributes hits/misses per position; the
+    // parser records a per-top-level-element hit bitmap directly
+    // (set_track_elem_misses), with zero reply materialization -- no malloc /
+    // memcpy of element values, no mbulk tree. EmptyCollection
+    // (HGETALL/SMEMBERS/LRANGE) only needs the top-level array length
+    // (response->get_top_array_len()); SingleNullBulk and IntegerMembership use
+    // the parser's scalar counters / status line. None of them keep values.
     if (config->arbitrary_commands->is_defined()) {
-        bool needs_array_walk = false;
+        bool needs_elem_tracking = false;
         for (size_t i = 0; i < config->arbitrary_commands->size(); ++i) {
             const arbitrary_command &cmd = config->arbitrary_commands->at(i);
             if (!cmd.miss_tracking_enabled || cmd.spec == NULL) continue;
             using memtier::command_meta::ReplyShape;
             if (cmd.spec->reply_shape == ReplyShape::ArrayPerElementNulls) {
-                needs_array_walk = true;
+                needs_elem_tracking = true;
                 break;
             }
         }
-        if (needs_array_walk) {
+        if (needs_elem_tracking) {
             for (size_t i = 0; i < m_connections.size(); ++i) {
-                m_connections[i]->get_protocol()->set_keep_value(true);
+                m_connections[i]->get_protocol()->set_track_elem_misses(true);
             }
         }
     }
@@ -819,77 +818,38 @@ void client::handle_response(unsigned int conn_id, struct timeval timestamp, req
                 break;
             }
             case ReplyShape::ArrayPerElementNulls: {
-                // Walk the top-level mbulk array. Bucket count is the reply
-                // element count, not the spec key count: HMGET / ZMSCORE
+                // The parser recorded a per-top-level-element hit/miss bitmap at
+                // parse time (set_track_elem_misses) with no materialization --
+                // no value malloc/memcpy, no mbulk tree. Bucket count is the
+                // reply element count, not the spec key count: HMGET / ZMSCORE
                 // have 1 Redis key but produce one reply element per
-                // field/member, so capping to num_keys (==1) would lose all
-                // but the first position. MGET (multi-key spec) naturally
-                // matches reply size 1:1.
-                mbulk_size_el *top = response->get_mbulk_value();
-                if (top != NULL) {
-                    size_t n = top->mbulks_elements.size();
-                    per_key_hit.assign(n, false);
-                    num_keys = (unsigned int) n;
-                    for (size_t i = 0; i < n; ++i) {
-                        mbulk_element *el = top->mbulks_elements[i];
-                        bool h = false;
-                        if (el != NULL) {
-                            // ArrayPerElementNulls covers two reply shapes:
-                            //   - array of (bulk | null bulk): MGET, HMGET,
-                            //     ZMSCORE. Null bulk ($-1) materializes as a
-                            //     bulk_el with value==NULL/value_len==0.
-                            //   - array of (nested-array | null array):
-                            //     GEOPOS, COMMAND INFO, SORT_RO. Null array
-                            //     (*-1) materializes as an mbulk_size_el with
-                            //     no children (indistinguishable from *0,
-                            //     which is also "no value here" in practice).
-                            // is_bulk()/is_mbulk_size() avoid the assert that
-                            // as_bulk()/as_mbulk_size() raise on the wrong
-                            // kind.
-                            if (el->is_bulk()) {
-                                bulk_el *bel = el->as_bulk();
-                                // Hit = the bulk slot carries a value. Use
-                                // value!=NULL (the parser zero-allocates the
-                                // pointer only for $-1 null bulks) so that
-                                // empty-string values ($0\r\n\r\n) count as
-                                // hits when the parser is later extended to
-                                // preserve them. Today the redis_protocol
-                                // parser collapses $0 and $-1 into the same
-                                // representation (value=NULL, value_len=0),
-                                // matching the existing GET path's m_hits
-                                // convention; the value-pointer check is the
-                                // semantically correct one and is forward-
-                                // compatible with a parser that distinguishes.
-                                //
-                                // RESP3 nil "_\r\n" goes through single_type
-                                // and is stored as a bulk_el with is_resp3_null
-                                // set to true. Using the flag (set at parse time)
-                                // avoids false positives from a legitimate bulk
-                                // string whose content happens to be the single
-                                // character '_' (parsed via blob_type, which
-                                // never sets is_resp3_null). Treat it as a miss.
-                                if (bel != NULL && bel->value != NULL && !bel->is_resp3_null) {
-                                    h = true;
-                                }
-                            } else if (el->is_mbulk_size()) {
-                                mbulk_size_el *sub = el->as_mbulk_size();
-                                if (sub != NULL && !sub->mbulks_elements.empty()) {
-                                    h = true;
-                                }
-                            }
-                        }
-                        per_key_hit[i] = h;
-                        if (h) hits++;
-                    }
-                    misses = (num_keys > hits) ? (num_keys - hits) : 0;
-                } else {
-                    // Top-level reply isn't an mbulk (could be +OK, -ERR, a
-                    // single bulk for a misshape, or any non-array reply).
-                    // Account uniformly: a single miss bucket so per-key and
-                    // aggregate counters stay in sync.
+                // field/member; MGET (multi-key spec) matches reply size 1:1.
+                //
+                // The bitmap reproduces the old materialized walk's semantics:
+                //   - bulk leaf: hit iff $N with N>0 (null $-1 and empty $0 are
+                //     misses); RESP3 null '_' is a miss; other single types are
+                //     hits (see track_leaf in protocol.cpp).
+                //   - nested sub-array element (GEOPOS/SORT_RO/...): hit iff the
+                //     sub-array is non-empty (*0 / *-1 are misses).
+                if (response->get_top_array_len() < 0) {
+                    // Top-level reply isn't an array (+OK, -ERR, a single bulk,
+                    // or any non-array misshape). One miss bucket, matching the
+                    // previous get_mbulk_value()==NULL guard.
                     per_key_hit.assign(1, false);
                     num_keys = 1;
                     misses = 1;
+                } else {
+                    const std::vector<uint8_t> &eh = response->get_elem_hits();
+                    size_t n = eh.size();
+                    per_key_hit.assign(n, false);
+                    num_keys = (unsigned int) n;
+                    for (size_t i = 0; i < n; ++i) {
+                        if (eh[i]) {
+                            per_key_hit[i] = true;
+                            hits++;
+                        }
+                    }
+                    misses = (num_keys > hits) ? (num_keys - hits) : 0;
                 }
                 break;
             }

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -33,7 +33,10 @@
 
 /////////////////////////////////////////////////////////////////////////
 
-abstract_protocol::abstract_protocol() : m_read_buf(NULL), m_write_buf(NULL), m_keep_value(false) {}
+abstract_protocol::abstract_protocol() :
+        m_read_buf(NULL), m_write_buf(NULL), m_keep_value(false), m_track_elem_misses(false)
+{
+}
 
 abstract_protocol::~abstract_protocol() {}
 
@@ -46,6 +49,11 @@ void abstract_protocol::set_buffers(struct evbuffer *read_buf, struct evbuffer *
 void abstract_protocol::set_keep_value(bool flag)
 {
     m_keep_value = flag;
+}
+
+void abstract_protocol::set_track_elem_misses(bool flag)
+{
+    m_track_elem_misses = flag;
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -132,6 +140,21 @@ int protocol_response::get_top_array_len(void)
     return m_top_array_len;
 }
 
+void protocol_response::elem_hits_reserve(size_t n)
+{
+    m_elem_hits.reserve(n);
+}
+
+void protocol_response::elem_hit_push(bool hit)
+{
+    m_elem_hits.push_back(hit ? 1 : 0);
+}
+
+const std::vector<uint8_t> &protocol_response::get_elem_hits(void)
+{
+    return m_elem_hits;
+}
+
 void protocol_response::clear(void)
 {
     if (m_status != NULL) {
@@ -152,6 +175,7 @@ void protocol_response::clear(void)
     m_hits = 0;
     m_error = 0;
     m_top_array_len = -1;
+    m_elem_hits.clear();
 }
 
 void protocol_response::set_mbulk_value(mbulk_size_el *element)
@@ -193,11 +217,32 @@ protected:
     // TODO: full out-of-band routing — surface push frames to a
     // listener instead of silently dropping them.
     bool m_push;
+    // Per-response state for alloc-free ArrayPerElementNulls miss tracking
+    // (m_track_elem_misses). m_tracking turns true once the reply's top-level
+    // array header is seen. m_nested_remaining counts leaf/element slots still
+    // to consume inside the current top-level element's subtree: while >0 we
+    // are below the top level and skip recording; when it returns to 0 the next
+    // element is again a direct child of the top array. This handles arbitrary
+    // nesting depth without a frame stack.
+    bool m_tracking;
+    int m_nested_remaining;
 
     bool aggregate_type(char c);
     bool blob_type(char c);
     bool single_type(char c);
     bool response_ended();
+    // Record one leaf element (bulk / single type) for alloc-free miss
+    // tracking: pushes a hit/miss flag when the leaf is a direct child of the
+    // top-level array, otherwise just consumes a slot of the current nested
+    // subtree. No-op unless tracking is active for this reply.
+    inline void track_leaf(bool hit)
+    {
+        if (!m_track_elem_misses || m_push || !m_tracking) return;
+        if (m_nested_remaining == 0)
+            m_last_response.elem_hit_push(hit);
+        else
+            m_nested_remaining--;
+    }
 
 public:
     redis_protocol() :
@@ -208,7 +253,9 @@ public:
             m_current_mbulk(NULL),
             m_resp3(false),
             m_attribute(false),
-            m_push(false)
+            m_push(false),
+            m_tracking(false),
+            m_nested_remaining(0)
     {
     }
     virtual redis_protocol *clone(void) { return new redis_protocol(); }
@@ -567,6 +614,8 @@ int redis_protocol::parse_response(void)
             m_total_bulks_count = 0;
             m_attribute = 0;
             m_push = 0;
+            m_tracking = false;
+            m_nested_remaining = 0;
             m_response_state = rs_read_line;
 
             break;
@@ -629,6 +678,25 @@ int redis_protocol::parse_response(void)
                     m_last_response.set_top_array_len(count);
                 }
 
+                // Alloc-free per-element miss tracking (m_track_elem_misses).
+                // The top-level array container starts tracking; a nested
+                // aggregate is itself an element -- a hit iff it is non-empty
+                // (count>0). See the m_tracking/m_nested_remaining contract.
+                if (m_track_elem_misses && !m_push && line[0] != '|') {
+                    if (top_level_aggregate) {
+                        m_tracking = true;
+                        m_nested_remaining = 0;
+                        m_last_response.elem_hits_reserve(count);
+                    } else if (m_tracking) {
+                        if (m_nested_remaining == 0) {
+                            m_last_response.elem_hit_push(count > 0);
+                            m_nested_remaining = count; // descend into this element's subtree
+                        } else {
+                            m_nested_remaining += count - 1; // consume this slot, add its children
+                        }
+                    }
+                }
+
                 // Suppress mbulk allocation while draining a push frame:
                 // the contents are out-of-band and must not be delivered
                 // as the reply to any in-flight command.
@@ -667,6 +735,10 @@ int redis_protocol::parse_response(void)
                 }
 
                 m_bulk_len = strtol(line + 1, NULL, 10);
+                // A bulk leaf is a hit iff it carries a value ($N, N>0). A null
+                // bulk ($-1) and an empty bulk ($0) are misses -- matching the
+                // pre-existing value!=NULL convention of the materialized walk.
+                track_leaf(m_bulk_len > 0);
                 // Suppress reply mutation while draining a push frame.
                 if (!m_push) {
                     m_last_response.set_status(line);
@@ -690,6 +762,12 @@ int redis_protocol::parse_response(void)
                 if (m_total_bulks_count == 0) {
                     m_total_bulks_count++;
                 }
+
+                // A single-type leaf carries a value (+status, :int, ,double,
+                // #bool, (bignum, -error) and counts as a hit; only the RESP3
+                // null '_' is a miss. Mirrors the materialized walk, which kept
+                // a value for every single type except '_' (is_resp3_null).
+                track_leaf(line[0] != '_');
 
                 // if we are not inside mbulk, the status will be kept in m_status anyway
                 if (m_keep_value && m_current_mbulk && !m_push) {

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -51,7 +51,13 @@ void abstract_protocol::set_keep_value(bool flag)
 /////////////////////////////////////////////////////////////////////////
 
 protocol_response::protocol_response() :
-        m_status(NULL), m_mbulk_value(NULL), m_value(NULL), m_value_len(0), m_hits(0), m_error(false)
+        m_status(NULL),
+        m_mbulk_value(NULL),
+        m_value(NULL),
+        m_value_len(0),
+        m_hits(0),
+        m_error(false),
+        m_top_array_len(-1)
 {
 }
 
@@ -116,6 +122,16 @@ unsigned int protocol_response::get_hits(void)
     return m_hits;
 }
 
+void protocol_response::set_top_array_len(int len)
+{
+    m_top_array_len = len;
+}
+
+int protocol_response::get_top_array_len(void)
+{
+    return m_top_array_len;
+}
+
 void protocol_response::clear(void)
 {
     if (m_status != NULL) {
@@ -135,6 +151,7 @@ void protocol_response::clear(void)
     m_total_len = 0;
     m_hits = 0;
     m_error = 0;
+    m_top_array_len = -1;
 }
 
 void protocol_response::set_mbulk_value(mbulk_size_el *element)
@@ -567,6 +584,15 @@ int redis_protocol::parse_response(void)
             if (aggregate_type(line[0])) {
                 int count = strtol(line + 1, NULL, 10);
 
+                // The reply's top-level aggregate is the one parsed while no
+                // bulks are still outstanding. Capture its declared length so
+                // miss-tracking can tell an empty collection from a populated
+                // one without materializing values (see EmptyCollection in
+                // client::handle_response). Out-of-band frames are excluded:
+                // attribute (|) is a prefix to the real reply, push (>) is not
+                // a reply at all.
+                bool top_level_aggregate = (m_total_bulks_count == 0);
+
                 // in case of nested mbulk, the mbulk is one of the total bulks
                 if (m_total_bulks_count > 0) {
                     m_total_bulks_count--;
@@ -594,6 +620,13 @@ int redis_protocol::parse_response(void)
                 // Map or Attribute contain key-value pair
                 if (line[0] == '%' || line[0] == '|') {
                     count *= 2;
+                }
+
+                // Record the reply body's declared element count (count is now
+                // null-clamped to >=0 and map-doubled). '|' is the attribute
+                // prefix, not the reply body; '>' (m_push) is out-of-band.
+                if (top_level_aggregate && !m_push && line[0] != '|') {
+                    m_last_response.set_top_array_len(count);
                 }
 
                 // Suppress mbulk allocation while draining a push frame:

--- a/protocol.h
+++ b/protocol.h
@@ -21,6 +21,7 @@
 
 #include <event2/buffer.h>
 #include <vector>
+#include <cstdint>
 #include "memtier_benchmark.h"
 
 enum mbulk_element_type
@@ -153,6 +154,15 @@ protected:
     // without materializing element values via set_keep_value(). A null array
     // ($-1/*-1) and an empty array (*0) both record 0.
     int m_top_array_len;
+    // Per-element hit/miss flags for the reply's top-level array, recorded at
+    // parse time when miss tracking is enabled (set_track_elem_misses). 1=hit
+    // (non-null element), 0=miss (null bulk, RESP3 null, or empty sub-array).
+    // This is the alloc-free alternative to materializing the reply tree via
+    // set_keep_value() purely to attribute per-position misses for the
+    // ArrayPerElementNulls shape (HMGET/MGET/ZMSCORE/GEOPOS/...). Only top-level
+    // elements are recorded; children of nested sub-arrays are skipped (a
+    // nested element is a hit iff its sub-array is non-empty).
+    std::vector<uint8_t> m_elem_hits;
 
 public:
     protocol_response();
@@ -175,6 +185,10 @@ public:
 
     void set_top_array_len(int len);
     int get_top_array_len(void);
+
+    void elem_hits_reserve(size_t n);
+    void elem_hit_push(bool hit);
+    const std::vector<uint8_t> &get_elem_hits(void);
 
     void clear();
 
@@ -217,6 +231,12 @@ protected:
     struct evbuffer *m_write_buf;
 
     bool m_keep_value;
+    // When set, the parser records per-top-level-element hit/miss flags into
+    // m_last_response.m_elem_hits without materializing the reply tree. Used by
+    // the ArrayPerElementNulls miss-tracking path as an alloc-free replacement
+    // for set_keep_value(). Independent of m_keep_value (both may be on if a
+    // SCAN-style command shares the connection).
+    bool m_track_elem_misses;
     struct protocol_response m_last_response;
 
 public:
@@ -225,6 +245,7 @@ public:
     virtual abstract_protocol *clone(void) = 0;
     void set_buffers(struct evbuffer *read_buf, struct evbuffer *write_buf);
     void set_keep_value(bool flag);
+    void set_track_elem_misses(bool flag);
 
     virtual int select_db(int db) = 0;
     virtual int authenticate(const char *credentials) = 0;

--- a/protocol.h
+++ b/protocol.h
@@ -146,6 +146,13 @@ protected:
     unsigned int m_total_len;
     unsigned int m_hits;
     bool m_error;
+    // Declared element count of the reply's top-level aggregate (* array, %
+    // map, ~ set), captured once per response from the header line. -1 means
+    // the top-level reply was not such an aggregate (a scalar, bulk, error, or
+    // unparsed). Lets miss-tracking classify empty vs non-empty collections
+    // without materializing element values via set_keep_value(). A null array
+    // ($-1/*-1) and an empty array (*0) both record 0.
+    int m_top_array_len;
 
 public:
     protocol_response();
@@ -165,6 +172,9 @@ public:
 
     void incr_hits(void);
     unsigned int get_hits(void);
+
+    void set_top_array_len(int len);
+    int get_top_array_len(void);
 
     void clear();
 

--- a/tests/test_arbitrary_command_misses.py
+++ b/tests/test_arbitrary_command_misses.py
@@ -151,6 +151,39 @@ def test_arbitrary_smembers_empty_collection(env):
                    message="expected SMEMBERS misses on missing keys")
 
 
+def test_arbitrary_smembers_zero_length_member_is_hit(env):
+    """Regression: a set whose only member is the empty string returns a
+    non-empty array (*1 $0) and must count as a HIT, not a miss.
+
+    EmptyCollection miss-tracking classifies emptiness from the reply's
+    declared top-level array length (get_top_array_len()), not from a per-value
+    hit walk. An earlier approach keyed on the parser's non-null-bulk hit
+    counter, which skips zero-length bulks and so misreported this populated
+    set as empty/missing. This test pins the declared-length behaviour."""
+    env.skipOnCluster()
+    set_prefix = "memtier-emptyset-"
+    env.flush()
+    conn = env.getConnection()
+    # Keys 1..3 each hold a single zero-length member; 4..10 stay missing.
+    for i in range(1, _PRELOADED_KEYS + 1):
+        conn.sadd("{}{}".format(set_prefix, i), "")
+
+    result = _run_benchmark(env, "SMEMBERS __key__", key_prefix=set_prefix)
+    per_key = result["ALL STATS"].get("Per-Key Misses", {})
+    env.assertContains("SMEMBERS", per_key)
+    cmd_stats = per_key["SMEMBERS"]
+
+    total_ops = cmd_stats["Total Hits"] + cmd_stats["Total Misses"]
+    env.assertEqual(total_ops, _REQUESTS * 2)
+    # The populated (zero-length-member) sets must register as hits.
+    env.assertTrue(cmd_stats["Total Hits"] > 0,
+                   message="zero-length set member must count as a hit, got "
+                           "{} hits".format(cmd_stats["Total Hits"]))
+    # And the missing keys 4..10 must still register as misses.
+    env.assertTrue(cmd_stats["Total Misses"] > 0,
+                   message="expected misses on missing keys")
+
+
 def test_arbitrary_exists_integer_membership(env):
     """EXISTS — IntegerMembership; integer reply N == hit count."""
     env.skipOnCluster()


### PR DESCRIPTION
## Cherry-pick to `2.4`

Backports the two RED-200840 fixes that landed on `master` into the `2.4` release line, where the regression was introduced (v2.4.x shipped arbitrary-command miss-tracking default-on, PRs #374/#398):

- **#469** — EmptyCollection (HGETALL/SMEMBERS/LRANGE): drop reply materialization; classify emptiness from the declared top-level array length.
- **#472** — ArrayPerElementNulls (HMGET/MGET/ZMSCORE/GEOPOS): alloc-free per-position hit bitmap in the parser instead of materializing the reply tree.

### Backport notes
- Clean cherry-pick except one conflict in `protocol.cpp`: master's `reset_state()` reconnect-reset infrastructure does not exist on `2.4`, so the incidental `reset_state` hunks were dropped. Per-response state (`m_tracking`/`m_nested_remaining`) is still reset in the `rs_initial` parser branch, so behavior is unchanged on this branch.
- Builds clean on `2.4`.

### Verification
Deterministic per-position checks (`--key-maximum=1`, fixed keys) on the built `2.4` binary — identical to the materialized walk:
- HMGET `f0 f1 f2 f3 f4` (f0/f2/f4 present) → pos 0,2,4 hit; 1,3 miss ✓
- GEOPOS nested (m1 absent) → pos 0,2 hit; 1 miss ✓
- SMEMBERS of a zero-length-member set → hit ✓

Lab numbers (on master, same code): HGETALL and HMGET both restored to within ~2–3% of the pre-2.4 (2.2.1) baseline, with miss-tracking left on. See RED-200840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RESP parsing and miss-accounting paths for many arbitrary commands; semantics are intended to match the old materialized walk but nested/RESP3 edge cases depend on the new tracker logic.
> 
> **Overview**
> Restores benchmark throughput for **HGETALL/HMGET/MGET**-style workloads when arbitrary-command miss tracking is on by **stopping full RESP reply materialization** for miss accounting.
> 
> **ArrayPerElementNulls** (HMGET, MGET, ZMSCORE, GEOPOS, …): client setup now enables **`set_track_elem_misses`** instead of **`set_keep_value`** on all connections. The Redis parser records a **per-top-level-element hit bitmap** at parse time (`track_leaf`, nested sub-arrays via `m_nested_remaining`), and **`handle_response`** reads **`get_elem_hits()`** rather than walking a built mbulk tree.
> 
> **EmptyCollection** (SMEMBERS, HGETALL, LRANGE, …): emptiness uses the **declared top-level aggregate length** **`get_top_array_len()`** from the `*N` header—so a set with only a **`$0`** member counts as a **hit**—without enabling keep-value for those commands.
> 
> Adds a regression test for **SMEMBERS** on sets whose sole member is the empty string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab663c12d47c552e4a70c66928e9ecf471640429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->