### PR TITLE
feat(prom): export arbitrary-command hits/misses as new counter series

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1427,6 +1427,26 @@ unsigned long int client_group::get_total_misses(void)
     return total;
 }
 
+unsigned long long client_group::get_total_arbitrary_hits(void)
+{
+    unsigned long long total = 0;
+    unsigned int count = active_client_count();
+    for (unsigned int i = 0; i < count; i++) {
+        total += m_clients[i]->get_stats()->get_total_arbitrary_hits();
+    }
+    return total;
+}
+
+unsigned long long client_group::get_total_arbitrary_misses(void)
+{
+    unsigned long long total = 0;
+    unsigned int count = active_client_count();
+    for (unsigned int i = 0; i < count; i++) {
+        total += m_clients[i]->get_stats()->get_total_arbitrary_misses();
+    }
+    return total;
+}
+
 unsigned long int client_group::get_total_retry_attempts(void)
 {
     unsigned long int total = 0;

--- a/client.h
+++ b/client.h
@@ -303,6 +303,8 @@ public:
     unsigned long int get_total_connection_errors(void);
     unsigned long int get_total_hits(void);
     unsigned long int get_total_misses(void);
+    unsigned long long get_total_arbitrary_hits(void);
+    unsigned long long get_total_arbitrary_misses(void);
     unsigned long int get_total_retry_attempts(void);
     unsigned long int get_total_retried_ops(void);
     unsigned long int get_total_errors(void);

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -3382,7 +3382,12 @@ static inline bool prom_enabled(benchmark_config *cfg)
 // Read one client_group's live cumulative counters into a counter_set. These
 // are the TSan-documented benign-race scalar getters (client.h:282-292); safe
 // to sample at 1 Hz from the main thread. Bytes are the split rx/tx getters
-// (never summarize() — it double-counts arbitrary-command bytes).
+// (never summarize() — it double-counts arbitrary-command bytes). The arbitrary
+// hits/misses sum only the per-command scalar totals in run_stats
+// m_arbitrary_misses[] (never the per-key vectors the worker grow-resizes), so
+// they read race-free at the same off-worker point as the GET hits/misses; the
+// accessors live on client_group/run_stats rather than the client.h:282-292
+// flat-scalar block because the source lives in per-command run_stats state.
 static counter_set prom_read_cg_counters(client_group *cg)
 {
     counter_set cs;
@@ -3395,6 +3400,8 @@ static counter_set prom_read_cg_counters(client_group *cg)
     cs.v[MT_CONN_ERRORS] = cg->get_total_connection_errors();
     cs.v[MT_RETRY_ATTEMPTS] = cg->get_total_retry_attempts();
     cs.v[MT_RETRIED_OPS] = cg->get_total_retried_ops();
+    cs.v[MT_ARBITRARY_HITS] = cg->get_total_arbitrary_hits();
+    cs.v[MT_ARBITRARY_MISSES] = cg->get_total_arbitrary_misses();
     return cs;
 }
 

--- a/prometheus_metrics.cpp
+++ b/prometheus_metrics.cpp
@@ -67,10 +67,10 @@ static const metric_def kMetricDefs[] = {
     {"memtier_received_bytes_total", MT_TYPE_COUNTER, "Total bytes read from the server since process start."},
     {"memtier_hits_total", MT_TYPE_COUNTER,
      "Total GET operations that found the key. Counts GET-command hits only; hits on arbitrary "
-     "(--command) miss-trackable commands are not included in this total."},
+     "(--command) miss-trackable commands are reported separately by memtier_arbitrary_hits_total."},
     {"memtier_misses_total", MT_TYPE_COUNTER,
      "Total GET operations that did not find the key. Counts GET-command misses only; misses on arbitrary "
-     "(--command) miss-trackable commands are not included in this total."},
+     "(--command) miss-trackable commands are reported separately by memtier_arbitrary_misses_total."},
     {"memtier_errors_total", MT_TYPE_COUNTER,
      "Total commands that received an error reply after retries were exhausted; connection errors are counted "
      "separately."},
@@ -81,6 +81,14 @@ static const metric_def kMetricDefs[] = {
      "Total command resend attempts; nonzero only with --retry-on-error."},
     {"memtier_retried_ops_total", MT_TYPE_COUNTER,
      "Total operations that eventually succeeded after at least one retry; nonzero only with --retry-on-error."},
