### PR TITLE
fix(miss-tracking): enable arbitrary-command miss tracking on cluster shard connections

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -55,6 +55,23 @@
 #include "retry_policy.h"
 
 
+void client::apply_arbitrary_tracking_flags(abstract_protocol *protocol)
+{
+    // Mirror the per-element miss-tracking decision made in setup_client onto a
+    // single protocol. In cluster mode shard connections are *re-created* (not
+    // reconnected in place) on topology reset -- cluster_client::disconnect()
+    // deletes the non-main connections and the next cluster-slots discovery
+    // rebuilds them via create_shard_connection(). Each rebuild clone()s a fresh
+    // protocol with runtime flags reset to defaults, so the flag must be
+    // re-applied here or miss tracking silently never engages for them. (An
+    // in-place reconnect keeps the same protocol object; reset_state() preserves
+    // the flag, so that path needs nothing.) See issue #476.
+    if (protocol == NULL) return;
+    if (m_arbitrary_needs_elem_tracking) {
+        protocol->set_track_elem_misses(true);
+    }
+}
+
 bool client::setup_client(benchmark_config *config, abstract_protocol *protocol, object_generator *objgen)
 {
     m_config = config;
@@ -95,20 +112,21 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
     // (response->get_top_array_len()); SingleNullBulk and IntegerMembership use
     // the parser's scalar counters / status line. None of them keep values.
     if (config->arbitrary_commands->is_defined()) {
-        bool needs_elem_tracking = false;
         for (size_t i = 0; i < config->arbitrary_commands->size(); ++i) {
             const arbitrary_command &cmd = config->arbitrary_commands->at(i);
             if (!cmd.miss_tracking_enabled || cmd.spec == NULL) continue;
             using memtier::command_meta::ReplyShape;
             if (cmd.spec->reply_shape == ReplyShape::ArrayPerElementNulls) {
-                needs_elem_tracking = true;
+                m_arbitrary_needs_elem_tracking = true;
                 break;
             }
         }
-        if (needs_elem_tracking) {
-            for (size_t i = 0; i < m_connections.size(); ++i) {
-                m_connections[i]->get_protocol()->set_track_elem_misses(true);
-            }
+        // Apply to the connections that exist now. Connections created later --
+        // notably the per-shard connections that cluster_client builds during
+        // cluster-slots discovery -- pick the flag up via
+        // apply_arbitrary_tracking_flags() at creation time (see issue #476).
+        for (size_t i = 0; i < m_connections.size(); ++i) {
+            apply_arbitrary_tracking_flags(m_connections[i]->get_protocol());
         }
     }
 
@@ -153,7 +171,8 @@ client::client(client_group *group) :
         m_tot_wait_ops(0),
         m_scan_cursor("0"),
         m_scan_iteration_count(0),
-        m_mget_defer(false)
+        m_mget_defer(false),
+        m_arbitrary_needs_elem_tracking(false)
 {
     m_event_base = group->get_event_base();
 
@@ -185,7 +204,8 @@ client::client(struct event_base *event_base, benchmark_config *config, abstract
         m_scan_cursor("0"),
         m_scan_iteration_count(0),
         m_keylist(NULL),
-        m_mget_defer(false)
+        m_mget_defer(false),
+        m_arbitrary_needs_elem_tracking(false)
 {
     m_event_base = event_base;
 

--- a/client.h
+++ b/client.h
@@ -103,6 +103,22 @@ protected:
     // Only meaningful when create_mget_request() returns false; undefined otherwise.
     bool m_mget_defer;
 
+    // True when at least one configured arbitrary command needs per-element
+    // miss tracking (ArrayPerElementNulls reply shape). Computed once in
+    // setup_client and applied to every shard connection's protocol via
+    // apply_arbitrary_tracking_flags() -- including connections created
+    // dynamically after setup (cluster-slots discovery / reconnect), whose
+    // freshly cloned protocols would otherwise start with the flag cleared.
+    bool m_arbitrary_needs_elem_tracking;
+
+    // Apply the resolved arbitrary-command tracking flags to a single protocol.
+    // Currently a single flag (set_track_elem_misses); plural name is
+    // deliberate so additional per-protocol arbitrary-command setup can be
+    // folded in here without touching the call sites. Idempotent and safe to
+    // call on any connection's protocol at or after setup_client(); a no-op
+    // until setup_client() has computed the flag.
+    void apply_arbitrary_tracking_flags(abstract_protocol *protocol);
+
 public:
     client(client_group *group);
     client(struct event_base *event_base, benchmark_config *config, abstract_protocol *protocol,

--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -231,6 +231,13 @@ shard_connection *cluster_client::create_shard_connection(abstract_protocol *abs
     shard_connection *sc = new shard_connection(m_connections.size(), this, m_config, m_event_base, abs_protocol);
     assert(sc != NULL);
 
+    // The shard_connection ctor clones abs_protocol, and clone() resets runtime
+    // flags to defaults, so re-apply the arbitrary-command miss-tracking flag
+    // here. Without this, per-shard connections discovered after setup_client()
+    // never track misses and cluster-mode miss accounting is silently a no-op
+    // (issue #476).
+    apply_arbitrary_tracking_flags(sc->get_protocol());
+
     m_connections.push_back(sc);
 
     // create key index pool

--- a/tests/test_arbitrary_command_misses.py
+++ b/tests/test_arbitrary_command_misses.py
@@ -44,7 +44,8 @@ def _preload_sets(env, prefix):
         conn.sadd("{}{}".format(prefix, i), "a", "b", "c")
 
 
-def _run_benchmark(env, command, miss_tracking="auto", key_prefix=_KEY_PREFIX, requests=_REQUESTS):
+def _run_benchmark(env, command, miss_tracking="auto", key_prefix=_KEY_PREFIX, requests=_REQUESTS,
+                   key_max=_KEY_RANGE_MAX):
     """Run memtier with the given --command and return the parsed mb.json."""
     test_dir = tempfile.mkdtemp()
     benchmark_specs = {
@@ -56,7 +57,7 @@ def _run_benchmark(env, command, miss_tracking="auto", key_prefix=_KEY_PREFIX, r
             "--command-miss-tracking={}".format(miss_tracking),
             "--key-prefix={}".format(key_prefix),
             "--key-minimum=1",
-            "--key-maximum={}".format(_KEY_RANGE_MAX),
+            "--key-maximum={}".format(key_max),
             "--hide-histogram",
         ],
     }
@@ -248,6 +249,45 @@ def test_arbitrary_hmget_per_field_buckets(env):
     # the 3 populated keys.
     env.assertTrue(cmd_stats["key[0] Hits"] > 0)
     env.assertTrue(cmd_stats["key[1] Hits"] > 0)
+
+
+def test_arbitrary_hmget_full_coverage_cluster_and_standalone(env):
+    """Every reply position must be accounted for, in BOTH standalone and OSS
+    cluster mode.
+
+    Regression for issue #476: arbitrary-command miss tracking is enabled per
+    connection in setup_client(), but in cluster mode the per-shard connections
+    are created later during cluster-slots discovery and their freshly cloned
+    protocols started with the tracking flag cleared. The result was that only
+    requests routed to the seed connection's shard were accounted -- roughly
+    1/num_shards coverage -- while the rest were silently dropped from the
+    per-key stats.
+
+    This test deliberately does NOT skipOnCluster and asserts FULL coverage
+    (every field position of every request shows up in Total Hits+Misses). No
+    preload is needed: absent keys still produce per-position miss accounting,
+    so the count is topology- and hit-rate-independent. A wide key range
+    ensures keys spread across all shards so non-seed connections are exercised;
+    before the fix this assertion fails on cluster (partial coverage).
+    """
+    fields = ["f0", "f1", "f2", "f3"]
+    command = "HMGET __key__ " + " ".join(fields)
+    # Wide key range so keys land on every shard, exercising non-seed conns.
+    result = _run_benchmark(env, command, key_max=1000)
+    per_key = result["ALL STATS"].get("Per-Key Misses", {})
+    env.assertContains("HMGET", per_key)
+    cmd_stats = per_key["HMGET"]
+
+    total_accounted = cmd_stats["Total Hits"] + cmd_stats["Total Misses"]
+    expected = _REQUESTS * 2 * len(fields)  # requests * clients * fields
+    env.assertEqual(total_accounted, expected,
+                    message="expected full per-position coverage {} but accounted {} "
+                            "(partial coverage indicates cluster shard connections are "
+                            "not tracking misses, issue #476)".format(expected, total_accounted))
+    # One bucket per field position, no phantom extra bucket.
+    for k in range(len(fields)):
+        env.assertContains("key[{}] Hits".format(k), cmd_stats)
+    env.assertNotContains("key[{}] Hits".format(len(fields)), cmd_stats)
 
 
 def test_arbitrary_geopos_nested_array_elements(env):


### PR DESCRIPTION
Fixes #476. Follow-up to the RED-200840 miss-tracking work (#469, #472).

## Problem

Arbitrary-command per-element miss tracking (`set_track_elem_misses`) was applied in `setup_client()` only to the connections that exist at setup time. In OSS cluster mode the per-shard connections are created **later**, during cluster-slots discovery (`cluster_client::create_shard_connection`), and the `shard_connection` ctor clones its protocol via `clone()` — which resets runtime flags to defaults. Those late-created connections started with miss tracking cleared, so **only requests routed to the seed connection's shard were accounted (~1/num_shards coverage)**; the rest were silently dropped from the per-key miss stats.

## Fix

Factor the tracking-flag decision into `client::apply_arbitrary_tracking_flags()` plus a cached `m_arbitrary_needs_elem_tracking` flag computed once in `setup_client()`. Apply it to each connection in `setup_client()` and, crucially, to every shard connection created in `cluster_client::create_shard_connection()`.

## Verification

Against a live 3-shard OSS cluster (`--cluster-mode`, HMGET with 4 fields, 800 ops):

| | positions accounted | coverage |
|---|---|---|
| before fix | 1,200 | **38%** (seed shard only) |
| after fix | 3,200 | **100%** |

Per-position hit/miss semantics unchanged (f0/f1/f2 present → hits; absent field → 100% miss in its bucket). Standalone is unaffected (its single connection always carried the flag).

Adds `test_arbitrary_hmget_full_coverage_cluster_and_standalone`, which does **not** `skipOnCluster` and asserts full per-position coverage in both topologies — it fails on cluster before this fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster connection setup and protocol flags for miss accounting; behavior is localized and covered by a cluster+standalone regression test, but incorrect flag application would skew benchmark miss metrics.
> 
> **Overview**
> Fixes **issue #476**: in OSS cluster mode, per-element arbitrary-command miss tracking (`set_track_elem_misses`) was only applied to connections that existed during `setup_client()`. Shard connections created later via `cluster_client::create_shard_connection()` get a **fresh protocol from `clone()`**, so the tracking flag stayed off and **~1/num_shards** of HMGET/MGET-style traffic was missing from per-key miss stats.
> 
> The PR caches whether any configured command needs **ArrayPerElementNulls** tracking in **`m_arbitrary_needs_elem_tracking`**, centralizes application in **`apply_arbitrary_tracking_flags()`**, and calls it from **`setup_client()`** and **`create_shard_connection()`** so every shard connection gets the flag.
> 
> Adds **`test_arbitrary_hmget_full_coverage_cluster_and_standalone`**, which runs in cluster and standalone and asserts total hits+misses equals requests × clients × fields (fails on cluster before the fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 320e07b69711bc6bc521828174a73f97b431aaf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->