### PR TITLE
[DIAGNOSTIC] UBSan bisect: C++ changes only

### DIFF
--- a/config_types.cpp
+++ b/config_types.cpp
@@ -722,6 +722,7 @@ bool monitor_command_list::load_from_file(const char *filename)
     size_t line_capacity = 0;
     ssize_t line_len;
     size_t total_lines = 0;
+    size_t skipped_malformed = 0;
 
     // Use getline() for dynamic allocation - handles arbitrarily long lines
     while ((line_len = getline(&line, &line_capacity, file)) != -1) {
@@ -770,6 +771,28 @@ bool monitor_command_list::load_from_file(const char *filename)
                 command_str.erase(command_str.length() - 1);
             }
 
+            // Validate that the command actually parses with the exact tokenizer
+            // used at request time (arbitrary_command::split_command_to_args).
+            // Previously any segment containing a quote was accepted and the only
+            // sanity check was that a command *type* (first quoted word) could be
+            // extracted -- so a line like  "SET" "key" "unterminated  has a valid
+            // type ("SET") yet fails to split at request time. When every loaded
+            // command is malformed, create_arbitrary_request() skips each one and
+            // never enqueues a request, leaving fill_pipeline() to busy-spin
+            // forever: the --test-time deadline is only re-evaluated once an op
+            // completes, and no op ever completes. That hung the run until the CI
+            // watchdog killed it (the Monitor-Input Fuzz 90s timeout). Reject
+            // unparseable commands here so the loader fails fast on garbage and a
+            // partially-malformed file still runs its valid commands. The probe
+            // uses command_str.c_str() exactly as the request path does, so any
+            // command accepted here is guaranteed to split at request time too.
+            arbitrary_command probe(command_str.c_str());
+            if (!probe.split_command_to_args()) {
+                skipped_malformed++;
+                seg_start = seg_end ? seg_end + 1 : line + line_len;
+                continue;
+            }
+
             commands.push_back(command_str);
 
             // Extract and store the command type (e.g., "SET", "GET")
@@ -784,11 +807,22 @@ bool monitor_command_list::load_from_file(const char *filename)
     fclose(file);
 
     if (commands.empty()) {
-        fprintf(stderr, "error: no commands found in monitor input file: %s\n", filename);
+        if (skipped_malformed > 0) {
+            fprintf(stderr,
+                    "error: no valid commands found in monitor input file: %s (%zu malformed line(s) skipped)\n",
+                    filename, skipped_malformed);
+        } else {
+            fprintf(stderr, "error: no commands found in monitor input file: %s\n", filename);
+        }
         return false;
     }
 
-    fprintf(stderr, "Loaded %zu monitor commands from %zu total lines\n", commands.size(), total_lines);
+    if (skipped_malformed > 0) {
+        fprintf(stderr, "Loaded %zu monitor commands from %zu total lines (%zu malformed line(s) skipped)\n",
+                commands.size(), total_lines, skipped_malformed);
+    } else {
+        fprintf(stderr, "Loaded %zu monitor commands from %zu total lines\n", commands.size(), total_lines);
+    }
     return true;
 }
 

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -3085,6 +3085,17 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     unsigned long int prev_errors = 0;
     unsigned long int prev_retry_attempts = 0;
 
+    // Wall-clock backstop for --test-time: counts consecutive 1s ticks that
+    // elapsed past the deadline with zero completed operations. A worker
+    // normally terminates itself once its finished() check reaches test_time,
+    // but that check is driven by op-completion stats (run_stats::get_duration),
+    // which freeze when no op ever completes -- every monitor-replay command
+    // skipped as malformed, a connection wedged after a parse error, a WAIT that
+    // never returns. The worker then sits idle in its event loop forever and the
+    // run ignores --test-time until an external watchdog kills it (the
+    // Monitor-Input Fuzz 90s timeouts). See the backstop below.
+    unsigned int testtime_stall_secs = 0;
+
     // Detect once whether stderr is a real terminal. --realtime-latencies uses
     // this to choose between in-place cursor-up redraw and plain-append output.
     bool stderr_is_tty = isatty(fileno(stderr)) != 0;
