### PR TITLE
test(soak): add opt-in timeout to Benchmark.run() on 2.4 (fix S7 TypeError)

### DIFF
--- a/tests/mb.py
+++ b/tests/mb.py
@@ -75,12 +75,41 @@ class Benchmark(object):
         with open(os.path.join(self.config.results_dir, name), 'wb') as outfile:
             outfile.write(data)
 
-    def run(self):
+    def run(self, timeout=None):
+        """Run memtier_benchmark to completion.
+
+        timeout: optional hard upper bound (seconds) on the child process.
+        A test that passes one (e.g. soak/test_slow_network uses
+        test_time + 90) gets fail-fast behaviour: on expiry we kill the
+        child, drain its pipes, write a truncated mb.stderr, and return
+        False instead of hanging until the CI job cap.
+
+        Defaults to None (wait indefinitely) to preserve the prior 2.4
+        behaviour for the many existing callers that don't pass a timeout
+        -- adopting master's 240s default here would risk killing long
+        soak/staircase runs that legitimately exceed 240s. (master uses a
+        240s default; 2.4 keeps opt-in to stay regression-free.)
+        """
         logging.debug('  Command: %s', ' '.join(self.args))
         process = subprocess.Popen(
             stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             executable=self.binary, args=self.args)
-        _stdout, _stderr = process.communicate()
+        try:
+            _stdout, _stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logging.error(
+                '  memtier_benchmark exceeded %ds timeout; killing child', timeout)
+            process.kill()
+            try:
+                _stdout, _stderr = process.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                _stdout, _stderr = b'', b''
+            if _stderr:
+                self.write_file('mb.stderr', _stderr)
+            self.write_file(
+                'mb.timeout',
+                'memtier_benchmark timed out after {}s\n'.format(timeout).encode())
+            return False
         if _stderr:
             logging.debug('  >>> stderr <<<\n%s\n', _stderr)
             self.write_file('mb.stderr', _stderr)

--- a/tests/mb.py
+++ b/tests/mb.py
@@ -96,14 +96,19 @@ class Benchmark(object):
             executable=self.binary, args=self.args)
         try:
             _stdout, _stderr = process.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             logging.error(
                 '  memtier_benchmark exceeded %ds timeout; killing child', timeout)
             process.kill()
+            # Preserve whatever stderr was already captured before the timeout
+            # (carried on the TimeoutExpired instance); the post-kill drain
+            # frequently returns empty, which would otherwise lose the log.
+            captured_err = e.stderr or b''
             try:
                 _stdout, _stderr = process.communicate(timeout=5)
             except subprocess.TimeoutExpired:
                 _stdout, _stderr = b'', b''
+            _stderr = captured_err + (_stderr or b'')
             if _stderr:
                 self.write_file('mb.stderr', _stderr)
             self.write_file(

--- a/tests/soak/test_slow_network.py
+++ b/tests/soak/test_slow_network.py
@@ -115,10 +115,11 @@ def test_slow_network_smooth(env):
         ensure_clean_benchmark_folder(config.results_dir)
 
         benchmark = Benchmark.from_json(config, benchmark_specs)
-        # Benchmark.run() defaults to timeout=240s. Soak runs with
-        # test_time>=300s would be killed before they could write a
-        # summary, so we pass an explicit upper bound that leaves
-        # ~90s of slack for graceful shutdown.
+        # Benchmark.run() on 2.4 defaults to timeout=None (waits
+        # indefinitely). Pass an explicit upper bound so a hung / slow-
+        # network run fails fast instead of stalling the CI job to its
+        # hard cap, leaving ~90s of slack past test_time for graceful
+        # shutdown.
         memtier_ok = benchmark.run(timeout=test_time + 90)
 
         if not memtier_ok:


### PR DESCRIPTION
## Failure
The nightly **Soak / Stress** 2.4 leg fails every run on `soak/test_slow_network.py` (S7):
```
TypeError: Benchmark.run() got an unexpected keyword argument 'timeout'
Total Tests Run: 1, Total Tests Failed: 1
```
(master's S7 leg passes.)

## Root cause
A backport gap: `soak/test_slow_network.py` (brought to 2.4 via #467 in #493) calls `benchmark.run(timeout=test_time + 90)`, but 2.4's `tests/mb.py` `Benchmark.run()` never had a `timeout` parameter — master added it separately. So the call raises `TypeError` at runtime on 2.4 only.

## Fix
Backport `Benchmark.run()`'s timeout support to 2.4, **defaulting to `None`** rather than master's `240`:
- 2.4 has many `run()` callers with no explicit timeout, and long soak/staircase runs can legitimately exceed 240s — a 240s default could newly kill them and create fresh failures.
- `None` = wait indefinitely = exactly the prior 2.4 behaviour for those callers (zero regression); the explicit-timeout caller (`test_slow_network`) gets fail-fast on a hang.

Verified: `Benchmark.run(timeout=...)` no longer raises; signature `run(self, timeout=None)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness change only; default `timeout=None` preserves existing callers; timeout behavior is opt-in except for the already-broken S7 call site.
> 
> **Overview**
> Fixes the 2.4 soak **S7** failure where `soak/test_slow_network.py` calls `benchmark.run(timeout=test_time + 90)` but `Benchmark.run()` did not accept `timeout`, causing a `TypeError`.
> 
> **`tests/mb.py`:** `Benchmark.run()` now takes an optional `timeout` (seconds). When set, `communicate(timeout=...)` is used; on expiry the child is killed, stderr is preserved and written, `mb.timeout` is recorded, and the method returns `False` instead of hanging until CI kills the job. **Default remains `None`** (wait forever), unlike master’s 240s default, so existing callers that use `benchmark.run()` with no args keep prior 2.4 behavior for long soak runs.
> 
> **`tests/soak/test_slow_network.py`:** Comments only—document the opt-in timeout and the `test_time + 90` bound for fail-fast on hangs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 679a880c4eab837f87adf22f7e383011d007ff7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->