### PR TITLE
[DIAGNOSTIC] UBSan bisect: C++ minus backstop

### DIFF
--- a/config_types.cpp
+++ b/config_types.cpp
@@ -722,6 +722,7 @@ bool monitor_command_list::load_from_file(const char *filename)
     size_t line_capacity = 0;
     ssize_t line_len;
     size_t total_lines = 0;
+    size_t skipped_malformed = 0;
 
     // Use getline() for dynamic allocation - handles arbitrarily long lines
     while ((line_len = getline(&line, &line_capacity, file)) != -1) {
@@ -770,6 +771,28 @@ bool monitor_command_list::load_from_file(const char *filename)
                 command_str.erase(command_str.length() - 1);
             }
 
+            // Validate that the command actually parses with the exact tokenizer
+            // used at request time (arbitrary_command::split_command_to_args).
+            // Previously any segment containing a quote was accepted and the only
+            // sanity check was that a command *type* (first quoted word) could be
+            // extracted -- so a line like  "SET" "key" "unterminated  has a valid
+            // type ("SET") yet fails to split at request time. When every loaded
+            // command is malformed, create_arbitrary_request() skips each one and
+            // never enqueues a request, leaving fill_pipeline() to busy-spin
+            // forever: the --test-time deadline is only re-evaluated once an op
+            // completes, and no op ever completes. That hung the run until the CI
+            // watchdog killed it (the Monitor-Input Fuzz 90s timeout). Reject
+            // unparseable commands here so the loader fails fast on garbage and a
+            // partially-malformed file still runs its valid commands. The probe
+            // uses command_str.c_str() exactly as the request path does, so any
+            // command accepted here is guaranteed to split at request time too.
+            arbitrary_command probe(command_str.c_str());
+            if (!probe.split_command_to_args()) {
+                skipped_malformed++;
+                seg_start = seg_end ? seg_end + 1 : line + line_len;
+                continue;
+            }
+
             commands.push_back(command_str);
 
             // Extract and store the command type (e.g., "SET", "GET")
@@ -784,11 +807,22 @@ bool monitor_command_list::load_from_file(const char *filename)
     fclose(file);
 
     if (commands.empty()) {
-        fprintf(stderr, "error: no commands found in monitor input file: %s\n", filename);
+        if (skipped_malformed > 0) {
+            fprintf(stderr,
+                    "error: no valid commands found in monitor input file: %s (%zu malformed line(s) skipped)\n",
+                    filename, skipped_malformed);
+        } else {
+            fprintf(stderr, "error: no commands found in monitor input file: %s\n", filename);
+        }
         return false;
     }
 
-    fprintf(stderr, "Loaded %zu monitor commands from %zu total lines\n", commands.size(), total_lines);
+    if (skipped_malformed > 0) {
+        fprintf(stderr, "Loaded %zu monitor commands from %zu total lines (%zu malformed line(s) skipped)\n",
+                commands.size(), total_lines, skipped_malformed);
+    } else {
+        fprintf(stderr, "Loaded %zu monitor commands from %zu total lines\n", commands.size(), total_lines);
+    }
     return true;
 }
 

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -1303,9 +1303,20 @@ void run_stats::print_type_column(output_table &table, arbitrary_command_list &c
     table_el el;
     table_column column;
 
-    // Type column
+    // Type column. The width is derived from the longest command name, which
+    // for --monitor-input comes from external (and fuzzed) input, so it can be
+    // arbitrarily long. Clamp it to a sane maximum: the fixed-size formatting
+    // buffers driven by column_size here and in output_table::print_header
+    // (char buf[100]) would otherwise overflow -- a memory-safety bug, not a
+    // cosmetic one. The previous `assert(column_size < 100)` aborted the whole
+    // process on such input (and <100 was itself one byte too generous for
+    // print_header's buf[100]). An over-long name still prints, just truncated
+    // to the column width by the snprintf in output_table::print.
+    static const unsigned int MAX_TYPE_COLUMN_SIZE = 64;
     column.column_size = MAX(6, command_list.get_max_command_name_length()) + 1;
-    assert(column.column_size < 100 && "command name too long");
+    if (column.column_size > MAX_TYPE_COLUMN_SIZE) {
+        column.column_size = MAX_TYPE_COLUMN_SIZE;
+    }
 
     // set enough space according to size of command name
     char buf[200];

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -311,6 +311,18 @@ shard_connection::~shard_connection()
     }
 
     if (m_pipeline != NULL) {
+        // Free any requests still in flight. A normally-completed run drains the
+        // pipeline before teardown, but an early teardown (Ctrl+C,
+        // --connection-stage-timeout abort, or the --test-time backstop tearing
+        // down a wedged connection -- e.g. replaying a monitor command that
+        // never gets a reply) leaves queued request objects behind. Deleting the
+        // queue without draining it leaks them; LeakSanitizer flags it (the
+        // Monitor-Input Fuzz exit=42 reports). Mirrors the retry/replay queues
+        // below.
+        while (!m_pipeline->empty()) {
+            delete m_pipeline->front();
+            m_pipeline->pop();
+        }
         delete m_pipeline;
         m_pipeline = NULL;
     }


### PR DESCRIPTION
Diagnostic. Will close. Not for merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect monitor-input parsing, results formatting, and connection destruction; low blast radius but touches request lifecycle and fuzz-sensitive paths where regressions could change which commands run or how failures surface.
> 
> **Overview**
> Hardens **--monitor-input** and fuzz/CI teardown paths so bad or wedged runs fail fast instead of hanging or crashing.
> 
> **Monitor input loading** now probes each candidate line with `arbitrary_command::split_command_to_args()` (same tokenizer as request time). Unparseable segments are skipped with a count; partially valid files still load good commands, while an all-malformed file errors with a clearer message. This avoids the case where every replay command fails to split, nothing is enqueued, and `fill_pipeline()` spins until the watchdog kills the job.
> 
> **Stats output** clamps the arbitrary-command “Type” column width to **64** instead of asserting `column_size < 100`, preventing `snprintf`/`buf[100]` overflows when fuzzed command names are huge (names still print, truncated).
> 
> **Connection teardown** drains and deletes in-flight `request` objects left on `m_pipeline` when the connection is torn down early (interrupt, timeouts, wedged replay), matching retry/replay queue cleanup and fixing LeakSanitizer reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29870788fb2065231caca2521ac068f7a0f8df88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->