### PR TITLE
ci(release-rpm): upload RPM objects with public-read ACL (backport of #501, fixes #500)

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -546,8 +546,13 @@ jobs:
 
     - name: Upload repo to S3
       run: |
-        # Use --delete to keep repo clean, but we verified RPMs exist above
-        aws s3 sync ./repo "s3://${{ secrets.APT_S3_BUCKET }}/rpm" --delete
+        # Use --delete to keep repo clean, but we verified RPMs exist above.
+        # --acl public-read is REQUIRED: the bucket serves packages.redis.io
+        # through CloudFront via per-object public-read ACLs (the DEB pipeline
+        # gets this for free because deb-s3 defaults objects to public-read).
+        # Plain `aws s3 sync` writes objects private, which returns 403
+        # AccessDenied for every rpm/* path through the CDN (issue #500).
+        aws s3 sync ./repo "s3://${{ secrets.APT_S3_BUCKET }}/rpm" --delete --acl public-read
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.APT_S3_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.APT_S3_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Backport of #501 to the **2.4 release branch**.

## Why this is needed on `2.4`

Releases are cut from `2.4`, and `publish-to-yum` is `SKIPPED` on PRs — so the fix only takes effect on a real release *from this branch*. Without it, the next 2.4.x release re-runs:

```
aws s3 sync ./repo "s3://.../rpm" --delete
```

with the default **private** ACL, which re-breaks `packages.redis.io/rpm/**` with `403 AccessDenied` (issue #500). #501 fixes `master` only; it does nothing for a release cut from `2.4`.

## Fix

Add `--acl public-read` to the RPM sync so objects match the DEB pipeline (`deb-s3` defaults to `public-read`) and stay readable through CloudFront. Identical one-line change to #501.

**Blocker for the 2.4.4 release** — must land before running `utils/prepare_release.sh 2.4.4`.

Still requires the one-time S3 ACL reset on the already-uploaded private objects (`aws s3 cp --recursive --acl public-read --metadata-directive REPLACE`), since `sync` skips unchanged files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI publish-step change; no runtime or application code, only object ACLs on release uploads.
> 
> **Overview**
> Fixes **403 AccessDenied** on `packages.redis.io/rpm/**` by setting **`--acl public-read`** on the release workflow’s `aws s3 sync` to the RPM prefix, aligning RPM uploads with how DEB objects are exposed (public-read via `deb-s3`).
> 
> Adds inline comments explaining that CloudFront expects per-object public-read ACLs and that default `aws s3 sync` leaves objects private.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b29ee6624fc249253fa0ea103f015bf4a2507b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->