### PR TITLE
fix(run_stats): normalize through int64_t microseconds (backport #463/#465 to 2.4)

### DIFF
--- a/run_stats.cpp
+++ b/run_stats.cpp
@@ -115,10 +115,15 @@ inline unsigned long int ts_diff_now(struct timeval a)
 
 inline timeval timeval_factorial_average(timeval a, timeval b, unsigned int weight)
 {
+    // Convert both to total microseconds, average via integer math, split back.
+    // Averaging tv_sec/tv_usec independently truncates each -> loses precision
+    // when aggregate spans < 1ms. See issue #463.
+    int64_t a_usec = (int64_t) a.tv_sec * 1000000 + a.tv_usec;
+    int64_t b_usec = (int64_t) b.tv_sec * 1000000 + b.tv_usec;
+    int64_t avg_usec = (a_usec * (weight - 1) + b_usec) / weight;
     timeval tv;
-    double factor = ((double) weight - 1) / weight;
-    tv.tv_sec = factor * a.tv_sec + (double) b.tv_sec / weight;
-    tv.tv_usec = factor * a.tv_usec + (double) b.tv_usec / weight;
+    tv.tv_sec = (time_t) (avg_usec / 1000000);
+    tv.tv_usec = (suseconds_t) (avg_usec % 1000000);
     return (tv);
 }
 


### PR DESCRIPTION
Backport of #463/#465 to the **2.4 release branch**, for inclusion in 2.4.4.

## Why

`run_stats::timeval_factorial_average` averaged `tv_sec` and `tv_usec` independently with `double`→`time_t`/`suseconds_t` truncation. For aggregate durations < ~1ms across multiple clients, the diff could round to **0 µs**, making `summarize()` report **Ops/sec = 0** (and Hits/sec, KB/sec) even when `Count > 0` and `Avg Latency > 0`. That's a user-facing results-correctness bug — exactly what a patch release should carry.

## Fix

Normalize both timevals to `int64_t` microseconds, average via integer math, split back. No precision loss for any aggregate duration > 0 µs. 8-line change, cherry-picked cleanly from master (`b4b18c0`).

Found during the 2.4.4 release-contents audit: this was the one correctness fix on `master` since 2.4.3 that was missing from `2.4` and applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to stats aggregation math with no auth or I/O impact; intended correctness fix for reported rates.
> 
> **Overview**
> Fixes **incorrect benchmark throughput** when merging stats from multiple clients/runs whose combined duration is under ~1ms.
> 
> `timeval_factorial_average` no longer averages `tv_sec` and `tv_usec` separately with floating-point truncation. It now converts both `timeval`s to **`int64_t` total microseconds**, applies the weighted average in integer math, and splits the result back into `tv_sec` / `tv_usec`. That keeps non-zero duration for `run_stats::merge()` start/end times so `summarize()` no longer reports **Ops/sec, Hits/sec, or KB/sec as 0** while counts and latency remain positive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d6786d89120517ae2aa023865d8b18321042c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->