+    {"memtier_arbitrary_hits_total", MT_TYPE_COUNTER,
+     "Total key lookups on arbitrary (--command) miss-trackable commands that found the key (a multi-key command "
+     "such as HMGET contributes one increment per element), aggregated across all configured arbitrary commands. "
+     "GET-command hits are reported separately by memtier_hits_total."},
+    {"memtier_arbitrary_misses_total", MT_TYPE_COUNTER,
+     "Total key lookups on arbitrary (--command) miss-trackable commands that did not find the key (a multi-key "
+     "command such as HMGET contributes one increment per element), aggregated across all configured arbitrary "
+     "commands. GET-command misses are reported separately by memtier_misses_total."},
     {"memtier_connections", MT_TYPE_GAUGE, "Client connections currently open."},
     {"memtier_threads", MT_TYPE_GAUGE, "Worker threads currently active."},
     {"memtier_run", MT_TYPE_GAUGE, "Current run number, 1-based; 0 before the first run starts."},
@@ -130,6 +138,10 @@ static const char *counter_metric_name(int m)
         return "memtier_retry_attempts_total";
     case MT_RETRIED_OPS:
         return "memtier_retried_ops_total";
+    case MT_ARBITRARY_HITS:
+        return "memtier_arbitrary_hits_total";
+    case MT_ARBITRARY_MISSES:
+        return "memtier_arbitrary_misses_total";
     default:
         return "";
     }
@@ -476,38 +488,39 @@ void text_renderer::render(std::string &out, const metrics_snapshot &snap, const
     emit_help_type(out, defs[di++]);
     append_fmt(out, "memtier_start_time_seconds%s %.3f\n", m_label_block.c_str(), start_time_seconds);
 
-    // 3-11. counters, in mt_counter order.
+    // All counters, in mt_counter order (defs[di] advances in lockstep, so the
+    // kMetricDefs counter rows must stay contiguous and in the same order).
     for (int m = 0; m < MT_NUM_COUNTERS; m++) {
         emit_help_type(out, defs[di++]);
         append_fmt(out, "%s%s %llu\n", counter_metric_name(m), m_label_block.c_str(),
                    (unsigned long long) snap.counters[m]);
     }
 
-    // 12. memtier_connections (gauge)
+    // memtier_connections (gauge)
     emit_help_type(out, defs[di++]);
     // integer count, rendered exactly (%.6g switches to scientific notation
     // past 6 significant digits, losing fidelity for large client x thread).
     append_fmt(out, "memtier_connections%s %u\n", m_label_block.c_str(), (unsigned) snap.connections);
 
-    // 13. memtier_threads (gauge)
+    // memtier_threads (gauge)
     emit_help_type(out, defs[di++]);
     append_fmt(out, "memtier_threads%s %u\n", m_label_block.c_str(), (unsigned) snap.active_threads);
 
-    // 14. memtier_run (gauge)
+    // memtier_run (gauge)
     emit_help_type(out, defs[di++]);
     append_fmt(out, "memtier_run%s %u\n", m_label_block.c_str(), (unsigned) snap.run_id);
 
-    // 15. memtier_configured_runs (gauge)
+    // memtier_configured_runs (gauge)
     emit_help_type(out, defs[di++]);
     append_fmt(out, "memtier_configured_runs%s %u\n", m_label_block.c_str(), (unsigned) snap.run_count);
 
-    // 16. memtier_config_test_time_seconds (gauge): the configured --test-time,
+    // memtier_config_test_time_seconds (gauge): the configured --test-time,
     // carried on the snapshot (stamped by the exporter's publish() from
     // options.test_time). 0 when running by --requests.
     emit_help_type(out, defs[di++]);
     append_fmt(out, "memtier_config_test_time_seconds%s %d\n", m_label_block.c_str(), (int) snap.test_time);
 
-    // 17. memtier_latency_seconds (histogram): cumulative bucket walk.
+    // memtier_latency_seconds (histogram): cumulative bucket walk.
     emit_help_type(out, defs[di++]);
     {
         size_t n = m_edge_us.size();
@@ -543,12 +556,12 @@ void text_renderer::render(std::string &out, const metrics_snapshot &snap, const
         append_fmt(out, "memtier_latency_seconds_sum%s %.9g\n", m_label_block.c_str(), sum_us / USECS_PER_SEC);
     }
 
-    // 18. memtier_exporter_renders_total (counter)
+    // memtier_exporter_renders_total (counter)
     emit_help_type(out, defs[di++]);
     append_fmt(out, "memtier_exporter_renders_total%s %llu\n", m_label_block.c_str(),
                (unsigned long long) renders_total);
 
-    // 19. memtier_exporter_snapshot_age_seconds (gauge)
+    // memtier_exporter_snapshot_age_seconds (gauge)
     emit_help_type(out, defs[di++]);
     append_fmt(out, "memtier_exporter_snapshot_age_seconds%s %.3f\n", m_label_block.c_str(), snapshot_age_seconds);
 

--- a/prometheus_metrics.h
+++ b/prometheus_metrics.h
@@ -61,6 +61,8 @@ enum mt_counter
     MT_CONN_ERRORS,
     MT_RETRY_ATTEMPTS,
     MT_RETRIED_OPS,
+    MT_ARBITRARY_HITS,   // hits on arbitrary (--command) miss-trackable commands
+    MT_ARBITRARY_MISSES, // misses on arbitrary (--command) miss-trackable commands
     MT_NUM_COUNTERS
 };
 

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -494,6 +494,22 @@ unsigned long int run_stats::get_total_misses(void)
     return m_totals.m_misses;
 }
 
