### PR TITLE
feat(transaction): break out EXEC aborts and surface live miss/abort rates

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1447,6 +1447,16 @@ unsigned long long client_group::get_total_arbitrary_misses(void)
     return total;
 }
 
+unsigned long long client_group::get_total_arbitrary_aborts(void)
+{
+    unsigned long long total = 0;
+    unsigned int count = active_client_count();
+    for (unsigned int i = 0; i < count; i++) {
+        total += m_clients[i]->get_stats()->get_total_arbitrary_aborts();
+    }
+    return total;
+}
+
 unsigned long int client_group::get_total_retry_attempts(void)
 {
     unsigned long int total = 0;

--- a/client.cpp
+++ b/client.cpp
@@ -473,10 +473,13 @@ bool client::create_arbitrary_request(unsigned int command_index, struct timeval
         } else if (arg->type == key_type) {
             // --transaction: reuse one key for every __key__ in the rotation so
             // the whole WATCH/MULTI/EXEC unit resolves to a single key/slot.
-            // Only when keys are generated (not on the data-import path, which
-            // streams a distinct key per command). cluster_client overrides this
-            // method, so this branch only runs for the non-cluster path.
-            const bool txn_reuse = m_config->transaction && (!m_config->data_import || m_config->generate_keys);
+            // Non-cluster path only: in --cluster-mode, cluster_client drives the
+            // reuse by pushing the rotation key onto m_key_index_pools and relies
+            // on this method draining it via get_key_for_conn, so the fast path
+            // here would leave the pool un-drained. Also skip the data-import
+            // path, which streams a distinct key per command.
+            const bool txn_reuse =
+                m_config->transaction && !m_config->cluster_mode && (!m_config->data_import || m_config->generate_keys);
             if (txn_reuse && m_txn_rotation_key_valid && m_txn_rotation_key_seq == m_arbitrary_command_rotation_seq) {
                 // Same rotation as the cached key: regenerate the identical key
                 // string without advancing the per-iter key cursor.

--- a/client.cpp
+++ b/client.cpp
@@ -167,6 +167,9 @@ client::client(client_group *group) :
         m_arbitrary_command_ratio_count(0),
         m_executed_command_index(0),
         m_arbitrary_command_rotation_seq(0),
+        m_txn_rotation_key_index(0),
+        m_txn_rotation_key_valid(false),
+        m_txn_rotation_key_seq(0),
         m_tot_set_ops(0),
         m_tot_wait_ops(0),
         m_scan_cursor("0"),
@@ -199,6 +202,9 @@ client::client(struct event_base *event_base, benchmark_config *config, abstract
         m_arbitrary_command_ratio_count(0),
         m_executed_command_index(0),
         m_arbitrary_command_rotation_seq(0),
+        m_txn_rotation_key_index(0),
+        m_txn_rotation_key_valid(false),
+        m_txn_rotation_key_seq(0),
         m_tot_set_ops(0),
         m_tot_wait_ops(0),
         m_scan_cursor("0"),
@@ -465,10 +471,29 @@ bool client::create_arbitrary_request(unsigned int command_index, struct timeval
         if (arg->type == const_type) {
             cmd_size += m_connections[conn_id]->send_arbitrary_command(arg);
         } else if (arg->type == key_type) {
-            unsigned long long key_index;
-            get_key_response res = get_key_for_conn(command_index, conn_id, &key_index);
-            /* If key not available for this connection, we have a bug of sending partial request */
-            assert(res == available_for_conn);
+            // --transaction: reuse one key for every __key__ in the rotation so
+            // the whole WATCH/MULTI/EXEC unit resolves to a single key/slot.
+            // Only when keys are generated (not on the data-import path, which
+            // streams a distinct key per command). cluster_client overrides this
+            // method, so this branch only runs for the non-cluster path.
+            const bool txn_reuse = m_config->transaction && (!m_config->data_import || m_config->generate_keys);
+            if (txn_reuse && m_txn_rotation_key_valid && m_txn_rotation_key_seq == m_arbitrary_command_rotation_seq) {
+                // Same rotation as the cached key: regenerate the identical key
+                // string without advancing the per-iter key cursor.
+                m_obj_gen->generate_key(m_txn_rotation_key_index);
+            } else {
+                unsigned long long key_index;
+                get_key_response res = get_key_for_conn(command_index, conn_id, &key_index);
+                /* If key not available for this connection, we have a bug of sending partial request */
+                assert(res == available_for_conn);
+                if (txn_reuse) {
+                    // First keyed command of the rotation: adopt this key for
+                    // the rest of the rotation.
+                    m_txn_rotation_key_index = key_index;
+                    m_txn_rotation_key_valid = true;
+                    m_txn_rotation_key_seq = m_arbitrary_command_rotation_seq;
+                }
+            }
 
             // when we have static data mixed with the key placeholder
             if (arg->has_key_affixes) {

--- a/client.h
+++ b/client.h
@@ -86,6 +86,17 @@ protected:
     // mirror the ratio-counter state machine.
     unsigned long long m_arbitrary_command_rotation_seq;
 
+    // --transaction (non-cluster path): reuse a single generated key for every
+    // __key__ in one --command rotation so a WATCH/MULTI/EXEC unit hits one key
+    // (and therefore one slot), avoiding CROSSSLOT against a slot-enforcing
+    // single endpoint (e.g. a Redis Enterprise proxy). m_txn_rotation_key_seq
+    // records the rotation_seq the cached index was generated for; a mismatch
+    // means a new rotation has started and the key must be regenerated. The
+    // --cluster-mode path has its own equivalent in cluster_client.
+    unsigned long long m_txn_rotation_key_index;
+    bool m_txn_rotation_key_valid;
+    unsigned long long m_txn_rotation_key_seq;
+
     unsigned long long m_tot_set_ops;  // Total number of SET ops
     unsigned long long m_tot_wait_ops; // Total number of WAIT ops
 

--- a/client.h
+++ b/client.h
@@ -305,6 +305,7 @@ public:
     unsigned long int get_total_misses(void);
     unsigned long long get_total_arbitrary_hits(void);
     unsigned long long get_total_arbitrary_misses(void);
+    unsigned long long get_total_arbitrary_aborts(void);
     unsigned long int get_total_retry_attempts(void);
     unsigned long int get_total_retried_ops(void);
     unsigned long int get_total_errors(void);

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -2495,14 +2495,6 @@ static int config_parse_args(int argc, char *argv[], struct benchmark_config *cf
         return -1;
     }
 
-    if (cfg->transaction && !cfg->cluster_mode) {
-        fprintf(stderr, "warning: --transaction has no effect without --cluster-mode. "
-                        "In standalone mode every client uses a single connection so commands "
-                        "are already serialized in order. Note the cluster-mode behavior of "
-                        "collapsing every __key__ in a rotation to a single key does NOT apply "
-                        "here: each keyed --command keeps its own key.\n");
-    }
-
     if ((cfg->cluster_mode && !verify_cluster_option(cfg)) ||
         (cfg->arbitrary_commands->is_defined() && !verify_arbitrary_command_option(cfg))) {
         return -1;
@@ -2588,23 +2580,24 @@ void usage()
         "  -x, --run-count=NUMBER         Number of full-test iterations to perform\n"
         "  -D, --debug                    Print debug output\n"
         "      --cluster-mode             Run client in cluster mode\n"
-        "      --transaction              In --cluster-mode, pin one full rotation of --command entries to\n"
-        "                                 a single shard connection so that keyless commands (MULTI/EXEC/\n"
-        "                                 UNWATCH) stay on the same connection as the keyed ones. Every\n"
-        "                                 __key__ in a rotation resolves to the same key (taken from the\n"
-        "                                 first keyed command's --command-key-pattern), so keyed commands\n"
-        "                                 (e.g. WATCH/GET/SETEX) all hit one slot and one key: the WATCH\n"
-        "                                 guards the key the SETEX writes and the WATCH/MULTI/EXEC unit\n"
-        "                                 runs without CROSSSLOT errors -- no hash-tag needed. Caveat: keep\n"
-        "                                 the literal text around __key__ (including any {tag}) identical\n"
-        "                                 across keyed commands; differing affixes still hash to different\n"
-        "                                 slots and get MOVED. This same-key collapse happens only in\n"
-        "                                 --cluster-mode; in standalone this flag is a no-op (each client\n"
-        "                                 already runs through a single connection and keys are NOT\n"
-        "                                 collapsed). Requires at least one --command.\n"
-        "                                 --pipeline > 1 is supported: each rotation is sent contiguously\n"
-        "                                 on its pinned connection, so multiple whole transactions can be\n"
-        "                                 in flight without interleaving MULTI/EXEC blocks.\n"
+        "      --transaction              Treat one full rotation of --command entries as a transactional\n"
+        "                                 unit (e.g. WATCH/GET/MULTI/SETEX/EXEC/UNWATCH). Every __key__ in\n"
+        "                                 a rotation resolves to the same key (taken from the first keyed\n"
+        "                                 command's --command-key-pattern), so all keyed commands hit one\n"
+        "                                 key and one slot: the WATCH guards the key the SETEX writes and\n"
+        "                                 the unit runs without CROSSSLOT errors -- no hash-tag needed.\n"
+        "                                 This same-key behavior applies in every mode, so it also works\n"
+        "                                 against a single endpoint fronting a sharded backend (e.g. a\n"
+        "                                 Redis Enterprise proxy) where keyed commands must share a slot.\n"
+        "                                 In --cluster-mode it additionally pins the whole rotation to the\n"
+        "                                 owning shard connection so the keyless commands (MULTI/EXEC/\n"
+        "                                 UNWATCH) stay with the keyed ones. Caveat: keep the literal text\n"
+        "                                 around __key__ (including any {tag}) identical across keyed\n"
+        "                                 commands; differing affixes still hash to different slots.\n"
+        "                                 Requires at least one --command.\n"
+        "                                 --pipeline > 1 is supported: in --cluster-mode each rotation is\n"
+        "                                 sent contiguously on its pinned connection, so multiple whole\n"
+        "                                 transactions can be in flight without interleaving MULTI/EXEC.\n"
         "                                 Note: if --reconnect-on-error triggers mid-rotation, the\n"
         "                                 interrupted rotation's stats will be inaccurate (server-side\n"
         "                                 WATCH/MULTI state is lost on reconnect).\n"

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -3547,6 +3547,7 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     unsigned long int cur_bytes_sec = 0;
     unsigned long int prev_hits = 0;
     unsigned long int prev_misses = 0;
+    unsigned long int prev_aborts = 0;
     unsigned long int prev_errors = 0;
     unsigned long int prev_retry_attempts = 0;
 
@@ -3631,6 +3632,7 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
         unsigned long int total_connection_errors = 0;
         unsigned long int total_hits = 0;
         unsigned long int total_misses = 0;
+        unsigned long int total_aborts = 0;
         unsigned long int total_errors = 0;
         unsigned long int total_retry_attempts = 0;
         unsigned long int total_retried_ops = 0;
@@ -3670,8 +3672,18 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
                 total_retried_ops += (*i)->m_cg->get_total_retried_ops();
             }
             if (cfg->realtime_latencies) {
-                total_hits += (*i)->m_cg->get_total_hits();
-                total_misses += (*i)->m_cg->get_total_misses();
+                // In --command (arbitrary) mode the SET/GET hit/miss counters
+                // stay zero, so pull the live miss/abort figures from the
+                // arbitrary-command counters instead. Aborts are the EXEC
+                // optimistic-lock subset of misses (see run_stats).
+                if (cfg->arbitrary_commands->is_defined()) {
+                    total_hits += (*i)->m_cg->get_total_arbitrary_hits();
+                    total_misses += (*i)->m_cg->get_total_arbitrary_misses();
+                    total_aborts += (*i)->m_cg->get_total_arbitrary_aborts();
+                } else {
+                    total_hits += (*i)->m_cg->get_total_hits();
+                    total_misses += (*i)->m_cg->get_total_misses();
+                }
             }
             thread_counter++;
             float factor = ((float) (thread_counter - 1) / thread_counter);
@@ -3772,6 +3784,23 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
             else
                 snprintf(avg_miss_str, sizeof(avg_miss_str), "  -  ");
 
+            // Abort ratio (--transaction only): EXEC optimistic-lock aborts as a
+            // share of the same lookup denominator. Aborts are a subset of misses,
+            // so abort% <= miss%. It's a blended live indicator across all
+            // arbitrary commands; the authoritative per-command abort rate is in
+            // the final table / "abort rate" warning.
+            char cur_abort_str[16], avg_abort_str[16];
+            if (cur_lookups > 0)
+                snprintf(cur_abort_str, sizeof(cur_abort_str), "%5.2f%%",
+                         100.0 * (double) (total_aborts - prev_aborts) / (double) cur_lookups);
+            else
+                snprintf(cur_abort_str, sizeof(cur_abort_str), "  -  ");
+            if (tot_lookups > 0)
+                snprintf(avg_abort_str, sizeof(avg_abort_str), "%5.2f%%",
+                         100.0 * (double) total_aborts / (double) tot_lookups);
+            else
+                snprintf(avg_abort_str, sizeof(avg_abort_str), "  -  ");
+
             char line1[640];
             int line1_used = 0;
             if (total_connection_errors > 0) {
@@ -3785,6 +3814,13 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
                     snprintf(line1, sizeof(line1),
                              "%s throughput %s (avg: %s) ops/sec   %s/sec (avg: %s/sec)   miss %s (avg: %s)", tag,
                              cur_ops_str, avg_ops_str, cur_bytes_str, bytes_str, cur_miss_str, avg_miss_str);
+            }
+            // Abort tail: only under --transaction so default arbitrary-command
+            // output is unchanged for existing log-scraping.
+            if (cfg->transaction && line1_used > 0 && (size_t) line1_used < sizeof(line1)) {
+                int n = snprintf(line1 + line1_used, sizeof(line1) - line1_used, "   abort %s (avg: %s)", cur_abort_str,
+                                 avg_abort_str);
+                if (n > 0) line1_used += n;
             }
             // Retry/error tail: only printed when --retry-on-error is enabled
             // so existing CI / log-scraping is unaffected by default.
@@ -3892,6 +3928,7 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
 
         prev_hits = total_hits;
         prev_misses = total_misses;
+        prev_aborts = total_aborts;
         prev_errors = total_errors;
         prev_retry_attempts = total_retry_attempts;
 

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -510,6 +510,32 @@ unsigned long long run_stats::get_total_arbitrary_misses(void)
     return t;
 }
 
+// A command whose null/aborted reply should be reported as a transaction
+// "abort" rather than a cache "miss". Today that is EXEC: in a WATCH/MULTI/EXEC
+// unit, EXEC returns a null array iff the optimistic lock failed (a watched key
+// changed), which is an abort, not a missing key. This is a display-only
+// reinterpretation: the count still lives in the per-command miss counter
+// (m_arbitrary_misses[i].total_misses), so global miss totals are unchanged.
+bool run_stats::is_abort_command_type(const std::string &command_type)
+{
+    return command_type == "EXEC";
+}
+
+// Sum of misses attributed to abort-semantics commands (EXEC). Reuses the miss
+// counter; selection is by command_type so no separate tracking is needed.
+unsigned long long run_stats::get_total_arbitrary_aborts(void)
+{
+    unsigned long long t = 0;
+    if (m_config == NULL || !m_config->arbitrary_commands->is_defined()) return 0;
+    for (size_t i = 0; i < m_arbitrary_misses.size(); ++i) {
+        if (i < m_config->arbitrary_commands->size() &&
+            is_abort_command_type(m_config->arbitrary_commands->at(i).command_type)) {
+            t += m_arbitrary_misses[i].total_misses;
+        }
+    }
+    return t;
+}
+
 #define AVERAGE(total, count) ((unsigned int) ((count) > 0 ? (total) / (count) : 0))
 #define USEC_FORMAT(value) (value) / 1000000, (value) % 1000000
 
@@ -1195,7 +1221,8 @@ void result_print_to_json(json_handler *jsonhandler, const char *type, double op
                           double moved, double ask, double kbs, double kbs_rx, double kbs_tx, double latency,
                           long m_total_latency, long ops, double connection_errors_sec, long connection_errors,
                           std::vector<double> quantile_list, struct hdr_histogram *latency_histogram,
-                          std::vector<unsigned int> timestamps, std::vector<one_sec_cmd_stats> timeserie_stats)
+                          std::vector<unsigned int> timestamps, std::vector<one_sec_cmd_stats> timeserie_stats,
+                          double aborts = -1.0)
 {
     if (jsonhandler != NULL) { // Added for double verification in case someone accidently send NULL.
         jsonhandler->open_nesting(type);
@@ -1203,6 +1230,10 @@ void result_print_to_json(json_handler *jsonhandler, const char *type, double op
         jsonhandler->write_obj("Ops/sec", "%.2f", ops_sec);
         jsonhandler->write_obj("Hits/sec", "%.2f", hits);
         jsonhandler->write_obj("Misses/sec", "%.2f", miss);
+
+        // Only emitted under --transaction (callers pass aborts >= 0). Aborts are
+        // the EXEC optimistic-lock subset already included in Misses/sec.
+        if (aborts >= 0) jsonhandler->write_obj("Aborts/sec", "%.2f", aborts);
 
         if (moved >= 0) jsonhandler->write_obj("MOVED/sec", "%.2f", moved);
 
@@ -1540,6 +1571,47 @@ void run_stats::print_missess_sec_column(output_table &table,
     table.add_column(column);
 }
 
+void run_stats::print_aborts_sec_column(output_table &table,
+                                        const std::vector<aggregated_command_type_stats> *aggregated)
+{
+    table_el el;
+    table_column column(12);
+
+    column.elements.push_back(*el.init_str("%12s ", "Aborts/sec"));
+    column.elements.push_back(*el.init_str("%s", "-------------"));
+
+    // Only abort-semantics commands (EXEC) contribute; every other row shows
+    // 0.00. The count is the same value carried in that command's Misses/sec
+    // (display-only reinterpretation), so Aborts is a labeled subset of Misses.
+    unsigned long int test_duration_usec = ts_diff(m_start_time, m_end_time);
+    unsigned long long total_aborts = 0;
+    if (aggregated != nullptr) {
+        for (const auto &agg : *aggregated) {
+            unsigned long long aborts = is_abort_command_type(agg.command_type) ? agg.total_misses : 0;
+            double aborts_sec =
+                test_duration_usec > 0 ? (double) aborts / (double) test_duration_usec * 1000000.0 : 0.0;
+            column.elements.push_back(*el.init_double("%12.2f ", aborts_sec));
+            total_aborts += aborts;
+        }
+    } else {
+        for (size_t i = 0; i < m_totals.m_ar_commands.size(); i++) {
+            bool is_abort = m_config != NULL && i < m_config->arbitrary_commands->size() &&
+                            is_abort_command_type(m_config->arbitrary_commands->at(i).command_type);
+            unsigned long long aborts =
+                (is_abort && i < m_arbitrary_misses.size()) ? m_arbitrary_misses[i].total_misses : 0;
+            double aborts_sec =
+                test_duration_usec > 0 ? (double) aborts / (double) test_duration_usec * 1000000.0 : 0.0;
+            column.elements.push_back(*el.init_double("%12.2f ", aborts_sec));
+            total_aborts += aborts;
+        }
+    }
+    double total_aborts_sec =
+        test_duration_usec > 0 ? (double) total_aborts / (double) test_duration_usec * 1000000.0 : 0.0;
+    column.elements.push_back(*el.init_double("%12.2f ", total_aborts_sec));
+
+    table.add_column(column);
+}
+
 void run_stats::print_moved_sec_column(output_table &table,
                                        const std::vector<aggregated_command_type_stats> *aggregated)
 {
@@ -1839,7 +1911,9 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
                                      avg_latency, agg.stats.m_total_latency, agg.stats.m_ops,
                                      0.0, // connection_errors_sec (not tracked per command)
                                      0,   // connection_errors (not tracked per command)
-                                     quantiles_list, agg.latency_hist, timestamps, agg.per_second_stats);
+                                     quantiles_list, agg.latency_hist, timestamps, agg.per_second_stats,
+                                     (m_config->transaction && is_abort_command_type(agg.command_type)) ? misses_sec
+                                                                                                        : -1.0);
             }
         } else {
             // Original per-command behavior
@@ -1858,16 +1932,17 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
                     misses_sec = (double) m_arbitrary_misses[i].total_misses / (double) test_duration_usec * 1000000.0;
                 }
 
-                result_print_to_json(jsonhandler, command_name.c_str(), m_totals.m_ar_commands[i].m_ops_sec, hits_sec,
-                                     misses_sec, cluster_mode ? m_totals.m_ar_commands[i].m_moved_sec : -1,
-                                     cluster_mode ? m_totals.m_ar_commands[i].m_ask_sec : -1,
-                                     m_totals.m_ar_commands[i].m_bytes_sec, m_totals.m_ar_commands[i].m_bytes_sec_rx,
-                                     m_totals.m_ar_commands[i].m_bytes_sec_tx, m_totals.m_ar_commands[i].m_latency,
-                                     m_totals.m_ar_commands[i].m_total_latency, m_totals.m_ar_commands[i].m_ops,
-                                     0.0, // connection_errors_sec (not tracked per command)
-                                     0,   // connection_errors (not tracked per command)
-                                     quantiles_list, arbitrary_command_latency_histogram, timestamps,
-                                     arbitrary_command_stats);
+                result_print_to_json(
+                    jsonhandler, command_name.c_str(), m_totals.m_ar_commands[i].m_ops_sec, hits_sec, misses_sec,
+                    cluster_mode ? m_totals.m_ar_commands[i].m_moved_sec : -1,
+                    cluster_mode ? m_totals.m_ar_commands[i].m_ask_sec : -1, m_totals.m_ar_commands[i].m_bytes_sec,
+                    m_totals.m_ar_commands[i].m_bytes_sec_rx, m_totals.m_ar_commands[i].m_bytes_sec_tx,
+                    m_totals.m_ar_commands[i].m_latency, m_totals.m_ar_commands[i].m_total_latency,
+                    m_totals.m_ar_commands[i].m_ops,
+                    0.0, // connection_errors_sec (not tracked per command)
+                    0,   // connection_errors (not tracked per command)
+                    quantiles_list, arbitrary_command_latency_histogram, timestamps, arbitrary_command_stats,
+                    (m_config->transaction && is_abort_command_type(command_list[i].command_type)) ? misses_sec : -1.0);
             }
         }
 
@@ -1952,12 +2027,17 @@ void run_stats::print_json(json_handler *jsonhandler, arbitrary_command_list &co
             totals_misses_sec = (double) all_misses / (double) dur_usec * 1000000.0;
         }
     }
+    double totals_aborts_sec = -1.0;
+    if (m_config->transaction && print_arbitrary_commands_results()) {
+        unsigned long int dur_usec = ts_diff(m_start_time, m_end_time);
+        totals_aborts_sec = dur_usec > 0 ? (double) get_total_arbitrary_aborts() / (double) dur_usec * 1000000.0 : 0.0;
+    }
     result_print_to_json(jsonhandler, "Totals", m_totals.m_ops_sec, totals_hits_sec, totals_misses_sec,
                          cluster_mode ? m_totals.m_moved_sec : -1, cluster_mode ? m_totals.m_ask_sec : -1,
                          m_totals.m_bytes_sec, m_totals.m_bytes_sec_rx, m_totals.m_bytes_sec_tx, m_totals.m_latency,
                          m_totals.m_total_latency, m_totals.m_ops, m_totals.m_connection_errors_sec,
                          m_totals.m_connection_errors, quantiles_list, m_totals.latency_histogram, timestamps,
-                         total_stats);
+                         total_stats, totals_aborts_sec);
 
     // -----------------------------------------------------------------
     // Read-preference observability (Step 2f).
@@ -2225,6 +2305,12 @@ void run_stats::print(FILE *out, benchmark_config *config, const char *header /*
     // Misses/sec column
     print_missess_sec_column(table, aggregated_ptr);
 
+    // Aborts/sec column (transaction mode only): EXEC optimistic-lock aborts,
+    // broken out from the generic Misses column.
+    if (config->transaction) {
+        print_aborts_sec_column(table, aggregated_ptr);
+    }
+
     // Moved & ASK column (relevant only for cluster mode)
     if (config->cluster_mode) {
         print_moved_sec_column(table, aggregated_ptr);
@@ -2261,9 +2347,11 @@ void run_stats::print(FILE *out, benchmark_config *config, const char *header /*
                 if (total == 0) continue;
                 double miss_rate = (double) agg.total_misses / (double) total;
                 if (miss_rate > miss_threshold) {
-                    fprintf(stderr, "warning: %s miss rate %.2f%% above target %.2f%% (%llu misses / %llu ops)\n",
-                            agg.command_type.c_str(), miss_rate * 100.0, miss_threshold * 100.0, agg.total_misses,
-                            total);
+                    // EXEC nulls are optimistic-lock aborts, not cache misses.
+                    const bool abort = is_abort_command_type(agg.command_type);
+                    fprintf(stderr, "warning: %s %s rate %.2f%% above target %.2f%% (%llu %s / %llu ops)\n",
+                            agg.command_type.c_str(), abort ? "abort" : "miss", miss_rate * 100.0,
+                            miss_threshold * 100.0, agg.total_misses, abort ? "aborts" : "misses", total);
                 }
             }
         } else {
@@ -2273,11 +2361,14 @@ void run_stats::print(FILE *out, benchmark_config *config, const char *header /*
                 if (total == 0) continue;
                 double miss_rate = (double) am.total_misses / (double) total;
                 if (miss_rate > miss_threshold) {
-                    const char *cmd_name = i < config->arbitrary_commands->size()
-                                               ? config->arbitrary_commands->at(i).command_type.c_str()
-                                               : "unknown";
-                    fprintf(stderr, "warning: %s miss rate %.2f%% above target %.2f%% (%llu misses / %llu ops)\n",
-                            cmd_name, miss_rate * 100.0, miss_threshold * 100.0, am.total_misses, total);
+                    const std::string &cmd_type = i < config->arbitrary_commands->size()
+                                                      ? config->arbitrary_commands->at(i).command_type
+                                                      : std::string("unknown");
+                    // EXEC nulls are optimistic-lock aborts, not cache misses.
+                    const bool abort = is_abort_command_type(cmd_type);
+                    fprintf(stderr, "warning: %s %s rate %.2f%% above target %.2f%% (%llu %s / %llu ops)\n",
+                            cmd_type.c_str(), abort ? "abort" : "miss", miss_rate * 100.0, miss_threshold * 100.0,
+                            am.total_misses, abort ? "aborts" : "misses", total);
                 }
             }
         }

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -1580,34 +1580,49 @@ void run_stats::print_aborts_sec_column(output_table &table,
     column.elements.push_back(*el.init_str("%12s ", "Aborts/sec"));
     column.elements.push_back(*el.init_str("%s", "-------------"));
 
-    // Only abort-semantics commands (EXEC) contribute; every other row shows
-    // 0.00. The count is the same value carried in that command's Misses/sec
-    // (display-only reinterpretation), so Aborts is a labeled subset of Misses.
-    unsigned long int test_duration_usec = ts_diff(m_start_time, m_end_time);
-    unsigned long long total_aborts = 0;
-    if (aggregated != nullptr) {
-        for (const auto &agg : *aggregated) {
-            unsigned long long aborts = is_abort_command_type(agg.command_type) ? agg.total_misses : 0;
-            double aborts_sec =
-                test_duration_usec > 0 ? (double) aborts / (double) test_duration_usec * 1000000.0 : 0.0;
-            column.elements.push_back(*el.init_double("%12.2f ", aborts_sec));
-            total_aborts += aborts;
+    // Aborts only exist for arbitrary (--command) workloads. This column is
+    // only added under --transaction, which requires --command, so the
+    // arbitrary branch is what actually runs; the SET/GET/Wait branch mirrors
+    // print_missess_sec_column's row layout so the column never misaligns if
+    // the gating ever changes.
+    if (print_arbitrary_commands_results()) {
+        // Only abort-semantics commands (EXEC) contribute; every other row
+        // shows 0.00. The count is the same value carried in that command's
+        // Misses/sec (display-only reinterpretation), so Aborts is a labeled
+        // subset of Misses.
+        unsigned long int test_duration_usec = ts_diff(m_start_time, m_end_time);
+        unsigned long long total_aborts = 0;
+        if (aggregated != nullptr) {
+            for (const auto &agg : *aggregated) {
+                unsigned long long aborts = is_abort_command_type(agg.command_type) ? agg.total_misses : 0;
+                double aborts_sec =
+                    test_duration_usec > 0 ? (double) aborts / (double) test_duration_usec * 1000000.0 : 0.0;
+                column.elements.push_back(*el.init_double("%12.2f ", aborts_sec));
+                total_aborts += aborts;
+            }
+        } else {
+            for (size_t i = 0; i < m_totals.m_ar_commands.size(); i++) {
+                bool is_abort = m_config != NULL && i < m_config->arbitrary_commands->size() &&
+                                is_abort_command_type(m_config->arbitrary_commands->at(i).command_type);
+                unsigned long long aborts =
+                    (is_abort && i < m_arbitrary_misses.size()) ? m_arbitrary_misses[i].total_misses : 0;
+                double aborts_sec =
+                    test_duration_usec > 0 ? (double) aborts / (double) test_duration_usec * 1000000.0 : 0.0;
+                column.elements.push_back(*el.init_double("%12.2f ", aborts_sec));
+                total_aborts += aborts;
+            }
         }
+        double total_aborts_sec =
+            test_duration_usec > 0 ? (double) total_aborts / (double) test_duration_usec * 1000000.0 : 0.0;
+        column.elements.push_back(*el.init_double("%12.2f ", total_aborts_sec));
     } else {
-        for (size_t i = 0; i < m_totals.m_ar_commands.size(); i++) {
-            bool is_abort = m_config != NULL && i < m_config->arbitrary_commands->size() &&
-                            is_abort_command_type(m_config->arbitrary_commands->at(i).command_type);
-            unsigned long long aborts =
-                (is_abort && i < m_arbitrary_misses.size()) ? m_arbitrary_misses[i].total_misses : 0;
-            double aborts_sec =
-                test_duration_usec > 0 ? (double) aborts / (double) test_duration_usec * 1000000.0 : 0.0;
-            column.elements.push_back(*el.init_double("%12.2f ", aborts_sec));
-            total_aborts += aborts;
-        }
+        // SET/GET/Wait layout (no aborts possible): one cell per Type row plus
+        // the Totals cell, matching the other columns' row count.
+        column.elements.push_back(*el.init_str("%12s ", "---"));
+        column.elements.push_back(*el.init_double("%12.2f ", 0.0));
+        column.elements.push_back(*el.init_str("%12s ", "---"));
+        column.elements.push_back(*el.init_double("%12.2f ", 0.0));
     }
-    double total_aborts_sec =
-        test_duration_usec > 0 ? (double) total_aborts / (double) test_duration_usec * 1000000.0 : 0.0;
-    column.elements.push_back(*el.init_double("%12.2f ", total_aborts_sec));
 
     table.add_column(column);
 }

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -2348,7 +2348,9 @@ void run_stats::print(FILE *out, benchmark_config *config, const char *header /*
                 double miss_rate = (double) agg.total_misses / (double) total;
                 if (miss_rate > miss_threshold) {
                     // EXEC nulls are optimistic-lock aborts, not cache misses.
-                    const bool abort = is_abort_command_type(agg.command_type);
+                    // Gated on --transaction to match the Aborts column / JSON /
+                    // live tail: without the flag, output keeps "miss" wording.
+                    const bool abort = config->transaction && is_abort_command_type(agg.command_type);
                     fprintf(stderr, "warning: %s %s rate %.2f%% above target %.2f%% (%llu %s / %llu ops)\n",
                             agg.command_type.c_str(), abort ? "abort" : "miss", miss_rate * 100.0,
                             miss_threshold * 100.0, agg.total_misses, abort ? "aborts" : "misses", total);
@@ -2365,7 +2367,9 @@ void run_stats::print(FILE *out, benchmark_config *config, const char *header /*
                                                       ? config->arbitrary_commands->at(i).command_type
                                                       : std::string("unknown");
                     // EXEC nulls are optimistic-lock aborts, not cache misses.
-                    const bool abort = is_abort_command_type(cmd_type);
+                    // Gated on --transaction to match the Aborts column / JSON /
+                    // live tail: without the flag, output keeps "miss" wording.
+                    const bool abort = config->transaction && is_abort_command_type(cmd_type);
                     fprintf(stderr, "warning: %s %s rate %.2f%% above target %.2f%% (%llu %s / %llu ops)\n",
                             cmd_type.c_str(), abort ? "abort" : "miss", miss_rate * 100.0, miss_threshold * 100.0,
                             am.total_misses, abort ? "aborts" : "misses", total);

--- a/run_stats.h
+++ b/run_stats.h
@@ -364,6 +364,10 @@ public:
                                const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
     void print_missess_sec_column(output_table &table,
                                   const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
+    // Aborts/sec column, shown only under --transaction. Reports the EXEC
+    // optimistic-lock abort rate (the abort-semantics subset of misses).
+    void print_aborts_sec_column(output_table &table,
+                                 const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
     void print_moved_sec_column(output_table &table,
                                 const std::vector<aggregated_command_type_stats> *aggregated = nullptr);
     void print_ask_sec_column(output_table &table,
@@ -407,6 +411,10 @@ public:
     // arbitrary_misses_total) and can exceed 32 bits on long runs.
     unsigned long long get_total_arbitrary_hits(void);
     unsigned long long get_total_arbitrary_misses(void);
+    // Subset of arbitrary misses that are transaction aborts (EXEC null reply).
+    // Display-only reinterpretation of the miss counter; see is_abort_command_type.
+    unsigned long long get_total_arbitrary_aborts(void);
+    static bool is_abort_command_type(const std::string &command_type);
 
     // Returns true if set_start_time() was called, indicating the client
     // produced (or was ready to produce) meaningful stats data.

--- a/tests/test_cluster_transaction.py
+++ b/tests/test_cluster_transaction.py
@@ -170,10 +170,9 @@ def test_transaction_with_discard(env):
             debugPrintMemtierOnError(run_config, env)
 
 
-def test_transaction_in_standalone_is_noop(env):
-    """In standalone, --transaction is accepted but does nothing: each client
-    already runs on a single connection, so the rotation order is naturally
-    preserved. The benchmark must complete cleanly with no server-side
+def test_transaction_in_standalone_runs_clean(env):
+    """In standalone, --transaction does not pin (there is only one
+    connection), but it must still run cleanly with no server-side
     transaction breakage."""
     if env.isCluster():
         env.skip()
@@ -192,6 +191,57 @@ def test_transaction_in_standalone_is_noop(env):
     try:
         env.assertTrue(ok, message="memtier_benchmark exited non-zero")
         _assert_no_transaction_breakage(env, stderr)
+    finally:
+        if env.getNumberOfFailedAssertion() > failed:
+            debugPrintMemtierOnError(run_config, env)
+
+
+def test_transaction_standalone_same_key_per_rotation(env):
+    """--transaction must collapse every __key__ in a rotation to one key even
+    WITHOUT --cluster-mode, so a single endpoint fronting a sharded backend
+    (e.g. a Redis Enterprise proxy) never sees a cross-slot WATCH/MULTI/EXEC.
+
+    Verified the slot-independent way: SET 'aa' then APPEND 'bb' on a bare
+    __key__ in one MULTI/EXEC. If both commands share the rotation's key every
+    populated key holds 'aabb'; if they drew independent keys (the pre-change
+    standalone behavior) we'd see stray 'aa' / 'bb' values."""
+    if env.isCluster():
+        env.skip()
+        return
+
+    conn = env.getConnection()
+    conn.flushall()
+
+    cmds = [
+        '--command=MULTI',
+        '--command=SET    __key__ aa',
+        '--command=APPEND __key__ bb',
+        '--command=EXEC',
+        '--command-key-pattern=R',
+        '--key-prefix=sk-',
+        '--key-minimum=1',
+        '--key-maximum=30',
+    ]
+    ok, run_config, stderr = _run_transaction_workload(
+        env, cmds, threads=2, clients=2, requests=400)
+
+    failed = env.getNumberOfFailedAssertion()
+    try:
+        env.assertTrue(ok, message="memtier_benchmark exited non-zero")
+        _assert_no_transaction_breakage(env, stderr)
+
+        total_keys = 0
+        for key in conn.scan_iter(match="sk-*"):
+            total_keys += 1
+            value = conn.execute_command("GET", key)
+            env.assertEqual(
+                value, b"aabb",
+                message="key {!r} holds {!r}, expected 'aabb' — standalone "
+                        "--transaction did not reuse one key per "
+                        "rotation".format(key, value))
+        env.assertGreater(
+            total_keys, 0,
+            message="no sk-* keys written; transaction produced no side effects")
     finally:
         if env.getNumberOfFailedAssertion() > failed:
             debugPrintMemtierOnError(run_config, env)

--- a/tests/test_cluster_transaction.py
+++ b/tests/test_cluster_transaction.py
@@ -54,6 +54,14 @@ def _read_stderr(run_config):
         return f.read()
 
 
+def _read_stdout(run_config):
+    path = "{0}/mb.stdout".format(run_config.results_dir)
+    if not os.path.isfile(path):
+        return ""
+    with open(path) as f:
+        return f.read()
+
+
 def _assert_no_transaction_breakage(env, stderr_text):
     for needle in TRANSACTION_BREAKAGE_PATTERNS:
         env.assertTrue(
@@ -654,6 +662,90 @@ def test_transaction_same_key_reused_within_rotation(env):
             total_keys, 0,
             message="no rk-* keys were written; the transaction produced no "
                     "side effects")
+    finally:
+        if env.getNumberOfFailedAssertion() > failed:
+            debugPrintMemtierOnError(run_config, env)
+
+
+def test_transaction_abort_column_and_warning(env):
+    """Under --transaction the stats output must break EXEC optimistic-lock
+    aborts out into their own 'Aborts/sec' column (table + JSON), and the
+    miss-rate warning for EXEC must say 'abort rate', never 'miss rate'.
+
+    A narrow key range with several contending clients makes concurrent
+    rotations watch+write the same key, so some EXECs abort and the abort
+    columns/warning are exercised with non-zero values."""
+    if not env.isCluster():
+        env.skip()
+        return
+
+    test_dir = tempfile.mkdtemp()
+    benchmark_specs = {"name": env.testName, "args": ["--transaction"]}
+    addTLSArgs(benchmark_specs, env)
+    benchmark_specs["args"].extend([
+        # Hash-tag prefix keeps every key in one slot (no cross-slot pin churn),
+        # and a narrow key range makes concurrent rotations watch+write the same
+        # key -> EXEC optimistic-lock aborts.
+        '--command=WATCH __key__',
+        '--command=GET   __key__',
+        '--command=MULTI',
+        '--command=SETEX __key__ 600 __data__',
+        '--command=EXEC',
+        '--command=UNWATCH',
+        '--command-key-pattern=R',
+        '--key-prefix={abrt}-',
+        '--key-minimum=1',
+        '--key-maximum=5',
+    ])
+
+    config = get_default_memtier_config(threads=4, clients=4, requests=500)
+    master_nodes_list = env.getMasterNodesList()
+    add_required_env_arguments(benchmark_specs, config, env, master_nodes_list)
+
+    run_config = RunConfig(test_dir, env.testName, config, {})
+    ensure_clean_benchmark_folder(run_config.results_dir)
+    benchmark = Benchmark.from_json(run_config, benchmark_specs)
+    ok = benchmark.run()
+
+    stdout = _read_stdout(run_config)
+    stderr = _read_stderr(run_config)
+
+    failed = env.getNumberOfFailedAssertion()
+    try:
+        env.assertTrue(ok, message="memtier_benchmark exited non-zero")
+        _assert_no_transaction_breakage(env, stderr)
+
+        # Table must carry the Aborts/sec column under --transaction.
+        env.assertTrue(
+            "Aborts/sec" in stdout,
+            message="'Aborts/sec' column missing from --transaction output")
+
+        # EXEC's miss-rate warning, if any, must be phrased as an abort.
+        env.assertTrue(
+            "EXEC miss rate" not in stderr,
+            message="EXEC reported as 'miss rate'; should be 'abort rate'")
+
+        # JSON: the Execs command block and Totals must expose Aborts/sec.
+        json_path = os.path.join(run_config.results_dir, "mb.json")
+        with open(json_path) as f:
+            doc = json.load(f)
+
+        def _find(node, key):
+            if isinstance(node, dict):
+                if key in node:
+                    return node[key]
+                for v in node.values():
+                    r = _find(v, key)
+                    if r is not None:
+                        return r
+            return None
+
+        execs = _find(doc, "Execs")
+        env.assertTrue(execs is not None, message="no Execs block in JSON")
+        env.assertTrue(
+            "Aborts/sec" in execs,
+            message="Execs JSON block missing 'Aborts/sec': {}".format(
+                list(execs.keys())))
     finally:
         if env.getNumberOfFailedAssertion() > failed:
             debugPrintMemtierOnError(run_config, env)


### PR DESCRIPTION
## Overview

Follow-up to #485. In a `WATCH`/`MULTI`/`EXEC` unit, `EXEC` returns a null array when the optimistic lock fails (a watched key changed) — a transaction **abort**, not a cache **miss**. Reporting it under "misses" conflated it with key-existence misses. This surfaces aborts as their own concept under `--transaction`, and fixes live miss/abort visibility in `--realtime-latencies`.

## What changed

**Under `--transaction`:**
- Stats table gains an **`Aborts/sec`** column (EXEC's optimistic-lock abort rate), broken out alongside the generic `Misses/sec`.
- The per-command miss-rate warning for EXEC now reads **`abort rate`** instead of `miss rate`.
- JSON output gains **`Aborts/sec`** for the EXEC command block and Totals.

**`--realtime-latencies` fix (independent of `--transaction`):**
- The live `miss %` was wired to the SET/GET hit/miss counters, which stay zero in `--command` (arbitrary) mode — so it always printed `-`. It now sources misses from the arbitrary-command counters.
- Adds a live `abort %` field under `--transaction`.

## Design

Display-only reinterpretation:
- EXEC nulls still increment the per-command **miss** counter, so global miss totals are unchanged; aborts are a **labeled subset** of misses.
- Abort-semantics commands are detected by command type (`EXEC`). No new counter or reply-shape.
- The column, JSON field, and warning wording change **only under `--transaction`**, so default arbitrary-command output is untouched (no Aborts column without the flag — verified).

Example (`Execs` row, heavy WATCH contention):

```
Type        Ops/sec   Hits/sec  Misses/sec  Aborts/sec ...
Execs      35497.97    3283.56    32214.41    32214.41 ...
warning: EXEC abort rate 90.75% above target 1.00% (1452 aborts / 1600 ops)
```

Live line:

```
... miss 90.83% (avg: 90.86%)   abort 90.83% (avg: 90.86%)
```

## Live abort %: a note

The live `abort %` is a **blended** indicator over all arbitrary commands (same lookup denominator as the live `miss %`, of which aborts are a subset). The authoritative per-command abort rate is in the final table and the `abort rate` warning. A true per-command live rate would need the per-command committed-EXEC denominator, which isn't cheaply available in the live aggregate.

## Test plan

`tests/test_cluster_transaction.py` (OSS-CLUSTER, 3 shards):
- New `test_transaction_abort_column_and_warning` — asserts the `Aborts/sec` column (table + JSON for the EXEC block) and that EXEC is never reported as `miss rate`. Uses a hash-tag prefix + narrow key range so concurrent rotations contend and exercise the abort path on a single slot.
- `test_realtime_latencies` (3 tests) pass unchanged — confirms the realtime rewiring is safe.
- All pre-existing transaction tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes arbitrary-command key generation for transactional standalone runs and several stats/output code paths; cluster mode deliberately bypasses the new client fast path, but proxy/single-endpoint transaction workloads will behave differently than before.
> 
> **Overview**
> Extends **`--transaction`** so one full `--command` rotation reuses a **single key** for every `__key__` in **standalone** mode (not only `--cluster-mode`), via cached rotation state in `client::create_arbitrary_request`. That keeps WATCH/MULTI/EXEC on one slot for single-endpoint sharded proxies; cluster routing still uses `cluster_client`.
> 
> Under **`--transaction`**, EXEC optimistic-lock failures are surfaced as **aborts** (display-only subset of existing miss counters): **`Aborts/sec`** in the results table and JSON, live **`abort %`** in `--realtime-latencies`, and threshold warnings that say **abort rate** for EXEC instead of miss rate. Default arbitrary-command output without `--transaction` is unchanged.
> 
> **`--realtime-latencies`** now drives live **miss %** from arbitrary-command hit/miss totals when using `--command`, fixing the always-`-` behavior from empty SET/GET counters.
> 
> Help text and validation drop the standalone “no effect / keys not collapsed” warning; tests add standalone same-key verification and cluster abort-column coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b9a171002e48037081bace9b42ec3a0acb30d36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Also in this PR: same-key-per-rotation without `--cluster-mode`

`--transaction`'s same-key behavior previously only ran under `--cluster-mode`. Against a **single endpoint fronting a sharded backend** (e.g. a Redis Enterprise proxy accessed without `--cluster-mode`), each keyed `--command` still drew an independent key, so a `WATCH`/`GET`/`SETEX` rotation spanned multiple slots and the server rejected it with `CROSSSLOT (context='within WATCH')`.

This lifts the per-rotation key reuse into the base `client::create_arbitrary_request`, so every `__key__` in a rotation resolves to one key/slot in **every mode**. `cluster_client` overrides that method and keeps its own pin-aware path, so cluster behavior is unchanged.

Consequence: `--transaction` is no longer a no-op without `--cluster-mode` — it still doesn't *pin* (a single connection needs none) but it now *collapses keys*. The `--help` text is updated and the standalone "keys are NOT collapsed" warning (added earlier in this PR) is dropped.

New test: `test_transaction_standalone_same_key_per_rotation` (SET `aa` / APPEND `bb` in one MULTI/EXEC against a standalone server → every key holds `aabb`).
