### PR TITLE
ci: one-time workflow to re-permission existing rpm/ objects to public-read (#505)

### DIFF
--- a/.github/workflows/fix-rpm-acl.yml
+++ b/.github/workflows/fix-rpm-acl.yml
@@ -1,0 +1,107 @@
+name: Fix RPM Repo ACLs (one-time maintenance)
+
+# One-time (re-runnable) admin job to set `public-read` on every object under
+# the shared rpm/ prefix. Needed because `aws s3 sync` in publish-to-yum only
+# re-permissions objects it re-uploads; pre-existing RPMs (e.g. 2.4.0..2.4.3)
+# kept their old private ACL and return 403 through CloudFront (issues #500, #505).
+# This changes ONLY the ACL — object bytes, content-type, and metadata are untouched.
+
+on:
+  workflow_dispatch:
+    inputs:
+      prefix:
+        description: "S3 key prefix to re-permission (must be under rpm/)"
+        required: false
+        default: "rpm/"
+      dry_run:
+        description: "List objects and report counts without changing ACLs"
+        required: false
+        default: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  fix-acl:
+    runs-on: ubuntu-latest
+    environment: build
+    steps:
+    - name: Verify AWS CLI
+      run: aws --version
+
+    - name: Set public-read ACL on all objects under prefix
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.APT_S3_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.APT_S3_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.APT_S3_REGION }}
+        BUCKET: ${{ secrets.APT_S3_BUCKET }}
+        PREFIX: ${{ github.event.inputs.prefix }}
+        DRY_RUN: ${{ github.event.inputs.dry_run }}
+      run: |
+        set -euo pipefail
+
+        # Guard: never let this loose outside the rpm/ tree.
+        case "$PREFIX" in
+          rpm/|rpm/*) : ;;
+          *) echo "::error::refusing prefix '$PREFIX' — must be 'rpm/' or under it"; exit 1 ;;
+        esac
+
+        echo "Listing s3://$BUCKET/$PREFIX ..."
+        # The CLI auto-paginates list-objects-v2 and returns every key.
+        # Tab/newline separated -> one key per line. RPM repo keys contain no
+        # whitespace, so word-splitting on \t\n is safe here.
+        aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$PREFIX" \
+          --query 'Contents[].Key' --output text | tr '\t' '\n' | sed '/^$/d' > keys.txt
+
+        total=$(wc -l < keys.txt | tr -d ' ')
+        echo "Found $total objects under $PREFIX"
+        if [ "$total" -eq 0 ]; then
+          echo "Nothing to do."
+          exit 0
+        fi
+
+        echo "Sample:"; head -5 keys.txt | sed 's/^/  /'
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "::notice::DRY RUN — $total objects would be set to public-read. No changes made."
+          exit 0
+        fi
+
+        # Pure ACL change per object. Parallelised; each failure is recorded.
+        echo "Applying public-read ACL to $total objects ..."
+        : > failures.txt
+        # shellcheck disable=SC2016
+        cat keys.txt | xargs -P 16 -I{} sh -c '
+          aws s3api put-object-acl --bucket "$0" --key "$1" --acl public-read \
+            || echo "$1" >> failures.txt
+        ' "$BUCKET" "{}"
+
+        fail=$(wc -l < failures.txt | tr -d ' ')
+        ok=$(( total - fail ))
+        echo "Re-permissioned $ok/$total objects (failures: $fail)"
+        if [ "$fail" -gt 0 ]; then
+          echo "::error::$fail object(s) failed put-object-acl:"; head -20 failures.txt
+          exit 1
+        fi
+
+    - name: Verify previously-private objects are now public (issue #505)
+      if: ${{ github.event.inputs.dry_run != 'true' }}
+      run: |
+        set -euo pipefail
+        bad=0
+        # The exact URLs the reporter hit, plus the current release for good measure.
+        for url in \
+          "https://packages.redis.io/rpm/el9/x86_64/memtier-benchmark-2.4.0-1.el9.x86_64.rpm" \
+          "https://packages.redis.io/rpm/el8/x86_64/memtier-benchmark-2.4.3-1.el8.x86_64.rpm" \
+          "https://packages.redis.io/rpm/el9/x86_64/memtier-benchmark-2.4.4-1.el9.x86_64.rpm" \
+          "https://packages.redis.io/rpm/el9/x86_64/repodata/repomd.xml" ; do
+          code=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+          echo "  HTTP $code  $url"
+          [ "$code" = "200" ] || bad=$((bad + 1))
+        done
+        # CloudFront may briefly serve a cached 403; re-run if so.
+        if [ "$bad" -gt 0 ]; then
+          echo "::warning::$bad URL(s) not yet 200 — likely CloudFront cache; re-check shortly."
+        else
+          echo "All checked URLs return 200."
+        fi


### PR DESCRIPTION
Follow-up to #500/#501. The `publish-to-yum` sync only re-permissions objects it re-uploads, so pre-existing RPMs (2.4.0…2.4.3) kept their private ACL and still return **403** through CloudFront — reported in #505.

Adds a `workflow_dispatch` maintenance job that sets `public-read` on every object under the `rpm/` prefix via `aws s3api put-object-acl` (pure ACL change — object bytes, content-type, and metadata untouched). Reuses the existing `build` environment + `APT_S3_*` secrets.

Safeguards:
- `dry_run` defaults to `true` (lists + counts, changes nothing).
- Prefix guarded to `rpm/`.
- Post-apply step verifies the exact 403 URLs from #505 (2.4.0/el9, 2.4.3/el8) plus 2.4.4 and `repomd.xml` return 200.

One-time op; kept in-tree so it's re-runnable if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Manual workflow can bulk-change S3 object ACLs on production package storage using shared secrets; safeguards (rpm-only prefix, dry-run default) limit blast radius but a mistaken non-dry run still affects every listed object.
> 
> **Overview**
> Adds a **manual `workflow_dispatch` job** (`fix-rpm-acl.yml`) to fix **403s on older RPMs** that `publish-to-yum` never re-uploaded, so they kept **private S3 ACLs** despite CloudFront serving `packages.redis.io` (issues #500, #505).
> 
> The workflow lists every object under a configurable **`rpm/` prefix** (hard-guarded to that tree), optionally runs in **`dry_run` mode** (default **true**), then applies **`public-read` via `put-object-acl` only**—no object bytes or metadata changes. It uses the existing **`build` environment** and **`APT_S3_*` secrets**, parallelizes ACL updates, and on a real run **curl-checks** the reported broken URLs plus `repomd.xml` for HTTP 200.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412f71c90f06ab2518ffa794b17ab276feddad40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->