### PR TITLE
cluster-mode: report endpoint count and connection fan-out (2.4 backport)

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -6,9 +6,9 @@ name: ASAN (AddressSanitizer & LeakSanitizer)
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/cli-fuzz-nightly.yml
+++ b/.github/workflows/cli-fuzz-nightly.yml
@@ -25,7 +25,7 @@ on:
         default: '500'
   pull_request:
     types: [labeled, synchronize, reopened]
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -2,9 +2,9 @@ name: Code Style
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/differential.yml
+++ b/.github/workflows/differential.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [labeled, synchronize, reopened]
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -8,9 +8,9 @@ name: Fuzz smoke (libFuzzer)
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/monitor-fuzz.yml
+++ b/.github/workflows/monitor-fuzz.yml
@@ -29,7 +29,7 @@ on:
         default: '2000'
   pull_request:
     types: [labeled, synchronize, reopened]
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/soak-nightly.yml
+++ b/.github/workflows/soak-nightly.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [labeled, synchronize, reopened]
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -10,9 +10,9 @@ name: TSAN (ThreadSanitizer)
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -6,9 +6,9 @@ name: UBSan (UndefinedBehaviorSanitizer)
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "2.4"]
 
 permissions:
   contents: read

--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -457,21 +457,20 @@ void cluster_client::print_topology_summary() const
 
     // Process-global gate keyed on (run id, signature), mutex-guarded because
     // the signature is wider than a lock-free atomic and several worker threads
-    // can reach this concurrently after a refresh.
+    // can reach this concurrently after a refresh. The lock is held across the
+    // whole emit (not just the gate update) so two workers cannot interleave
+    // their blocks or print a superseded topology after a newer one.
     const unsigned int rid = m_config->current_run_id;
-    {
-        static pthread_mutex_t s_mtx = PTHREAD_MUTEX_INITIALIZER;
-        static unsigned int s_last_run = UINT_MAX;
-        static unsigned long long s_last_sig = 0;
-        pthread_mutex_lock(&s_mtx);
-        bool already_printed = (s_last_run == rid && s_last_sig == sig);
-        if (!already_printed) {
-            s_last_run = rid;
-            s_last_sig = sig;
-        }
+    static pthread_mutex_t s_mtx = PTHREAD_MUTEX_INITIALIZER;
+    static unsigned int s_last_run = UINT_MAX;
+    static unsigned long long s_last_sig = 0;
+    pthread_mutex_lock(&s_mtx);
+    if (s_last_run == rid && s_last_sig == sig) {
         pthread_mutex_unlock(&s_mtx);
-        if (already_printed) return;
+        return;
     }
+    s_last_run = rid;
+    s_last_sig = sig;
 
     fprintf(stderr, "[RUN #%u] Cluster topology: %zu endpoints discovered (%zu primaries)\n", rid, eps.size(),
             eps.size());
@@ -493,20 +492,26 @@ void cluster_client::print_topology_summary() const
     if (eps.size() > shown) fprintf(stderr, "           ... and %zu more endpoints\n", eps.size() - shown);
 
     // Total opened connections = threads x conns-per-thread x endpoints. Each
-    // cluster_client opens one shard_connection per distinct endpoint.
+    // cluster_client opens one shard_connection per distinct endpoint. With the
+    // --clients-start staircase ramp, m_config->clients is the peak (full-ramp)
+    // value, so the figure is the target fan-out; flag that so it isn't read as
+    // the count already opened.
+    const char *ramp = (m_config->clients_start > 0) ? " at full ramp" : "";
     const unsigned long long endpoints = (unsigned long long) eps.size();
     const unsigned long long total_conns =
         (unsigned long long) m_config->threads * (unsigned long long) m_config->clients * endpoints;
-    fprintf(stderr, "[RUN #%u] Total connections: %u threads x %u conns/thread x %llu endpoints = %llu\n", rid,
+    fprintf(stderr, "[RUN #%u] Total connections%s: %u threads x %u conns/thread x %llu endpoints = %llu\n", rid, ramp,
             m_config->threads, m_config->clients, endpoints, total_conns);
 
     // --rate-limiting is per-connection. 2.4 cluster mode is primary-only, so
     // every connection generates traffic; the aggregate target spans them all.
     if (m_config->request_rate > 0) {
         const unsigned long long aggregate = (unsigned long long) m_config->request_rate * total_conns;
-        fprintf(stderr, "[RUN #%u] Rate limit: %u req/s/conn -> %llu req/s aggregate target\n", rid,
-                m_config->request_rate, aggregate);
+        fprintf(stderr, "[RUN #%u] Rate limit: %u req/s/conn -> %llu req/s aggregate target%s\n", rid,
+                m_config->request_rate, aggregate, ramp);
     }
+
+    pthread_mutex_unlock(&s_mtx);
 }
 
 void cluster_client::handle_cluster_slots(protocol_response *r)

--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -44,6 +44,10 @@
 #include <assert.h>
 #endif
 
+#include <atomic>
+#include <map>
+#include <algorithm>
+
 #include "cluster_client.h"
 #include "memtier_benchmark.h"
 #include "obj_gen.h"
@@ -355,6 +359,156 @@ void cluster_client::build_mget_slot_cache()
     }
 }
 
