### PR TITLE
ci(fix-rpm-acl): dump package-name stems in dry-run

### DIFF
--- a/.github/workflows/fix-rpm-acl.yml
+++ b/.github/workflows/fix-rpm-acl.yml
@@ -70,6 +70,10 @@ jobs:
         printf "  %6d  other\n"                "$(grep -vE '\.rpm$|/repodata/' keys.txt | grep -c . || true)"
         echo "--- memtier-benchmark objects only ---"
         printf "  %6d  memtier-benchmark*.rpm\n" "$(grep -c 'memtier-benchmark.*\.rpm$' keys.txt || true)"
+        echo "--- distinct package-name stems among *.rpm (basename minus version) ---"
+        grep '\.rpm$' keys.txt | sed 's#.*/##; s/-[0-9].*//' | sort | uniq -c | sort -rn | sed 's/^/  /'
+        echo "--- non-memtier *.rpm sample paths ---"
+        grep '\.rpm$' keys.txt | grep -v 'memtier-benchmark' | head -15 | sed 's/^/  /'
 
         if [ "$DRY_RUN" = "true" ]; then
           echo "::notice::DRY RUN — $total objects would be set to public-read. No changes made."


### PR DESCRIPTION
Adds distinct package-name stems + non-memtier sample paths to the dry-run, to see exactly which products live under the shared rpm/ prefix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only shell logging in a manual maintenance workflow; no ACL or publish logic changes.
> 
> **Overview**
> Extends the **Fix RPM Repo ACLs** workflow’s pre-ACL reporting so dry runs show more detail about what sits under the shared `rpm/` prefix.
> 
> After the existing memtier-benchmark count, it prints a **distinct package-name stem** breakdown for `*.rpm` keys (basename with the version suffix stripped) and a **sample of up to 15 non-memtier** `.rpm` paths. ACL application and dry-run behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e30232c4bd27665c8dce7cea9d416e9a7244fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->