### PR TITLE
ci(fix-rpm-acl): report object breakdown in dry-run

### DIFF
--- a/.github/workflows/fix-rpm-acl.yml
+++ b/.github/workflows/fix-rpm-acl.yml
@@ -62,6 +62,15 @@ jobs:
 
         echo "Sample:"; head -5 keys.txt | sed 's/^/  /'
 
+        echo "--- breakdown by top-level component (rpm/<X>/) ---"
+        awk -F/ 'NF>1{print $2}' keys.txt | sort | uniq -c | sort -rn | sed 's/^/  /'
+        echo "--- breakdown by object kind ---"
+        printf "  %6d  *.rpm packages\n"       "$(grep -c '\.rpm$' keys.txt || true)"
+        printf "  %6d  repodata/* metadata\n"  "$(grep -c '/repodata/' keys.txt || true)"
+        printf "  %6d  other\n"                "$(grep -vE '\.rpm$|/repodata/' keys.txt | grep -c . || true)"
+        echo "--- memtier-benchmark objects only ---"
+        printf "  %6d  memtier-benchmark*.rpm\n" "$(grep -c 'memtier-benchmark.*\.rpm$' keys.txt || true)"
+
         if [ "$DRY_RUN" = "true" ]; then
           echo "::notice::DRY RUN — $total objects would be set to public-read. No changes made."
           exit 0


### PR DESCRIPTION
Adds per-component / per-kind counts to the dry-run of the rpm ACL maintenance workflow, for transparency into what's under the shared `rpm/` prefix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only shell reporting on listed keys; no change to ACL application logic or workflow inputs.
> 
> **Overview**
> The **Fix RPM Repo ACLs** workflow now prints extra inventory stats after listing S3 keys and before dry-run exit or ACL updates.
> 
> Logs include counts by top-level path under `rpm/<component>/`, splits for `*.rpm`, `repodata/`, and other keys, plus a dedicated count of `memtier-benchmark*.rpm` objects—so dry runs (default) show what would be re-permissioned without changing ACLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b954cece4ef9068a19e6319285754ff77fe3af3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->