@@ -3215,6 +3226,39 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
         prev_bytes = total_bytes;
         prev_latency = total_latency;
         prev_duration = duration;
+
+        // Wall-clock --test-time backstop (see testtime_stall_secs above).
+        // `duration` is the average per-thread wall-clock elapsed
+        // (get_duration_usec), so it advances even when no op completes. Once we
+        // are past the deadline AND no operation has completed for a grace
+        // window, the workers are wedged (not merely draining): interrupt them.
+        // interrupt() wakes a worker blocked in epoll via loopexit (see
+        // client_group::interrupt), so an idle-but-stuck event loop is reliably
+        // torn down. We require a run of zero-op ticks rather than firing the
+        // instant we cross the deadline so a healthy run flushing its last
+        // in-flight responses -- or a deliberately sparse --request-rate run --
+        // is never cut short. request_rate runs can legitimately idle between
+        // ticks, so the grace is widened there.
+        if (cfg->test_time > 0 && active_threads > 0 && (duration / 1000000) >= (unsigned long) cfg->test_time) {
+            const unsigned int grace = cfg->request_rate ? 30 : 5;
+            if (cur_ops == 0) {
+                testtime_stall_secs++;
+            } else {
+                testtime_stall_secs = 0;
+            }
+            if (testtime_stall_secs >= grace) {
+                fprintf(stderr,
+                        "\n[RUN #%u] --test-time deadline exceeded: %lus elapsed (limit %us) with no completed "
+                        "operations for %us; stopping stalled threads...\n",
+                        run_id, duration / 1000000, cfg->test_time, testtime_stall_secs);
+                for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {
+                    (*i)->m_cg->interrupt();
+                }
+                break;
+            }
+        } else {
+            testtime_stall_secs = 0;
+        }
 
         unsigned long int ops_sec = 0;
         unsigned long int bytes_sec = 0;

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -1303,9 +1303,20 @@ void run_stats::print_type_column(output_table &table, arbitrary_command_list &c
     table_el el;
     table_column column;
 
-    // Type column
+    // Type column. The width is derived from the longest command name, which
+    // for --monitor-input comes from external (and fuzzed) input, so it can be
+    // arbitrarily long. Clamp it to a sane maximum: the fixed-size formatting
+    // buffers driven by column_size here and in output_table::print_header
+    // (char buf[100]) would otherwise overflow -- a memory-safety bug, not a
+    // cosmetic one. The previous `assert(column_size < 100)` aborted the whole
+    // process on such input (and <100 was itself one byte too generous for
+    // print_header's buf[100]). An over-long name still prints, just truncated
+    // to the column width by the snprintf in output_table::print.
+    static const unsigned int MAX_TYPE_COLUMN_SIZE = 64;
     column.column_size = MAX(6, command_list.get_max_command_name_length()) + 1;
-    assert(column.column_size < 100 && "command name too long");
+    if (column.column_size > MAX_TYPE_COLUMN_SIZE) {
+        column.column_size = MAX_TYPE_COLUMN_SIZE;
+    }
 
     // set enough space according to size of command name
     char buf[200];

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -311,6 +311,18 @@ shard_connection::~shard_connection()
     }
 
     if (m_pipeline != NULL) {
+        // Free any requests still in flight. A normally-completed run drains the
+        // pipeline before teardown, but an early teardown (Ctrl+C,
+        // --connection-stage-timeout abort, or the --test-time backstop tearing
+        // down a wedged connection -- e.g. replaying a monitor command that
+        // never gets a reply) leaves queued request objects behind. Deleting the
+        // queue without draining it leaks them; LeakSanitizer flags it (the
+        // Monitor-Input Fuzz exit=42 reports). Mirrors the retry/replay queues
+        // below.
+        while (!m_pipeline->empty()) {
+            delete m_pipeline->front();
+            m_pipeline->pop();
+        }
         delete m_pipeline;
         m_pipeline = NULL;
     }


### PR DESCRIPTION
Diagnostic to isolate a UBSan zipfian hang. Will be closed. Not for merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 522a66f11d26722fd5c69a9edfae99e1968ad605. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->