### PR TITLE
feat(transaction): reuse one key across a --command rotation in cluster mode

### DIFF
--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -132,6 +132,8 @@ cluster_client::cluster_client(client_group *group) :
         m_txn_observed_rotation_seq(0),
         m_txn_staged_key_index(0),
         m_txn_has_staged_key(false),
+        m_txn_round_key_index(0),
+        m_txn_round_key_valid(false),
         m_txn_pin_lost_warned(false),
         m_strict_no_route_attempts(0),
         m_last_no_replica_warning_ts(0)
@@ -193,6 +195,11 @@ void cluster_client::txn_release_pin()
         m_key_index_pools[m_txn_pinned_conn_id]->push(m_txn_staged_key_index);
         m_txn_has_staged_key = false;
     }
+    // Forget the rotation's shared key: a dropped pin restarts the rotation on
+    // a fresh pin/lookahead, which will adopt a new key. Leaving this set would
+    // make the re-pinned rotation reuse the old key while the fresh lookahead
+    // key goes unconsumed -- burning a sequential index at the next wrap.
+    m_txn_round_key_valid = false;
     m_txn_pinned_conn_id = -1;
 }
 
@@ -203,6 +210,7 @@ void cluster_client::disconnect(void)
     // m_connections (which would be an out-of-bounds access).
     m_txn_pinned_conn_id = -1;
     m_txn_has_staged_key = false;
+    m_txn_round_key_valid = false;
     m_txn_pin_lost_warned = false;
 
     unsigned int conn_size = m_connections.size();