+// "host:port" for a shard_connection, defensive against NULL fields.
+static std::string sc_endpoint_addr(shard_connection *sc)
+{
+    const char *a = sc->get_address();
+    const char *p = sc->get_port();
+    std::string s(a ? a : "?");
+    s += ":";
+    s += (p ? p : "?");
+    return s;
+}
+
+// Sort [start,end] ranges and merge touching/overlapping ones into the minimal
+// set of contiguous ranges.
+static std::vector<std::pair<int, int> > merge_slot_ranges(std::vector<std::pair<int, int> > v)
+{
+    std::sort(v.begin(), v.end());
+    std::vector<std::pair<int, int> > m;
+    for (size_t i = 0; i < v.size(); i++) {
+        if (!m.empty() && v[i].first <= m.back().second + 1)
+            m.back().second = std::max(m.back().second, v[i].second);
+        else
+            m.push_back(v[i]);
+    }
+    return m;
+}
+
+std::vector<cluster_endpoint_info> cluster_client::build_topology_snapshot() const
+{
+    std::vector<cluster_endpoint_info> out;
+    if (m_connections.empty()) return out;
+
+    // Build per-conn_id contiguous slot runs by scanning the slot map once.
+    // m_slot_to_shard[slot] = owning shard_connection id (== index in
+    // m_connections). 2.4 is primary-only -- there are no replica endpoints.
+    // (Uncovered slots default to conn 0 since the map is zero-initialized; a
+    // fully-covered cluster -- the normal case -- assigns every slot.)
+    std::map<unsigned int, std::vector<std::pair<int, int> > > conn_ranges;
+    unsigned int run_conn = m_slot_to_shard[0];
+    int run_start = 0;
+    for (int s = 1; s <= MAX_CLUSTER_HSLOT; s++) {
+        if (m_slot_to_shard[s] != run_conn) {
+            conn_ranges[run_conn].push_back(std::make_pair(run_start, s - 1));
+            run_conn = m_slot_to_shard[s];
+            run_start = s;
+        }
+    }
+    conn_ranges[run_conn].push_back(std::make_pair(run_start, MAX_CLUSTER_HSLOT));
+
+    // Coalesce by distinct endpoint (host:port), preserving first-seen order,
+    // so the count is by node rather than by slot range.
+    std::vector<std::string> order;
+    std::map<std::string, std::vector<std::pair<int, int> > > addr_ranges;
+    for (std::map<unsigned int, std::vector<std::pair<int, int> > >::const_iterator it = conn_ranges.begin();
+         it != conn_ranges.end(); ++it) {
+        unsigned int cid = it->first;
+        if (cid >= m_connections.size() || m_connections[cid] == NULL) continue;
+        std::string addr = sc_endpoint_addr(m_connections[cid]);
+        if (addr_ranges.find(addr) == addr_ranges.end()) order.push_back(addr);
+        std::vector<std::pair<int, int> > &v = addr_ranges[addr];
+        v.insert(v.end(), it->second.begin(), it->second.end());
+    }
+    for (size_t i = 0; i < order.size(); i++) {
+        cluster_endpoint_info info;
+        info.addr = order[i];
+        info.is_primary = true;
+        info.slot_ranges = merge_slot_ranges(addr_ranges[order[i]]);
+        out.push_back(info);
+    }
+    return out;
+}
+
+void cluster_client::print_topology_summary() const
+{
+    std::vector<cluster_endpoint_info> eps = build_topology_snapshot();
+    if (eps.empty()) return;
+
+    // Signature of the topology shape (endpoints + slot ranges). The startup
+    // block prints on the first commit of each run AND reprints when this
+    // signature changes within a run, so a mid-run CLUSTER SLOTS refresh that
+    // alters the topology is logged and stays consistent with the run-end
+    // results summary.
+    unsigned long long sig = 1469598103934665603ULL; // FNV-1a 64-bit offset basis
+    for (size_t i = 0; i < eps.size(); i++) {
+        const cluster_endpoint_info &e = eps[i];
+        for (size_t c = 0; c < e.addr.size(); c++) {
+            sig ^= (unsigned char) e.addr[c];
+            sig *= 1099511628211ULL;
+        }
+        for (size_t r = 0; r < e.slot_ranges.size(); r++) {
+            sig ^= (unsigned long long) e.slot_ranges[r].first;
+            sig *= 1099511628211ULL;
+            sig ^= (unsigned long long) e.slot_ranges[r].second;
+            sig *= 1099511628211ULL;
+        }
+    }
+
+    // Process-global gate keyed on (run id, signature), mutex-guarded because
+    // the signature is wider than a lock-free atomic and several worker threads
+    // can reach this concurrently after a refresh.
+    const unsigned int rid = m_config->current_run_id;
+    {
+        static pthread_mutex_t s_mtx = PTHREAD_MUTEX_INITIALIZER;
+        static unsigned int s_last_run = UINT_MAX;
+        static unsigned long long s_last_sig = 0;
+        pthread_mutex_lock(&s_mtx);
+        bool already_printed = (s_last_run == rid && s_last_sig == sig);
+        if (!already_printed) {
+            s_last_run = rid;
+            s_last_sig = sig;
+        }
+        pthread_mutex_unlock(&s_mtx);
+        if (already_printed) return;
+    }
+
+    fprintf(stderr, "[RUN #%u] Cluster topology: %zu endpoints discovered (%zu primaries)\n", rid, eps.size(),
+            eps.size());
+
+    // One compact line per node: slot count + range count. Cap the list so a
+    // large cluster doesn't flood the log; the count above is authoritative.
+    const size_t LIST_CAP = 40;
+    const size_t shown = eps.size() < LIST_CAP ? eps.size() : LIST_CAP;
+    for (size_t i = 0; i < shown; i++) {
+        const cluster_endpoint_info &e = eps[i];
+        size_t slots = 0;
+        for (size_t r = 0; r < e.slot_ranges.size(); r++)
+            slots += (size_t) (e.slot_ranges[r].second - e.slot_ranges[r].first + 1);
+        const size_t nr = e.slot_ranges.size();
+        const char *rp = (nr == 1) ? "" : "s";
+        const char *sp = (slots == 1) ? "" : "s";
+        fprintf(stderr, "           %-22s primary   %5zu slot%s in %zu range%s\n", e.addr.c_str(), slots, sp, nr, rp);
+    }
+    if (eps.size() > shown) fprintf(stderr, "           ... and %zu more endpoints\n", eps.size() - shown);
+
+    // Total opened connections = threads x conns-per-thread x endpoints. Each
+    // cluster_client opens one shard_connection per distinct endpoint.
+    const unsigned long long endpoints = (unsigned long long) eps.size();
+    const unsigned long long total_conns =
+        (unsigned long long) m_config->threads * (unsigned long long) m_config->clients * endpoints;
+    fprintf(stderr, "[RUN #%u] Total connections: %u threads x %u conns/thread x %llu endpoints = %llu\n", rid,
+            m_config->threads, m_config->clients, endpoints, total_conns);
+
+    // --rate-limiting is per-connection. 2.4 cluster mode is primary-only, so
+    // every connection generates traffic; the aggregate target spans them all.
+    if (m_config->request_rate > 0) {
+        const unsigned long long aggregate = (unsigned long long) m_config->request_rate * total_conns;
+        fprintf(stderr, "[RUN #%u] Rate limit: %u req/s/conn -> %llu req/s aggregate target\n", rid,
+                m_config->request_rate, aggregate);
+    }
+}
+
 void cluster_client::handle_cluster_slots(protocol_response *r)
 {
     /*
@@ -529,6 +683,11 @@ void cluster_client::handle_cluster_slots(protocol_response *r)
             }
         }
     }
+
+    // Emit the one-shot human-readable topology summary now that the slot map
+    // is committed (slot ranges and endpoints are only known here).
+    // print_topology_summary() self-gates to fire once per run / shape.
+    print_topology_summary();
 
     // Rebuild same-slot key index cache for MGET if enabled.
     build_mget_slot_cache();

--- a/cluster_client.h
+++ b/cluster_client.h
@@ -38,6 +38,19 @@ struct staged_monitor_cmd
 // forward decleration
 class shard_connection;
 
+// One distinct endpoint (host:port) in the discovered cluster topology, with
+// the hash-slot ranges it serves. 2.4 cluster mode is primary-only, so every
+// entry is a primary. Built by cluster_client::build_topology_snapshot() from
+// m_slot_to_shard + m_connections after a CLUSTER SLOTS commit, and consumed by
+// the human-readable startup summary (print_topology_summary) and the captured
+// results-summary counts.
+struct cluster_endpoint_info
+{
+    std::string addr;                              // "host:port"
+    bool is_primary;                               // always true on 2.4 (no replica routing)
+    std::vector<std::pair<int, int> > slot_ranges; // contiguous [start,end] runs
+};
+
 class cluster_client : public client
 {
 protected:
@@ -110,6 +123,18 @@ public:
                                               unsigned long long *key_index);
     virtual bool create_arbitrary_request(unsigned int command_index, struct timeval &timestamp, unsigned int conn_id);
     virtual bool create_mget_request(struct timeval &timestamp, unsigned int conn_id);
+
+    // Build a per-endpoint view of the committed topology: one entry per
+    // distinct host:port that owns slots, each annotated with its contiguous
+    // slot ranges. Called after a CLUSTER SLOTS commit; no lock needed because
+    // each cluster_client is single-threaded.
+    std::vector<cluster_endpoint_info> build_topology_snapshot() const;
+
+    // Emit the "[RUN #N] Cluster topology: ..." block to stderr (endpoint list
+    // with slot ranges, total opened connections, and the aggregate rate-limit
+    // target when --rate-limiting is set). Prints once per run and reprints when
+    // the topology shape changes mid-run.
+    void print_topology_summary() const;
 
     // client manager api's
     virtual void handle_cluster_slots(protocol_response *r);

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -82,6 +82,7 @@
 #include <algorithm>
 
 #include "client.h"
+#include "cluster_client.h"
 #include "JSON_handler.h"
 #include "obj_gen.h"
 #include "memtier_benchmark.h"
@@ -2590,6 +2591,10 @@ static void print_staircase_pattern(int run_id, benchmark_config *cfg)
 
 run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj_gen)
 {
+    // Expose the current run id so the cluster topology summary (printed from a
+    // worker thread once CLUSTER SLOTS commits) can label and gate itself.
+    cfg->current_run_id = (unsigned int) run_id;
+
     fprintf(stderr, "[RUN #%u] Preparing benchmark client...\n", run_id);
 
     // Shared MGET slot cache: allocate fresh for this run so the lazy build
@@ -3088,6 +3093,31 @@ run_stats run_benchmark(int run_id, benchmark_config *cfg, object_generator *obj
     for (std::vector<cg_thread *>::iterator i = threads.begin(); i != threads.end(); i++) {
         (*i)->join();
         (*i)->m_cg->merge_run_stats(&stats);
+    }
+
+    // Capture the discovered cluster topology once (identical across clients)
+    // from the same snapshot the startup line uses, so the results summary's
+    // endpoint/connection counts agree with it.
+    if (cfg->cluster_mode) {
+        bool captured = false;
+        for (std::vector<cg_thread *>::iterator i = threads.begin(); !captured && i != threads.end(); i++) {
+            std::vector<client *> &clients = (*i)->m_cg->get_clients();
+            for (size_t ci = 0; !captured && ci < clients.size(); ++ci) {
+                cluster_client *cc = dynamic_cast<cluster_client *>(clients[ci]);
+                if (cc == NULL) continue;
+                std::vector<cluster_endpoint_info> eps = cc->build_topology_snapshot();
+                if (eps.empty()) continue;
+                size_t prim = 0, rep = 0;
+                for (size_t e = 0; e < eps.size(); ++e) {
+                    if (eps[e].is_primary)
+                        prim++;
+                    else
+                        rep++;
+                }
+                stats.set_cluster_topology(eps.size(), prim, rep);
+                captured = true;
+            }
+        }
     }
 
     // Do we need to produce client stats?
@@ -4039,18 +4069,58 @@ int main(int argc, char *argv[])
             stats.save_hdr_arbitrary_commands(&cfg, run_id);
         }
         //
-        // Print some run information
+        // Print some run information.
+        //
+        // In cluster mode, also surface the discovered endpoint count and the
+        // real total connection fan-out (threads x conns/thread x endpoints),
+        // plus the aggregate rate-limit target when --rate-limiting is set.
+        // Counts come from the topology snapshot captured at run end (same
+        // source as the startup "[RUN #N] Cluster topology" line). 2.4 cluster
+        // mode is primary-only, so all endpoints are primaries.
+        bool have_cluster_topo = false;
+        size_t c_endpoints = 0, c_primaries = 0;
+        unsigned long long c_total_conns = 0, c_rate_aggregate = 0;
+        bool c_has_rate = false;
+        if (cfg.cluster_mode && !all_stats.empty()) {
+            const run_stats &topo = all_stats.back();
+            c_endpoints = topo.get_endpoint_count();
+            if (c_endpoints > 0) {
+                have_cluster_topo = true;
+                c_primaries = topo.get_primary_endpoint_count();
+                c_total_conns = (unsigned long long) cfg.threads * (unsigned long long) cfg.clients *
+                                (unsigned long long) c_endpoints;
+                if (cfg.request_rate > 0) {
+                    c_rate_aggregate = (unsigned long long) cfg.request_rate * c_total_conns;
+                    c_has_rate = true;
+                }
+            }
+        }
+
         fprintf(outfile,
                 "%-9u Threads\n"
-                "%-9u Connections per thread\n"
-                "%-9llu %s\n",
-                cfg.threads, cfg.clients, (unsigned long long) (cfg.requests > 0 ? cfg.requests : cfg.test_time),
+                "%-9u Connections per thread\n",
+                cfg.threads, cfg.clients);
+
+        if (have_cluster_topo) {
+            fprintf(outfile, "%-9zu Cluster endpoints (%zu primaries)\n", c_endpoints, c_primaries);
+            fprintf(outfile, "%-9llu Total connections (%u x %u x %zu)\n", c_total_conns, cfg.threads, cfg.clients,
+                    c_endpoints);
+            if (c_has_rate) fprintf(outfile, "%-9llu Aggregate rate-limit target (req/s)\n", c_rate_aggregate);
+        }
+
+        fprintf(outfile, "%-9llu %s\n", (unsigned long long) (cfg.requests > 0 ? cfg.requests : cfg.test_time),
                 cfg.requests > 0 ? "Requests per client" : "Seconds");
 
         if (jsonhandler != NULL) {
             jsonhandler->open_nesting("run information");
             jsonhandler->write_obj("Threads", "%u", cfg.threads);
             jsonhandler->write_obj("Connections per thread", "%u", cfg.clients);
+            if (have_cluster_topo) {
+                jsonhandler->write_obj("Cluster endpoints", "%zu", c_endpoints);
+                jsonhandler->write_obj("Cluster primary endpoints", "%zu", c_primaries);
+                jsonhandler->write_obj("Total connections", "%llu", c_total_conns);
+                if (c_has_rate) jsonhandler->write_obj("Aggregate rate-limit target", "%llu", c_rate_aggregate);
+            }
             jsonhandler->write_obj(cfg.requests > 0 ? "Requests per client" : "Seconds", "%llu",
                                    cfg.requests > 0 ? cfg.requests : (unsigned long long) cfg.test_time);
             jsonhandler->write_obj("Format version", "%d", 2);

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -4102,10 +4102,14 @@ int main(int argc, char *argv[])
                 cfg.threads, cfg.clients);
 
         if (have_cluster_topo) {
+            // With the --clients-start staircase ramp, cfg.clients is the peak
+            // (full-ramp) value, so total connections / rate are the target
+            // fan-out rather than the count necessarily opened; label it.
+            const char *ramp = (cfg.clients_start > 0) ? " at full ramp" : "";
             fprintf(outfile, "%-9zu Cluster endpoints (%zu primaries)\n", c_endpoints, c_primaries);
-            fprintf(outfile, "%-9llu Total connections (%u x %u x %zu)\n", c_total_conns, cfg.threads, cfg.clients,
-                    c_endpoints);
-            if (c_has_rate) fprintf(outfile, "%-9llu Aggregate rate-limit target (req/s)\n", c_rate_aggregate);
+            fprintf(outfile, "%-9llu Total connections%s (%u x %u x %zu)\n", c_total_conns, ramp, cfg.threads,
+                    cfg.clients, c_endpoints);
+            if (c_has_rate) fprintf(outfile, "%-9llu Aggregate rate-limit target (req/s)%s\n", c_rate_aggregate, ramp);
         }
 
         fprintf(outfile, "%-9llu %s\n", (unsigned long long) (cfg.requests > 0 ? cfg.requests : cfg.test_time),

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -185,6 +185,11 @@ struct benchmark_config
     unsigned int clients_step;
     unsigned int step_duration;
     struct timeval benchmark_start_time;
+    // Index of the currently-executing run (1-based), set at the top of
+    // run_benchmark(). Read by cluster_client::handle_cluster_slots() so the
+    // one-shot topology summary it prints can label itself "[RUN #N]" and emit
+    // once per run (runs are sequential, so a plain field is enough).
+    unsigned int current_run_id;
     // StatsD metrics export
     const char *statsd_host;
     unsigned short statsd_port;

--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -122,7 +122,14 @@ inline timeval timeval_factorial_average(timeval a, timeval b, unsigned int weig
     return (tv);
 }
 
-run_stats::run_stats(benchmark_config *config) : m_config(config), m_interrupted(false), m_totals(), m_cur_stats(0)
+run_stats::run_stats(benchmark_config *config) :
+        m_config(config),
+        m_interrupted(false),
+        m_totals(),
+        m_cur_stats(0),
+        m_cluster_endpoints(0),
+        m_cluster_primaries(0),
+        m_cluster_replicas(0)
 {
     memset(&m_start_time, 0, sizeof(m_start_time));
     memset(&m_end_time, 0, sizeof(m_end_time));

--- a/run_stats.h
+++ b/run_stats.h
@@ -192,6 +192,23 @@ public:
     void set_interrupted(bool interrupted) { m_interrupted = interrupted; }
     bool get_interrupted() const { return m_interrupted; }
 
+    // Cluster topology counts captured once at run end from a cluster_client's
+    // build_topology_snapshot() so the results summary agrees with the one-shot
+    // startup "[RUN #N] Cluster topology" line. 0 when not in cluster mode.
+    // (2.4 cluster mode is primary-only, so replicas is always 0.)
+    size_t m_cluster_endpoints;
+    size_t m_cluster_primaries;
+    size_t m_cluster_replicas;
+    void set_cluster_topology(size_t total, size_t primaries, size_t replicas)
+    {
+        m_cluster_endpoints = total;
+        m_cluster_primaries = primaries;
+        m_cluster_replicas = replicas;
+    }
+    size_t get_endpoint_count() const { return m_cluster_endpoints; }
+    size_t get_primary_endpoint_count() const { return m_cluster_primaries; }
+    size_t get_replica_endpoint_count() const { return m_cluster_replicas; }
+
     void update_get_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency,
                        unsigned int hits, unsigned int misses);
     void update_set_op(struct timeval *ts, unsigned int bytes_rx, unsigned int bytes_tx, unsigned int latency);


### PR DESCRIPTION
Backport of #489 to the **2.4** branch.

## Why a re-implementation (not a cherry-pick)
2.4 predates the `--read-preference` / `shard_group` infrastructure (#456) that #489 was built on. The 2.4 cluster client is primary-only and uses `m_slot_to_shard[16384]` + `m_connections`, with no `shard_group`/`endpoint_snapshot`/replica routing. A straight cherry-pick conflicts in 4 files on missing types, so this re-implements the same user-facing feature against 2.4's model.

## What
In `--cluster-mode`:
- **Startup (stderr)** — once per run, reprinting on a mid-run topology shape change:
  ```
  [RUN #1] Cluster topology: 9 endpoints discovered (9 primaries)
             10.0.0.1:7000          primary    1820 slots in 13 ranges
             ...
  [RUN #1] Total connections: 128 threads x 3 conns/thread x 9 endpoints = 3456
  [RUN #1] Rate limit: 34 req/s/conn -> 117504 req/s aggregate target
  ```
- **Results summary (text + JSON)** — `Cluster endpoints`, `Total connections`, `Aggregate rate-limit target`.

## Notes
- Endpoints are counted by **distinct host:port** (coalesced from the slot map), so the count equals the per-client connection fan-out and `Total connections` is the real opened-connection count.
- Startup block and run-end summary share one snapshot source, so they agree.
- **Primary-only** (2.4 has no replica routing), so the read-preference-aware rate nuance from #489 doesn't apply here — every connection generates traffic.
- Non-cluster runs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly logging and summary output on the cluster path; routing and request handling are unchanged, and non-cluster runs are unaffected.
> 
> **Overview**
> **Cluster-mode observability (2.4 backport)** adds reporting of discovered **distinct host:port** endpoints, **total connection fan-out** (`threads × conns/thread × endpoints`), and optional **aggregate rate-limit** targets, using the primary-only `m_slot_to_shard` + `m_connections` model.
> 
> After **CLUSTER SLOTS** commits, `cluster_client` builds a topology snapshot and prints a gated **`[RUN #N] Cluster topology`** block on stderr (once per run/signature, reprints on mid-run topology changes). At run end, the same snapshot is captured into **`run_stats`** so the text/JSON **run information** section matches the startup lines. **`benchmark_config::current_run_id`** labels those messages.
> 
> **CI** workflows now also run on push/PR to the **`2.4`** branch alongside `master`/`main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76dd1e2ec5eab08b31a3efef008157166ae48ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->