### PR TITLE
ci(release-rpm): upload RPM objects with public-read ACL (fixes #500)

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -546,8 +546,13 @@ jobs:
 
     - name: Upload repo to S3
       run: |
-        # Use --delete to keep repo clean, but we verified RPMs exist above
-        aws s3 sync ./repo "s3://${{ secrets.APT_S3_BUCKET }}/rpm" --delete
+        # Use --delete to keep repo clean, but we verified RPMs exist above.
+        # --acl public-read is REQUIRED: the bucket serves packages.redis.io
+        # through CloudFront via per-object public-read ACLs (the DEB pipeline
+        # gets this for free because deb-s3 defaults objects to public-read).
+        # Plain `aws s3 sync` writes objects private, which returns 403
+        # AccessDenied for every rpm/* path through the CDN (issue #500).
+        aws s3 sync ./repo "s3://${{ secrets.APT_S3_BUCKET }}/rpm" --delete --acl public-read
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.APT_S3_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.APT_S3_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Problem

`packages.redis.io/rpm/**` returns `403 AccessDenied` through CloudFront for `repomd.xml` and every package, across all distros (issue #500). The DEB repo, GPG key, and the rest of the CDN are fine — only the `rpm/` tree is affected.

## Root cause

The `publish-to-yum` job uploads the YUM repo with:

```
aws s3 sync ./repo "s3://.../rpm" --delete
```

Plain `aws s3 sync` writes objects with the **default private** ACL. The bucket behind `packages.redis.io` serves public reads through CloudFront via **per-object `public-read` ACLs** — so every `.rpm` and `repodata/*` object this job writes lands unreadable, and the CDN returns 403 for the whole `rpm/` prefix.

The DEB pipeline is unaffected because `deb-s3` defaults objects to `public-read`. This is the one behavioural difference between the two publish paths on the same bucket.

## Fix

Add `--acl public-read` to the RPM sync so both pipelines write objects with the same visibility.

## ⚠️ Follow-up required (not fixable in CI alone)

`aws s3 sync` only re-uploads *changed* files, so this does **not** retroactively fix objects already uploaded private. The existing tree needs a one-time reset by someone with the `APT_S3_*` credentials:

```
aws s3 cp "s3://$APT_S3_BUCKET/rpm" "s3://$APT_S3_BUCKET/rpm" \
  --recursive --acl public-read --metadata-directive REPLACE
```

Longer term, a **bucket policy** granting `s3:GetObject` on `arn:...:<bucket>/rpm/*` would make public read prefix-wide and immune to any single job forgetting `--acl` — worth considering given this job round-trips and `--delete`s the shared `rpm/` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7aefb549def415b12dd858bbaf02f2d3c091361d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->