@@ -1805,6 +1813,7 @@ bool cluster_client::create_arbitrary_request(unsigned int command_index, struct
             m_txn_observed_rotation_seq = m_arbitrary_command_rotation_seq;
             m_txn_pinned_conn_id = -1;
             m_txn_has_staged_key = false;
+            m_txn_round_key_valid = false;
             m_txn_pin_lost_warned = false;
             /* Wake up connections that were held back by hold_pipeline so
              * they can participate in the new rotation's lookahead. */
@@ -1924,17 +1933,27 @@ bool cluster_client::create_arbitrary_request(unsigned int command_index, struct
             return false;
         }
 
-        /* For keyed commands the lookahead may have pre-generated a key
-         * stored in m_txn_staged_key_index. Use it so the per-iter key
-         * counter advances exactly once per rotation. */
+        /* Every keyed --command in one rotation must resolve to the SAME key so
+         * the whole WATCH/MULTI/EXEC unit hits a single slot -- otherwise the
+         * cluster rejects it with CROSSSLOT. The first keyed command adopts the
+         * lookahead-staged key (or, on the fallback path, generates one) as the
+         * rotation key; every later keyed command reuses it. Reusing the staged
+         * index also keeps the per-iter key counter advancing exactly once per
+         * rotation. */
         if (cmd.keys_count > 0) {
-            if (m_txn_has_staged_key) {
+            if (m_txn_round_key_valid) {
+                m_key_index_pools[conn_id]->push(m_txn_round_key_index);
+            } else if (m_txn_has_staged_key) {
                 m_key_index_pools[conn_id]->push(m_txn_staged_key_index);
+                m_txn_round_key_index = m_txn_staged_key_index;
+                m_txn_round_key_valid = true;
                 m_txn_has_staged_key = false;
             } else if (m_key_index_pools[conn_id]->empty()) {
                 unsigned long long key_index;
                 client::get_key_for_conn(command_index, conn_id, &key_index);
                 m_key_index_pools[conn_id]->push(key_index);
+                m_txn_round_key_index = key_index;
+                m_txn_round_key_valid = true;
             }
         }
         client::create_arbitrary_request(command_index, timestamp, conn_id);

--- a/cluster_client.h
+++ b/cluster_client.h
@@ -94,6 +94,16 @@ protected:
     // corrupting the pool's (command_index, key_index) pair invariant.
     unsigned long long m_txn_staged_key_index;
     bool m_txn_has_staged_key;
+    // Key index adopted as *the* key for the whole pinned rotation. In
+    // --transaction mode every keyed --command in one rotation (e.g.
+    // WATCH/GET/SETEX inside WATCH...MULTI...EXEC) must resolve to the SAME
+    // key so they all hash to one slot -- otherwise the cluster rejects the
+    // transaction with CROSSSLOT. The first keyed command adopts the
+    // lookahead-staged key here; subsequent keyed commands reuse it instead of
+    // generating their own. Reset (m_txn_round_key_valid=false) whenever the
+    // rotation wraps or the pin is dropped mid-rotation.
+    unsigned long long m_txn_round_key_index;
+    bool m_txn_round_key_valid;
     // Set when we emit the "pin connection lost mid-rotation" warning so we
     // don't spam it on every hold_pipeline() call during the outage.
     bool m_txn_pin_lost_warned;

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -2498,7 +2498,9 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
     if (cfg->transaction && !cfg->cluster_mode) {
         fprintf(stderr, "warning: --transaction has no effect without --cluster-mode. "
                         "In standalone mode every client uses a single connection so commands "
-                        "are already serialized in order.\n");
+                        "are already serialized in order. Note the cluster-mode behavior of "
+                        "collapsing every __key__ in a rotation to a single key does NOT apply "
+                        "here: each keyed --command keeps its own key.\n");
     }
 
     if ((cfg->cluster_mode && !verify_cluster_option(cfg)) ||
@@ -2588,11 +2590,18 @@ void usage()
         "      --cluster-mode             Run client in cluster mode\n"
         "      --transaction              In --cluster-mode, pin one full rotation of --command entries to\n"
         "                                 a single shard connection so that keyless commands (MULTI/EXEC/\n"
-        "                                 UNWATCH) stay on the same connection as the keyed ones. Hash-tag\n"
-        "                                 your keys so they map to the same slot, otherwise the cross-slot\n"
-        "                                 keyed commands of the same rotation will get MOVED back. In\n"
-        "                                 standalone mode this flag is a no-op (each client already runs\n"
-        "                                 through a single connection). Requires at least one --command.\n"
+        "                                 UNWATCH) stay on the same connection as the keyed ones. Every\n"
+        "                                 __key__ in a rotation resolves to the same key (taken from the\n"
+        "                                 first keyed command's --command-key-pattern), so keyed commands\n"
+        "                                 (e.g. WATCH/GET/SETEX) all hit one slot and one key: the WATCH\n"
+        "                                 guards the key the SETEX writes and the WATCH/MULTI/EXEC unit\n"
+        "                                 runs without CROSSSLOT errors -- no hash-tag needed. Caveat: keep\n"
+        "                                 the literal text around __key__ (including any {tag}) identical\n"
+        "                                 across keyed commands; differing affixes still hash to different\n"
+        "                                 slots and get MOVED. This same-key collapse happens only in\n"
+        "                                 --cluster-mode; in standalone this flag is a no-op (each client\n"
+        "                                 already runs through a single connection and keys are NOT\n"
+        "                                 collapsed). Requires at least one --command.\n"
         "                                 --pipeline > 1 is supported: each rotation is sent contiguously\n"
         "                                 on its pinned connection, so multiple whole transactions can be\n"
         "                                 in flight without interleaving MULTI/EXEC blocks.\n"

--- a/tests/test_cluster_transaction.py
+++ b/tests/test_cluster_transaction.py
@@ -40,6 +40,11 @@ TRANSACTION_BREAKAGE_PATTERNS = [
     "DISCARD without MULTI",
 ]
 
+# Cluster rejects a multi-key access whose keys don't all hash to one slot.
+# With --transaction every __key__ in a rotation must resolve to the SAME key,
+# so a WATCH/GET/SETEX rotation stays single-slot even without a hash tag.
+CROSSSLOT_PATTERN = "CROSSSLOT"
+
 
 def _read_stderr(run_config):
     path = "{0}/mb.stderr".format(run_config.results_dir)
@@ -543,6 +548,112 @@ def test_transaction_appears_in_config_and_json_output(env):
             cfg_section.get("transaction"), "true",
             message="JSON configuration.transaction expected 'true', got {!r}".format(
                 cfg_section.get("transaction")))
+    finally:
+        if env.getNumberOfFailedAssertion() > failed:
+            debugPrintMemtierOnError(run_config, env)
+
+
+def test_transaction_same_key_no_hash_tag_no_crossslot(env):
+    """The exact issue repro: WATCH/GET/MULTI/SETEX/EXEC/UNWATCH where each
+    keyed command uses a bare __key__ with NO hash tag and --command-key-
+    pattern=R. Because --transaction now reuses one key for the whole
+    rotation, all three keyed commands hit a single slot, so the cluster
+    must NOT raise CROSSSLOT and the transaction must stay intact."""
+    if not env.isCluster():
+        env.skip()
+        return
+
+    # No hash tag, random key pattern: pre-change this would have generated a
+    # different key per command and the WATCH/MULTI/EXEC unit would be torn
+    # across slots (CROSSSLOT / MOVED).
+    _flush_cluster(env)
+    cmds = [
+        '--command=WATCH __key__',
+        '--command=GET   __key__',
+        '--command=MULTI',
+        '--command=SETEX __key__ 7200 __data__',
+        '--command=EXEC',
+        '--command=UNWATCH',
+        '--command-key-pattern=R',
+        '--key-minimum=1',
+        '--key-maximum=1000',
+    ]
+    ok, run_config, stderr = _run_transaction_workload(env, cmds)
+
+    failed = env.getNumberOfFailedAssertion()
+    try:
+        env.assertTrue(ok, message="memtier_benchmark exited non-zero")
+        _assert_no_transaction_breakage(env, stderr)
+        env.assertTrue(
+            CROSSSLOT_PATTERN not in stderr,
+            message="CROSSSLOT error present — keyed commands in the rotation "
+                    "resolved to different keys/slots instead of sharing one")
+        # Liveness floor: the SETEX inside the transaction must actually have
+        # committed keys. Without this a regression that silently emits no
+        # keyed writes (clean stderr, exit 0) would pass the checks above.
+        total = sum(_dbsize_per_shard(env).values())
+        env.assertGreater(
+            total, 0,
+            message="no keys committed by the SETEX — the transaction "
+                    "produced no side effects")
+    finally:
+        if env.getNumberOfFailedAssertion() > failed:
+            debugPrintMemtierOnError(run_config, env)
+
+
+def test_transaction_same_key_reused_within_rotation(env):
+    """A SET then an APPEND in the same MULTI/EXEC rotation, both on a bare
+    __key__ with no hash tag, must land on the SAME key. We SET 'aa' then
+    APPEND 'bb'; if both commands share one key every populated key ends up
+    'aabb'. This distinguishes same-key reuse from a dropped/misrouted first
+    command: if the SET were dropped or hit a different key, APPEND-on-missing
+    would leave 'bb' instead of 'aabb'. And if the two commands resolved to
+    different keys with no hash tag they'd hash to different slots and the
+    cluster would reject the transaction with CROSSSLOT."""
+    if not env.isCluster():
+        env.skip()
+        return
+
+    _flush_cluster(env)
+    cmds = [
+        '--command=MULTI',
+        '--command=SET    __key__ aa',
+        '--command=APPEND __key__ bb',
+        '--command=EXEC',
+        '--command-key-pattern=R',
+        '--key-prefix=rk-',
+        '--key-minimum=1',
+        '--key-maximum=40',
+    ]
+    ok, run_config, stderr = _run_transaction_workload(
+        env, cmds, threads=1, clients=1, requests=400)
+
+    failed = env.getNumberOfFailedAssertion()
+    try:
+        env.assertTrue(ok, message="memtier_benchmark exited non-zero")
+        _assert_no_transaction_breakage(env, stderr)
+        env.assertTrue(
+            CROSSSLOT_PATTERN not in stderr,
+            message="CROSSSLOT error present — the SET and APPEND in a "
+                    "rotation resolved to different keys")
+
+        # Every populated key across all shards must hold 'aabb', proving the
+        # SET and the APPEND in each rotation targeted the same key (a dropped
+        # or misrouted SET would leave 'bb').
+        total_keys = 0
+        for conn in env.getOSSMasterNodesConnectionList():
+            for key in conn.scan_iter(match="rk-*"):
+                total_keys += 1
+                value = conn.execute_command("GET", key)
+                env.assertEqual(
+                    value, b"aabb",
+                    message="key {!r} holds {!r}, expected 'aabb' — the SET "
+                            "and APPEND in the rotation did not share a "
+                            "key".format(key, value))
+        env.assertGreater(
+            total_keys, 0,
+            message="no rk-* keys were written; the transaction produced no "
+                    "side effects")
     finally:
         if env.getNumberOfFailedAssertion() > failed:
             debugPrintMemtierOnError(run_config, env)


### PR DESCRIPTION
## Overview

In `--cluster-mode --transaction`, every `__key__` in a `--command` rotation now resolves to the **same key**, so all keyed commands of a `WATCH`/`MULTI`/`EXEC` unit (e.g. `WATCH`/`GET`/`SETEX`) hash to a single slot **and** a single key. This makes optimistic-lock transaction benchmarks both correct and CROSSSLOT-free without requiring a hash-tag prefix.

Previously `--transaction` only pinned a rotation to one shard connection. That fixes routing of the keyless commands (`MULTI`/`EXEC`/`UNWATCH`), but each keyed `--command` still drew an independent key value — so without a hash tag the keyed commands landed in different slots and the cluster rejected the transaction with `CROSSSLOT`/`MOVED`, and even *with* a hash tag the `WATCH` guarded a different key than the `SETEX` wrote, making the transaction semantically meaningless.

## Behavior

- The key for a rotation is taken from the **first keyed command's** `--command-key-pattern`; later keyed commands reuse it.
- Works without a hash tag. **Caveat:** keep the literal text around `__key__` (including any `{tag}`) identical across keyed commands — differing affixes still hash to different slots and get `MOVED`.
- **Cluster-mode only.** In standalone, `--transaction` remains a no-op and each keyed command keeps its own key. This divergence is documented in `--help` and the standalone warning.
- **Behavior change:** rotations that previously drew multiple distinct keys within a slot (via a hash tag) now collapse to one key.

## Example

This now runs cleanly with no hash tag and no `CROSSSLOT`:

```
memtier_benchmark --cluster-mode --transaction \
  --command='WATCH __key__' --command='GET __key__' --command='MULTI' \
  --command='SETEX __key__ 7200 __data__' --command='EXEC' --command='UNWATCH' \
  --command-key-pattern=R
```

## Mechanism

A per-rotation key index (`m_txn_round_key_index` / `m_txn_round_key_valid`) is adopted from the lookahead-staged key by the first keyed command and reused by the rest. The per-iter key counter still advances exactly once per rotation. The rotation key is reset at the rotation boundary, on mid-rotation pin loss (`txn_release_pin`), and on `disconnect`.

## Deferred

- No startup guard rejecting *different* per-command hash-tag affixes within a rotation — documented as a caveat in `--help` instead of enforced, to avoid false-positives on legitimate mixed rotations.

## Test plan

`tests/test_cluster_transaction.py`, run against `OSS_CLUSTER` (3 shards):

- `test_transaction_same_key_no_hash_tag_no_crossslot` — the bare-`__key__` `WATCH/GET/MULTI/SETEX/EXEC/UNWATCH` workload; asserts no `CROSSSLOT` and a committed-keys liveness floor.
- `test_transaction_same_key_reused_within_rotation` — a `SET aa` + `APPEND bb` rotation; asserts every key holds `aabb`, proving both commands hit the same key (not just last-write-wins, and catching a dropped/misrouted first command).
- All pre-existing transaction tests (including the strict `DBSIZE == n` sequential-ingestion check) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional behavior change for cluster transaction rotations (one key per rotation instead of independent keys per keyed command); touches pin/key pool logic where mid-rotation MOVED/disconnect already existed.
> 
> **Overview**
> **Cluster `--transaction` now forces every keyed `--command` in one rotation to share a single key index**, so WATCH/MULTI/EXEC workloads hit one slot (and one Redis key) without hash tags—fixing **CROSSSLOT** and making WATCH guard the same key SETEX writes.
> 
> The cluster client adds **`m_txn_round_key_index` / `m_txn_round_key_valid`**: the first keyed command adopts the lookahead-staged key (or generates one); later keyed commands push that same index into the pool. The rotation key is cleared on rotation wrap, **`txn_release_pin`**, and **`disconnect`** so a dropped pin does not reuse a stale key and burn sequential key indices.
> 
> **Docs:** `--help` and the standalone `--transaction` warning now state that same-key collapse applies only in **`--cluster-mode`**; standalone keeps per-command keys.
> 
> **Tests:** `test_transaction_same_key_no_hash_tag_no_crossslot` and `test_transaction_same_key_reused_within_rotation` (SET+APPEND → `aabb` on cluster).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc94b5c213f6c670931365df0ec328550b0867b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->