+unsigned long long run_stats::get_total_arbitrary_hits(void)
+{
+    unsigned long long t = 0;
+    for (size_t i = 0; i < m_arbitrary_misses.size(); ++i)
+        t += m_arbitrary_misses[i].total_hits;
+    return t;
+}
+
+unsigned long long run_stats::get_total_arbitrary_misses(void)
+{
+    unsigned long long t = 0;
+    for (size_t i = 0; i < m_arbitrary_misses.size(); ++i)
+        t += m_arbitrary_misses[i].total_misses;
+    return t;
+}
+
 #define AVERAGE(total, count) ((unsigned int) ((count) > 0 ? (total) / (count) : 0))
 #define USEC_FORMAT(value) (value) / 1000000, (value) % 1000000
 

--- a/run_stats.h
+++ b/run_stats.h
@@ -399,6 +399,15 @@ public:
     unsigned long int get_total_hits(void);
     unsigned long int get_total_misses(void);
 
+    // Aggregate hits/misses across arbitrary (--command) miss-trackable commands.
+    // Sums only the per-command scalar totals in m_arbitrary_misses[] (assigned
+    // once in setup_arbitrary_commands), never the per-key vectors which the
+    // worker grow-resizes; safe to sample off-worker at 1 Hz like get_total_hits.
+    // unsigned long long because the source fields are 64-bit (run_stats.h
+    // arbitrary_misses_total) and can exceed 32 bits on long runs.
+    unsigned long long get_total_arbitrary_hits(void);
+    unsigned long long get_total_arbitrary_misses(void);
+
     // Returns true if set_start_time() was called, indicating the client
     // produced (or was ready to produce) meaningful stats data.
     bool has_started(void) const { return m_started.flag.load(std::memory_order_acquire); }

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -53,7 +53,8 @@ DEFAULT_LE_STRINGS = [
     "0.05", "0.075", "0.1", "0.25", "0.5", "1", "2.5", "5", "10", "30", "60",
 ]
 
