### PR TITLE
ci: backport nightly fuzz/soak harness fixes to 2.4 (#449, #464, #467)

### DIFF
--- a/.github/workflows/differential.yml
+++ b/.github/workflows/differential.yml
@@ -32,7 +32,12 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'run-differential')
-    runs-on: ubuntu-22.04
+    # ubuntu-22.04 ships redis-tools 6.0.16, whose `redis-benchmark --csv`
+    # output does not yet expose the `p99_latency_ms` column that the
+    # differential parser depends on (tests/differential_redis_benchmark.py
+    # raises IndexError when that column is missing). ubuntu-24.04 ships
+    # redis-tools 7.x with the new CSV schema.
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/monitor-fuzz.yml
+++ b/.github/workflows/monitor-fuzz.yml
@@ -72,7 +72,8 @@ jobs:
           REDIS_PORT: "6379"
           # Smaller corpus pass on PR-label runs; larger on nightly/manual.
           FUZZ_ITER: ${{ github.event_name == 'pull_request' && '300' || (inputs.iterations || '2000') }}
-          FUZZ_TIMEOUT: "30"
+          # 90s accommodates ASAN+UBSan overhead × 8 MiB payloads (#443)
+          FUZZ_TIMEOUT: "90"
         run: python3 tests/fuzz/fuzz_monitor_input.py
 
       - name: Upload reproducers on failure

--- a/tests/cli_fuzz.py
+++ b/tests/cli_fuzz.py
@@ -390,6 +390,13 @@ def _run_memtier(extra_args):
         "--threads=1",
         "--clients=1",
         "--hide-histogram",
+        # Tighten the connection-stage supervisor (#431) so it fires well
+        # inside the subprocess timeout below; the default (30 s) is too
+        # large for the 10 s hang threshold, letting cases like
+        # `--authenticate ''` against a no-auth server look like hangs to
+        # the fuzzer. `extra_args` is appended after, so a fuzzed
+        # `--connection-stage-timeout=` value still wins (last flag wins).
+        "--connection-stage-timeout=3",
     ] + list(extra_args)
     return subprocess.run(
         cmd,

--- a/tests/fuzz/fuzz_monitor_input.py
+++ b/tests/fuzz/fuzz_monitor_input.py
@@ -28,6 +28,7 @@ import random
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -254,8 +255,22 @@ def main() -> int:
         return 2
     failures = 0
     total = 0
+    grand_total = FUZZ_ITER * len(seeds)
+    t0 = time.time()
+    # Emit per-iteration progress so a preempted / killed GH-hosted run
+    # still tells us which seed and iteration were in flight. Without this
+    # the driver only prints the startup banner and final summary, leaving
+    # an opaque gap whenever the runner is yanked mid-run.
+    progress_every = int(os.environ.get("FUZZ_PROGRESS_EVERY", "50"))
     for name, payload in seeds.items():
         for i in range(FUZZ_ITER):
+            if progress_every > 0 and total % progress_every == 0:
+                sys.stderr.write(
+                    "fuzz_monitor_input: iter {}/{} elapsed={}s seed={}\n".format(
+                        total, grand_total, int(time.time() - t0), name
+                    )
+                )
+                sys.stderr.flush()
             total += 1
             mutated = mutate(payload)
             ok = run_one(name, mutated)

--- a/tests/soak/test_long_run_memory.py
+++ b/tests/soak/test_long_run_memory.py
@@ -8,8 +8,8 @@ histogram accumulator.
 
 Pass conditions:
   * memtier exits 0
-  * RSS slope (linear regression over the samples) stays below 2 MB/min
-  * final / initial RSS ratio stays below 1.5x
+  * RSS slope (linear regression over the samples) stays below 10 MB/min
+  * final / initial RSS ratio stays below 6.0x
 
 Tunable via ``MEMTIER_SOAK_TEST_TIME`` (seconds) so the harness can be
 smoke-tested locally without waiting 30 minutes.
@@ -154,9 +154,18 @@ def test_long_run_memory_growth(env):
             True,
         )
         # Slope only meaningful once we're past the warmup phase. Apply
-        # the < 2 MB/min check only when we have at least 5 minutes of
+        # the slope check only when we have at least 5 minutes of
         # samples; for shorter (smoke) runs only enforce the ratio cap.
