### PR TITLE
cluster-mode: serialize topology print; flag staircase fan-out

### DIFF
--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -771,22 +771,20 @@ void cluster_client::print_topology_summary() const
 
     // Process-global gate keyed on (run id, signature). Guarded by a mutex
     // because the signature is wider than a lock-free atomic and several worker
-    // threads can reach this concurrently after a refresh. The first thread to
-    // observe a new (run, shape) prints; the rest return.
+    // threads can reach this concurrently after a refresh. The lock is held
+    // across the whole emit (not just the gate update) so two workers cannot
+    // interleave their blocks or print a superseded topology after a newer one.
     const unsigned int rid = m_config->current_run_id;
-    {
-        static pthread_mutex_t s_mtx = PTHREAD_MUTEX_INITIALIZER;
-        static unsigned int s_last_run = UINT_MAX;
-        static unsigned long long s_last_sig = 0;
-        pthread_mutex_lock(&s_mtx);
-        bool already_printed = (s_last_run == rid && s_last_sig == sig);
-        if (!already_printed) {
-            s_last_run = rid;
-            s_last_sig = sig;
-        }
+    static pthread_mutex_t s_mtx = PTHREAD_MUTEX_INITIALIZER;
+    static unsigned int s_last_run = UINT_MAX;
+    static unsigned long long s_last_sig = 0;
+    pthread_mutex_lock(&s_mtx);
+    if (s_last_run == rid && s_last_sig == sig) {
         pthread_mutex_unlock(&s_mtx);
-        if (already_printed) return;
+        return;
     }
+    s_last_run = rid;
+    s_last_sig = sig;
 
     size_t primaries = 0, replicas = 0;
     for (size_t i = 0; i < eps.size(); i++) {
@@ -827,11 +825,15 @@ void cluster_client::print_topology_summary() const
 
     // Total opened connections = threads x conns-per-thread x endpoints. Each
     // cluster_client opens one shard_connection per distinct endpoint, so the
-    // endpoint count is the per-client connection fan-out.
+    // endpoint count is the per-client connection fan-out. With the
+    // --clients-start staircase ramp, m_config->clients is the peak (full-ramp)
+    // value, so the figure is the target fan-out; flag that so it isn't read as
+    // the count already opened.
+    const char *ramp = (m_config->clients_start > 0) ? " at full ramp" : "";
     const unsigned long long endpoints = (unsigned long long) eps.size();
     const unsigned long long total_conns =
         (unsigned long long) m_config->threads * (unsigned long long) m_config->clients * endpoints;
-    fprintf(stderr, "[RUN #%u] Total connections: %u threads x %u conns/thread x %llu endpoints = %llu\n", rid,
+    fprintf(stderr, "[RUN #%u] Total connections%s: %u threads x %u conns/thread x %llu endpoints = %llu\n", rid, ramp,
             m_config->threads, m_config->clients, endpoints, total_conns);
 
     // --rate-limiting is per-connection; surface the aggregate target only when
@@ -845,9 +847,11 @@ void cluster_client::print_topology_summary() const
         const unsigned long long aggregate = (unsigned long long) m_config->request_rate *
                                              (unsigned long long) m_config->threads *
                                              (unsigned long long) m_config->clients * traffic_eps;
-        fprintf(stderr, "[RUN #%u] Rate limit: %u req/s/conn -> %llu req/s aggregate target\n", rid,
-                m_config->request_rate, aggregate);
+        fprintf(stderr, "[RUN #%u] Rate limit: %u req/s/conn -> %llu req/s aggregate target%s\n", rid,
+                m_config->request_rate, aggregate, ramp);
     }
+
+    pthread_mutex_unlock(&s_mtx);
 }
 
 bool cluster_client::handle_cluster_slots(protocol_response *r)

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -5156,14 +5156,18 @@ int main(int argc, char *argv[])
                 cfg.threads, cfg.clients);
 
         if (have_cluster_topo) {
+            // With the --clients-start staircase ramp, cfg.clients is the peak
+            // (full-ramp) value, so total connections / rate are the target
+            // fan-out rather than the count necessarily opened; label it.
+            const char *ramp = (cfg.clients_start > 0) ? " at full ramp" : "";
             if (c_replicas > 0)
                 fprintf(outfile, "%-9zu Cluster endpoints (%zu primaries, %zu replicas)\n", c_endpoints, c_primaries,
                         c_replicas);
             else
                 fprintf(outfile, "%-9zu Cluster endpoints (%zu primaries)\n", c_endpoints, c_primaries);
-            fprintf(outfile, "%-9llu Total connections (%u x %u x %zu)\n", c_total_conns, cfg.threads, cfg.clients,
-                    c_endpoints);
-            if (c_has_rate) fprintf(outfile, "%-9llu Aggregate rate-limit target (req/s)\n", c_rate_aggregate);
+            fprintf(outfile, "%-9llu Total connections%s (%u x %u x %zu)\n", c_total_conns, ramp, cfg.threads,
+                    cfg.clients, c_endpoints);
+            if (c_has_rate) fprintf(outfile, "%-9llu Aggregate rate-limit target (req/s)%s\n", c_rate_aggregate, ramp);
         }
 
         fprintf(outfile, "%-9llu %s\n", (unsigned long long) (cfg.requests > 0 ? cfg.requests : cfg.test_time),


### PR DESCRIPTION
Follow-up to #489 addressing two Cursor Bugbot findings (also fixed on the 2.4 backport #490):

1. **Stale topology log ordering** — `print_topology_summary()` released the print-gate mutex before writing the topology block, so two workers could interleave their blocks or emit a superseded topology after a newer one. The lock is now held across the entire emit.
2. **Staircase inflates connection count** — with `--clients-start`, `cfg.clients` is the peak (full-ramp) value, so `Total connections` / aggregate rate overstated the fan-out if the ramp didn't complete. Both the startup block and the results summary now label these "at full ramp" when staircase is in use.

No functional change to the numbers outside staircase mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging synchronization and output labeling only; no change to connection math or routing behavior outside clarified reporting.
> 
> **Overview**
> **Topology logging** — `print_topology_summary()` no longer releases the process-global print gate mutex after updating `(run id, signature)`; the lock stays held through the entire stderr emit (endpoint list, total connections, rate limit) and unlocks at the end. That stops worker threads from interleaving blocks or printing an older topology after a newer one.
> 
> **Staircase ramp clarity** — When `--clients-start` is set, `clients` is the peak connection count, not necessarily what is open mid-ramp. Startup topology output (`cluster_client.cpp`) and the run results summary (`memtier_benchmark.cpp`) append **" at full ramp"** to total-connection and aggregate rate-limit lines so those figures read as targets, not live counts. Numbers are unchanged when staircase mode is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b57a3ccd9e5ea3060542fec5e1127b4972a3d6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->