-# The nine cumulative counter families the exporter exports (PLAN.md §3.4 / §4).
+# The cumulative counter families the exporter exports (PLAN.md §3.4 / §4;
+# arbitrary hits/misses added for #483).
 COUNTER_NAMES = [
     "memtier_ops_total",
     "memtier_sent_bytes_total",
@@ -64,7 +65,31 @@ COUNTER_NAMES = [
     "memtier_connection_errors_total",
     "memtier_retry_attempts_total",
     "memtier_retried_ops_total",
+    "memtier_arbitrary_hits_total",
+    "memtier_arbitrary_misses_total",
 ]
+
+# --command arguments that make memtier issue a single miss-trackable GET per op
+# (random key over a sparse range -> mostly misses), used by the #483 tests.
+_ARBITRARY_MISS_ARGS = [
+    "--command=GET __key__",
+    "--command-key-pattern=R",
+    "--command-stats-breakdown=line",
+    "--command-miss-tracking=auto",
+    "--key-prefix=prom_arb:",
+    "--key-minimum=1",
+    "--key-maximum=100000",
+]
+
+
+def _json_arbitrary_totals(json_path):
+    """Sum Total Hits / Total Misses across every arbitrary command in mb.json."""
+    with open(json_path) as fh:
+        js = json.load(fh)
+    per_key = js.get("ALL STATS", {}).get("Per-Key Misses", {})
+    hits = sum(v.get("Total Hits", 0) for v in per_key.values())
+    misses = sum(v.get("Total Misses", 0) for v in per_key.values())
+    return hits, misses
 
 
 # ---------------------------------------------------------------------------
@@ -1100,5 +1125,176 @@ def test_F20_inflight_cap_503(env):
             env.assertTrue(False, message="cap-seam: did not exit within 120s")
             return
         _no_sanitizer_output(env, _drain(err_path))
+    finally:
+        _kill(proc)
+
+
+# ---------------------------------------------------------------------------
+# F21-F24 -- arbitrary-command hits/misses series (#483).
+# memtier_arbitrary_hits_total / memtier_arbitrary_misses_total surface the
+# per-command miss tracking that the GET-only memtier_hits_total/misses_total
+# deliberately exclude. Sourced race-free at the same 1 Hz producer point.
+# ---------------------------------------------------------------------------
+def _scrape_last(proc, url, names, deadline_s=90):
+    """Poll /metrics @0.25 s until the process exits; return {name: last_value}
+    from the last successful scrape for each requested name, plus the last run."""
+    last = {n: None for n in names}
+    last["memtier_run"] = None
+    deadline = time.time() + deadline_s
+    while proc.poll() is None and time.time() < deadline:
+        r = prom_scrape(url, timeout=2)
+        if r.status == 200:
+            p = prom_parse(r.body)
+            for n in last:
+                v = prom_sample_value(p, n)
+                if v is not None:
+                    last[n] = v
+        time.sleep(0.25)
+    return last
+
+
+def test_F21_arbitrary_misses_surfaced(env):
+    """A --command miss workload populates the arbitrary series, and must NOT
+    leak into the GET-only memtier_hits_total/misses_total (Option B contract)."""
+    if _is_cluster(env):
+        env.skip()  # cluster covered by F23
+        return
+    rd = _new_results_dir()
+    json_path = os.path.join(rd, "mb.json")
+    proc, out_path, err_path = _popen_memtier(
+        env,
+        ["--test-time=6", "--prometheus-port=0", "--json-out-file", json_path] + _ARBITRARY_MISS_ARGS,
+        rd,
+    )
+    try:
+        url = wait_for_prometheus_url(out_path, timeout=20)
+        env.assertFalse(url is None, message="no announce line")
+        last = _scrape_last(proc, url,
+                            ["memtier_arbitrary_hits_total", "memtier_arbitrary_misses_total",
+                             "memtier_hits_total", "memtier_misses_total"])
+        rc = proc.wait()
+        env.assertEqual(rc, 0, message="memtier exit {}: {}".format(rc, _drain(err_path)))
+        am = last["memtier_arbitrary_misses_total"]
+        env.assertFalse(am is None, message="arbitrary_misses never scraped")
+        env.assertTrue(am > 0, message="arbitrary_misses stayed 0 under a miss workload")
+        # Option-B leak guard (exact): an arbitrary-only workload must leave the
+        # GET-path series at zero.
+        env.assertEqual(last["memtier_hits_total"], 0,
+                        message="GET hits_total inflated by arbitrary workload: {}".format(last["memtier_hits_total"]))
+        env.assertEqual(last["memtier_misses_total"], 0,
+                        message="GET misses_total inflated by arbitrary workload: {}".format(last["memtier_misses_total"]))
+        # Cross-check vs final JSON. Band (mirrors F5): the exporter dies with the
+        # process and the last pre-exit scrape lags the final JSON by the in-flight
+        # second, so an exact equality would flake; the band catches a gross
+        # under-count and any double-count (scrape must never exceed JSON).
+        _jh, jm = _json_arbitrary_totals(json_path)
+        env.assertTrue(jm > 0, message="JSON reported no arbitrary misses")
+        env.assertTrue(0.5 * jm <= am <= jm,
+                       message="arbitrary_misses {} not within [0.5*{}, {}]".format(am, jm, jm))
+    finally:
+        _kill(proc)
+
+
+def test_F22_arbitrary_series_zero_without_command(env):
+    """Without --command the arbitrary series are present and read exactly 0
+    while the benchmark is doing work (reverse leak guard)."""
+    if _is_cluster(env):
+        env.skip()
+        return
+    rd = _new_results_dir()
+    proc, out_path, err_path = _popen_memtier(
+        env, ["--test-time=4", "--ratio=1:1", "--prometheus-port=0"], rd
+    )
+    try:
+        url = wait_for_prometheus_url(out_path, timeout=20)
+        env.assertFalse(url is None, message="no announce line")
+        last = _scrape_last(proc, url,
+                            ["memtier_arbitrary_hits_total", "memtier_arbitrary_misses_total", "memtier_ops_total"])
+        rc = proc.wait()
+        env.assertEqual(rc, 0, message="memtier exit {}: {}".format(rc, _drain(err_path)))
+        env.assertTrue(last["memtier_ops_total"] and last["memtier_ops_total"] > 0,
+                       message="no ops observed")
+        env.assertEqual(last["memtier_arbitrary_hits_total"], 0,
+                        message="arbitrary_hits nonzero without --command")
+        env.assertEqual(last["memtier_arbitrary_misses_total"], 0,
+                        message="arbitrary_misses nonzero without --command")
+    finally:
+        _kill(proc)
+
+
+def test_F23_arbitrary_misses_cluster(env):
+    """Cluster mode: the per-shard arbitrary miss counts aggregate into the two
+    series the same race-free way (proves no partial-shard loss / no double count)."""
+    if not _is_cluster(env):
+        env.skip()
+        return
+    rd = _new_results_dir()
+    json_path = os.path.join(rd, "mb.json")
+    proc, out_path, err_path = _popen_memtier(
+        env,
+        ["--test-time=6", "--prometheus-port=0", "--json-out-file", json_path] + _ARBITRARY_MISS_ARGS,
+        rd,
+    )
+    try:
+        url = wait_for_prometheus_url(out_path, timeout=30)
+        env.assertFalse(url is None, message="no announce line")
+        last = _scrape_last(proc, url, ["memtier_arbitrary_misses_total"], deadline_s=120)
+        rc = proc.wait()
+        env.assertEqual(rc, 0, message="memtier exit {}: {}".format(rc, _drain(err_path)))
+        am = last["memtier_arbitrary_misses_total"]
+        env.assertFalse(am is None, message="arbitrary_misses never scraped")
+        env.assertTrue(am > 0, message="cluster arbitrary_misses stayed 0")
+        _jh, jm = _json_arbitrary_totals(json_path)
+        env.assertTrue(jm > 0, message="JSON reported no arbitrary misses")
+        env.assertTrue(0.5 * jm <= am <= jm,
+                       message="cluster arbitrary_misses {} not within [0.5*{}, {}]".format(am, jm, jm))
+    finally:
+        _kill(proc)
+
+
+def test_F24_arbitrary_misses_accumulate_across_runs(env):
+    """--run-count=2: the arbitrary counters accumulate across the run boundary
+    (monotonic, never reset) -- the value seen in run 2 strictly exceeds the
+    last value seen in run 1."""
+    if _is_cluster(env):
+        env.skip()  # cluster run boundaries covered by F18/F23
+        return
+    rd = _new_results_dir()
+    proc, out_path, err_path = _popen_memtier(
+        env,
+        ["--test-time=4", "--run-count=2", "--prometheus-port=0"] + _ARBITRARY_MISS_ARGS,
+        rd,
+    )
+    samples = []  # (arbitrary_misses, run)
+    try:
+        url = wait_for_prometheus_url(out_path, timeout=20)
+        env.assertFalse(url is None, message="no announce line")
+        deadline = time.time() + 90
+        while proc.poll() is None and time.time() < deadline:
+            r = prom_scrape(url, timeout=2)
+            if r.status == 200:
+                p = prom_parse(r.body)
+                am = prom_sample_value(p, "memtier_arbitrary_misses_total")
+                run = prom_sample_value(p, "memtier_run")
+                if am is not None and run is not None:
+                    samples.append((am, int(run)))
+            time.sleep(0.25)
+        rc = proc.wait()
+        env.assertEqual(rc, 0, message="memtier exit {}: {}".format(rc, _drain(err_path)))
+        env.assertTrue(len(samples) >= 3, message="too few samples: {}".format(samples))
+        # never decreases (monotonic accumulator, same path as memtier_ops_total)
+        prev = -1.0
+        for am, _run in samples:
+            env.assertTrue(am >= prev, message="arbitrary_misses went backwards: {}".format(samples))
+            prev = am
+        run1 = [am for am, run in samples if run == 1]
+        run2 = [am for am, run in samples if run == 2]
+        env.assertTrue(len(run1) > 0 and len(run2) > 0,
+                       message="did not observe both runs: {}".format(samples))
+        env.assertTrue(run1[-1] > 0, message="run 1 produced no arbitrary misses")
+        # run 2 continues accumulating from run 1's total, not from zero.
+        env.assertTrue(run2[-1] > run1[-1],
+                       message="arbitrary_misses did not accumulate across runs: run1={} run2={}".format(
+                           run1[-1], run2[-1]))
     finally:
         _kill(proc)

--- a/tests/unit/prometheus_metrics_test.cpp
+++ b/tests/unit/prometheus_metrics_test.cpp
@@ -17,7 +17,7 @@
  */
 
 /*
- * Unit tests U1-U9 for the pure metrics layer (PLAN.md section 10).
+ * Unit tests U1-U10 for the pure metrics layer (PLAN.md section 10).
  * Assert-style main, no gtest. PURITY: no config.h / version.h / libevent.
  * Links prometheus_metrics.cpp + hdr_histogram (a leaf dep). U2 ships a clamp
  * replica pinned to run_stats.cpp:46-47 instead of linking run_stats.cpp.
@@ -690,6 +690,77 @@ static void U9()
     }
 }
 
+// U10 — arbitrary-command hits/misses series (#483): structural counter/def
+// alignment, positional placement of the two new counter rows, and a sentinel
+// render proving the GET series are NOT folded and the new series render at
+// their own enum index (the kMetricDefs order vs counter_metric_name hazard).
+static void U10()
+{
+    const prom::metric_def *defs = prom::metric_defs();
+    const size_t n = prom::metric_defs_count();
+
+    // (b) positional: the two new rows sit immediately after memtier_retried_ops_total
+    // and before memtier_connections, both typed counter.
+    size_t k = n;
+    for (size_t i = 0; i < n; i++)
+        if (strcmp(defs[i].name, "memtier_retried_ops_total") == 0) {
+            k = i;
+            break;
+        }
+    CHECK(k != n, "U10: memtier_retried_ops_total present");
+    if (k + 3 < n) {
+        CHECK(strcmp(defs[k + 1].name, "memtier_arbitrary_hits_total") == 0,
+              "U10: arbitrary_hits_total follows retried_ops_total");
+        CHECK(defs[k + 1].type == prom::MT_TYPE_COUNTER, "U10: arbitrary_hits_total is a counter");
+        CHECK(strcmp(defs[k + 2].name, "memtier_arbitrary_misses_total") == 0,
+              "U10: arbitrary_misses_total follows arbitrary_hits_total");
+        CHECK(defs[k + 2].type == prom::MT_TYPE_COUNTER, "U10: arbitrary_misses_total is a counter");
+        CHECK(strcmp(defs[k + 3].name, "memtier_connections") == 0,
+              "U10: memtier_connections follows the two new counter rows");
+    }
+
+    // (c) sentinel render: distinct value per counter index. The render loop
+    // walks the contiguous counter-def block in mt_counter order, so for every
+    // enum index m the def at (ops_offset + m) must render value 1000+m. This
+    // proves kMetricDefs order aligns with counter_metric_name across the WHOLE
+    // block — and, for the GET series specifically, that arbitrary is NOT folded
+    // into them (each renders its own sentinel, not a sum).
+    prom::text_renderer r = make_default_renderer();
+    struct hdr_histogram *h = new_hist();
+    metrics_snapshot s;
+    zero_snapshot(s);
+    for (int m = 0; m < MT_NUM_COUNTERS; m++)
+        s.counters[m] = (uint64_t) (1000 + m);
+    std::string body;
+    r.render(body, s, h, 0.0, 0.0, 0);
+    std::string v;
+    size_t ops_off = n;
+    for (size_t i = 0; i < n; i++)
+        if (strcmp(defs[i].name, "memtier_ops_total") == 0) {
+            ops_off = i;
+            break;
+        }
+    CHECK(ops_off != n, "U10: memtier_ops_total present (counter block start)");
+    if (ops_off + (size_t) MT_NUM_COUNTERS <= n) {
+        for (int m = 0; m < MT_NUM_COUNTERS; m++) {
+            const prom::metric_def &d = defs[ops_off + m];
+            char msg[160];
+            snprintf(msg, sizeof(msg), "U10: counter[%d] %s renders sentinel 1000+%d", m, d.name, m);
+            CHECK(d.type == prom::MT_TYPE_COUNTER && find_line_value(body, d.name, v) && atoi(v.c_str()) == 1000 + m,
+                  msg);
+        }
+    }
+
+    // (d) HELP honesty: GET series forward-reference the new series and no longer
+    // claim arbitrary is "not included"; new series name "arbitrary" + "per element".
+    CHECK(body.find("Counts GET-command hits only") != std::string::npos, "U10: GET hits HELP scope retained");
+    CHECK(body.find("memtier_arbitrary_hits_total") != std::string::npos,
+          "U10: GET hits HELP forward-references new series");
+    CHECK(body.find("not included in this total") == std::string::npos, "U10: stale 'not included' HELP removed");
+    CHECK(body.find("per element") != std::string::npos, "U10: new HELP states per-element (key-lookup) granularity");
+    hdr_close(h);
+}
+
 int main()
 {
     U1();
@@ -702,9 +773,10 @@ int main()
     U7();
     U8();
     U9();
+    U10();
 
     if (g_failures == 0) {
-        printf("PASS: all %d checks passed (U1-U9)\n", g_checks);
+        printf("PASS: all %d checks passed (U1-U10)\n", g_checks);
         return 0;
     }
     fprintf(stderr, "FAILED: %d of %d checks failed\n", g_failures, g_checks);

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -28,6 +28,16 @@ race:run_stats::get_total_errors
 race:run_stats::get_total_retry_attempts
 race:run_stats::get_total_retried_ops
 
+# Arbitrary-command hits/misses (#483): the producer tick sums the per-command
+# scalar totals in m_arbitrary_misses[] (run_stats::get_total_arbitrary_hits/
+# misses) while workers bump them in run_stats::update_arbitrary_op_misses. Same
+# benign class as the display getters: the read touches only the monotonic
+# total_hits/total_misses scalars (never the grow-resized per_key_* vectors),
+# live data is approximate, and authoritative totals merge race-free post-join.
+race:run_stats::get_total_arbitrary_hits
+race:run_stats::get_total_arbitrary_misses
+race:run_stats::update_arbitrary_op_misses
+
 # Write-side inline counter bumps read by those getters.
 race:run_stats::inc_error
 race:run_stats::inc_retry_attempt


### PR DESCRIPTION
Closes #483. Follow-up to the built-in Prometheus exporter (#468).

## Problem

The exporter reports `memtier_hits_total` / `memtier_misses_total` from the **GET path only**. Arbitrary-command (`--command`) hits/misses are tracked separately in `run_stats m_arbitrary_misses[]` and were never surfaced — a `--command "GET __key__"` workload showed `0` in `/metrics` while the console and JSON output showed nonzero counts.

## Approach — Option B (additive), chosen over folding

Add two new aggregate COUNTER series; **`memtier_hits_total` / `memtier_misses_total` values are unchanged** (only their HELP text gains a forward reference):

```
memtier_arbitrary_hits_total    counter
memtier_arbitrary_misses_total  counter
```

Aggregate, no per-command label (respects the v1 cardinality decision). A grand total is one PromQL expression: `sum(memtier_hits_total) + sum(memtier_arbitrary_hits_total)`.

Folding arbitrary into the existing series (Option A) was **rejected**: it silently redefines a shipped monotonic counter's meaning across a binary upgrade (stepping every `rate()`/hit-ratio rule with no series rename to signal it) and destroys GET-vs-`--command` decomposability. B costs two enum slots + two def rows + two accessors and never breaks a scraper; the race-safety work is identical either way.

This design was produced by 7 independent implementation proposals, synthesized, then vetted by 7 adversarial maintainer-persona reviews (using the repo's review bars).

## Race safety

New `client_group`/`run_stats` accessors sum only the **per-command scalar totals** in `m_arbitrary_misses[]` (never the `per_key_*` vectors the worker grow-resizes), read at the single off-worker producer point `prom_read_cg_counters` alongside the GET totals. They therefore inherit the monotonic accumulator and the cross-run/restart fold with **no new publish site and no new hot-path work** — the same TSan-documented benign-race class as the existing scalar getters.

## Changes

- `prometheus_metrics.{h,cpp}`: `MT_ARBITRARY_HITS`/`MT_ARBITRARY_MISSES` enum slots before `MT_NUM_COUNTERS`; two `kMetricDefs` rows inserted in the contiguous counter block (after `memtier_retried_ops_total`, before `memtier_connections`) so the render loop's def-vs-enum lockstep holds; `counter_metric_name` cases; GET HELP reworded to forward-reference the new series (values unchanged); render ordinal comments made range-relative.
- `run_stats` / `client_group`: `get_total_arbitrary_hits/misses` (`unsigned long long` — the source fields are 64-bit).
- `memtier_benchmark.cpp`: fill the two slots in `prom_read_cg_counters`.

## Notes for review (intentional)

- The accessor pair duplicates the existing GET pair deliberately (mirrors the established pattern; the source lives in per-command `run_stats` state, not the `client.h` flat-scalar block).
- The arbitrary series are **always present** and read `0` without a miss-trackable `--command` (stable presence beats appearing/disappearing).
- The new accessors are always-compiled but consumed only from the `HAVE_EVHTTP` producer (verified `--disable-prometheus` still links).
- HELP says **key lookups** (a multi-key `HMGET` increments per element), matching how `m_arbitrary_misses` is recorded.

## Tests

- **Unit U10**: positional-placement guard via `prom::metric_defs()`; a full **sentinel render** (`counters[m] = 1000+m`) asserting every counter index renders its own value — proving the GET series are NOT folded and the new series render at their enum index; HELP honesty.
- **Integration**: `F21` (series populated + **exact** Option-B leak guard: GET series stay `0` under an arbitrary-only workload), `F22` (arbitrary series present and `0` without `--command`), `F23` (cluster aggregation — no partial-shard loss / no double-count), `F24` (accumulation across the run boundary, tracked via `memtier_run`).
- Cross-check vs final JSON uses the same tolerance band as the existing `F5` (the exporter dies with the process, so the last pre-exit scrape lags the final JSON by the in-flight second; an exact scrape==JSON identity would be flaky — the exactness lives in U10 and the leak guard).

Verified locally: `make check` (U1–U10), prometheus RLTest standalone 24/25 (the one miss is `F19`, which needs `DEBUG SLEEP` the local redis rejects; it passes in CI), `--disable-prometheus` builds and links, `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only additive metrics sampled off the worker path; existing GET counter values and semantics are preserved.
> 
> **Overview**
> Adds **`memtier_arbitrary_hits_total`** and **`memtier_arbitrary_misses_total`** so `--command` miss-trackable workloads show up in `/metrics` without changing **`memtier_hits_total` / `memtier_misses_total`** (GET-only; HELP text now points at the new series).
> 
> **`run_stats`** / **`client_group`** gain aggregators that sum per-command scalar totals in **`m_arbitrary_misses[]`** (not per-key vectors). The 1 Hz Prometheus producer fills the new **`MT_ARBITRARY_*`** slots in **`prom_read_cg_counters`**, with TSan suppressions for the same benign read-while-worker-update pattern as other live getters.
> 
> Tests: unit **U10** (metric def order + sentinel render), integration **F21–F24** (isolation from GET series, cluster, cross-run accumulation), and updated counter name lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2388207f604cc7102b0e937ce510ade38ac15bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->