+        #
+        # Caps are sized above the design-not-leak baseline from
+        # run_stats::roll_cur_stats (run_stats.cpp:204), which appends one
+        # snapshot/sec to an unbounded std::list<one_second_stats> m_stats.
+        # Over a 30-min run with --threads=4 --clients=50 --pipeline=4 the
+        # observed steady-state is ~6.66 MB/min slope and ~4.7x final/initial
+        # ratio. We allow 1.5x headroom on slope (10.0 MB/min) and 1.3x on
+        # ratio (6.0) so the test still catches genuine leaks above the
+        # known accumulator baseline.
         if elapsed >= 300:
-            env.assertTrue(slope_mb_per_min < 2.0)
+            env.assertTrue(slope_mb_per_min < 10.0)
         if initial > 0:
-            env.assertTrue(final / initial < 1.5)
+            env.assertTrue(final / initial < 6.0)

--- a/tests/soak/test_slow_network.py
+++ b/tests/soak/test_slow_network.py
@@ -115,7 +115,11 @@ def test_slow_network_smooth(env):
         ensure_clean_benchmark_folder(config.results_dir)
 
         benchmark = Benchmark.from_json(config, benchmark_specs)
-        memtier_ok = benchmark.run()
+        # Benchmark.run() defaults to timeout=240s. Soak runs with
+        # test_time>=300s would be killed before they could write a
+        # summary, so we pass an explicit upper bound that leaves
+        # ~90s of slack for graceful shutdown.
+        memtier_ok = benchmark.run(timeout=test_time + 90)
 
         if not memtier_ok:
             debugPrintMemtierOnError(config, env)


### PR DESCRIPTION
Backports three **test/CI-only** commits from master so the nightly fuzzers (now wired to also run against 2.4 via #492) pass on the 2.4 branch:

- **#449** `tests/cli_fuzz.py` — append `--connection-stage-timeout=3` so AUTH-failure cases (e.g. `--authenticate ''` against a no-auth server) abort via the connection-stage supervisor before the harness's 10s "hung" check. Without it the supervisor sat at its 30s default → spurious `hung (>10s)`.
- **#464** soak slope threshold + monitor-fuzz timeout tuning.
- **#467** soak `test_slow_network` timeout, differential runner, fuzz progress.

No source changes — `.py` / `.yml` only.

**Locally verified on 2.4:** `--authenticate '' --connection-stage-timeout=3` aborts in 3.0s (exit 2); without the flag it's still running at 8s (the hang the fuzzer caught). Confirms 2.4's memtier respects the supervisor — this was only a harness gap, not a code bug.

Note: `monitor-fuzz` on 2.4 remains red (it catches 5 pre-existing parser bugs fixed on master in #475 — reported separately, intentionally not backported here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Python test harnesses and GitHub Actions; no production binary or runtime behavior is modified.
> 
> **Overview**
> **Test and CI-only** backports so nightly fuzz/soak and opt-in differential jobs behave on **2.4** (no memtier C++ changes).
> 
> The **differential** workflow moves from `ubuntu-22.04` to **`ubuntu-24.04`** so `redis-benchmark --csv` includes the **`p99_latency_ms`** column the differential parser expects (older redis-tools 6.x lacked it and caused `IndexError`).
> 
> **CLI fuzz** (`tests/cli_fuzz.py`) now always passes **`--connection-stage-timeout=3`** before fuzzed args so AUTH/connect failures exit via the connection-stage supervisor before the harness’s **10s** hang limit (default 30s looked like hangs, e.g. `--authenticate ''` on a no-auth server).
> 
> **Monitor-input fuzz** raises **`FUZZ_TIMEOUT` to 90s** in CI for ASAN/UBSan + large payloads, and the driver logs **periodic progress** (seed, iter, elapsed) so killed GH runs show where they stopped.
> 
> **Soak** tests relax long-run **RSS slope** (2→**10 MB/min**) and **final/initial ratio** (1.5→**6.0×**) with comments tying caps to the known `run_stats` per-second list growth baseline; **slow-network** soak calls **`benchmark.run(timeout=test_time + 90)`** so runs ≥300s aren’t cut off by a ~240s default before summary output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c9cb49bd31132e22bd104bfb424b2353bbd30b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->