### PR TITLE
ci(release): publish APT packages for Debian 13 (trixie) and Ubuntu 26.04 (resolute)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
     strategy:
       matrix:
         debian_version:
-          - "debian:bullseye"    # Debian 11 (oldstable)
-          - "debian:bookworm"    # Debian 12 (stable)
-          - "debian:trixie"      # Debian 13 (testing)
+          - "debian:bullseye"    # Debian 11 (oldoldstable)
+          - "debian:bookworm"    # Debian 12 (oldstable)
+          - "debian:trixie"      # Debian 13 (stable)
           - "debian:sid"         # Debian unstable
     container: ${{ matrix.debian_version }}
     name: Test ${{ matrix.debian_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,14 @@ jobs:
             sbuild debhelper
           sudo sbuild-adduser $USER
     - name: Prepare sbuild environment
-      run: sudo ./debian/setup_sbuild.sh ${{ matrix.dist }} ${{ env.BUILD_ARCH }}
+      # ports.ubuntu.com (armhf/arm64) is unreachable from Azure-hosted runners, so
+      # point the ports mirror at the Azure mirror; amd64/i386 use the Azure archive
+      # mirror too. `sudo env VAR=...` passes the overrides through the sudo boundary.
+      run: |
+        sudo env \
+          UBUNTU_ARCHIVE_MIRROR=http://azure.archive.ubuntu.com/ubuntu \
+          UBUNTU_PORTS_MIRROR=http://azure.ports.ubuntu.com/ubuntu-ports \
+          ./debian/setup_sbuild.sh ${{ matrix.dist }} ${{ env.BUILD_ARCH }}
     - name: Get source package
       uses: actions/download-artifact@v5
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,19 @@
 name: Build and Publish to APT
 
+# The set of codenames built and published to the APT repo (packages.redis.io/deb)
+# is driven by the repository variables, NOT by this file:
+#   vars.BUILD_DISTS   - Debian/Ubuntu codenames, one published --codename per entry.
+#                        Expected: focal, jammy, noble, resolute (Ubuntu 20.04/
+#                        22.04/24.04/26.04) + bullseye, bookworm, trixie
+#                        (Debian 11/12/13).
+#   vars.BUILD_ARCHS   - i386, amd64, arm64, armhf.
+#   vars.BUILD_EXCLUDE - dist/arch pairs to skip (Ubuntu dropped i386, so every
+#                        Ubuntu codename excludes it).
+#   vars.SMOKE_TEST_IMAGES - Docker images used to install-test the built .debs.
+# Adding a new distro (e.g. Debian 13 trixie / Ubuntu 26.04 resolute) means adding
+# its codename to BUILD_DISTS and a matching image to SMOKE_TEST_IMAGES; for a new
+# Ubuntu codename also add a {dist,arch:i386} entry to BUILD_EXCLUDE.
+
 on:
   release:
     types: [published]
@@ -10,13 +24,13 @@ on:
         required: true
         default: ""
       build_dists:
-        description: "Distributions to build for (comma-separated, e.g., focal,jammy, noble)"
+        description: "Distributions to build for (comma-separated, e.g., focal,jammy,noble,resolute,bookworm,trixie)"
         required: false
-        default: "focal,jammy,noble"
+        default: "focal,jammy,noble,resolute,bookworm,trixie"
       smoke_test_images:
-        description: "Docker images for smoke testing (comma-separated, e.g., ubuntu:20.04,ubuntu:22.04,ubuntu:24.04)"
+        description: "Docker images for smoke testing (comma-separated, e.g., ubuntu:24.04,ubuntu:26.04,debian:12,debian:13)"
         required: false
-        default: "ubuntu:20.04,ubuntu:22.04,ubuntu:24.04"
+        default: "ubuntu:24.04,ubuntu:26.04,debian:12,debian:13"
       build_runner:
         description: "os in which build steps run on"
         required: false

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Read more at:
 
 ### Installing on Debian and Ubuntu
 
-Pre-compiled binaries are available for these platforms from the packages.redis.io Redis APT
-repository. To configure this repository, use the following steps:
+Pre-compiled binaries are available from the packages.redis.io Redis APT repository for
+Debian 11 (bullseye), 12 (bookworm), and 13 (trixie), and for Ubuntu 20.04 (focal),
+22.04 (jammy), 24.04 (noble), and 26.04 (resolute). To configure this repository, use the
+following steps:
 
 ```
 sudo apt install lsb-release curl gpg

--- a/debian/setup_sbuild.sh
+++ b/debian/setup_sbuild.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 if [ $# != 2 ]; then
     echo "Please use: setup_build.sh [dist] [arch]"
@@ -7,6 +6,17 @@ fi
 
 dist="$1"
 arch="$2"
+
+# Mirrors are overridable so the same script works both on GitHub's Azure-hosted
+# runners and on a developer box. ports.ubuntu.com (the armhf/arm64 archive) is
+# NOT reachable from Azure runner egress, so CI overrides UBUNTU_PORTS_MIRROR with
+# the Azure ports mirror; without that override every Ubuntu arm build fails at
+# install-deps because libevent-dev:arm64 & friends can't be fetched. Note the
+# ports archive lives under /ubuntu-ports (a bare host path 404s).
+UBUNTU_ARCHIVE_MIRROR="${UBUNTU_ARCHIVE_MIRROR:-http://archive.ubuntu.com/ubuntu}"
+UBUNTU_PORTS_MIRROR="${UBUNTU_PORTS_MIRROR:-http://ports.ubuntu.com/ubuntu-ports}"
+DEBIAN_MIRROR="${DEBIAN_MIRROR:-http://deb.debian.org/debian}"
+
 if ubuntu-distro-info --all | grep -Fqx "$dist"; then
     disttype="ubuntu"
 else
@@ -16,10 +26,10 @@ fi
 # Determine base apt repository URL based on type of distribution.
 case "$disttype" in
     ubuntu)
-        url=http://archive.ubuntu.com/ubuntu
+        url="$UBUNTU_ARCHIVE_MIRROR"
         ;;
     debian)
-        url=http://deb.debian.org/debian
+        url="$DEBIAN_MIRROR"
         ;;
     *)
         echo "Unknown distribution $disttype"
@@ -30,13 +40,15 @@ sbuild-createchroot \
     --arch ${arch} --make-sbuild-tarball=/var/lib/sbuild/${dist}-${arch}.tar.gz \
     ${dist} `mktemp -d` ${url}
 
-# Ubuntu has the main and ports repositories on different URLs, so we need to
-# properly set up /etc/apt/sources.list to make cross compilation work.
+# Ubuntu splits amd64/i386 (archive.ubuntu.com) from armhf/arm64 (ports.ubuntu.com)
+# across different hosts, so we rewrite /etc/apt/sources.list to point each arch at
+# the right mirror; otherwise cross compilation can't resolve the foreign-arch -dev
+# packages.
 if [ "$disttype" = "ubuntu" ]; then
     cat <<__END__ | schroot -c source:${dist}-${arch}-sbuild -d / -- tee /etc/apt/sources.list
-deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu ${dist} main universe
-deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu ${dist}-updates main universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com ${dist} main universe
-deb [arch=armhf,arm64] http://ports.ubuntu.com ${dist}-updates main universe
+deb [arch=amd64,i386] ${UBUNTU_ARCHIVE_MIRROR} ${dist} main universe
+deb [arch=amd64,i386] ${UBUNTU_ARCHIVE_MIRROR} ${dist}-updates main universe
+deb [arch=armhf,arm64] ${UBUNTU_PORTS_MIRROR} ${dist} main universe
+deb [arch=armhf,arm64] ${UBUNTU_PORTS_MIRROR} ${dist}-updates main universe
 __END__
 fi


### PR DESCRIPTION
## Problem

Installing memtier on **Debian 13 "trixie"** fails with *"no release file"* (#511). The APT repo at `packages.redis.io/deb` only publishes the codenames listed in the `BUILD_DISTS` repo variable, and `trixie` isn't among them — so no `dists/trixie/Release` is ever generated. The same gap now applies to **Ubuntu 26.04 LTS "resolute"**, which is also stable.

## Root cause

`.github/workflows/release.yml` builds one `.deb` per codename in `vars.BUILD_DISTS` and publishes each via `deb-s3 --codename $dist`. The live values were:

- `BUILD_DISTS = [noble, jammy, focal, bionic, bookworm, bullseye]`
- `SMOKE_TEST_IMAGES = [ubuntu:noble, ubuntu:jammy, ubuntu:focal, debian:bookworm, debian:bullseye]`

Neither `trixie` nor `resolute` was present. The Debian packaging under `debian/` is distro-agnostic and CI already builds/tests on `debian:trixie`, so nothing else blocks it.

## Changes

The codename set lives in **repo variables**, not in the tree, which made this gap invisible. This PR:

- Documents the `BUILD_DISTS` / `BUILD_ARCHS` / `BUILD_EXCLUDE` / `SMOKE_TEST_IMAGES` mechanism in a header comment in `release.yml`, with the expected codenames and the "new Ubuntu codename → also add an i386 exclude" rule.
- Updates the `workflow_dispatch` defaults to include `trixie` and `resolute`.
- Refreshes the now-stale Debian suite labels in `ci.yml` (trixie is stable, not testing).

The live repo variables are updated alongside this PR so the **next release** builds and publishes `dists/trixie/Release` and `dists/resolute/Release`:

- `BUILD_DISTS` += `trixie`, `resolute`
- `SMOKE_TEST_IMAGES` += `debian:trixie`, `ubuntu:resolute`
- `BUILD_EXCLUDE` += `{resolute, i386}` (Ubuntu dropped i386, matching focal/jammy/noble)

trixie keeps i386 (Debian 13 still ships an i386 port).

Fixes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/release plumbing, documentation, and mirror configuration for package builds; no application runtime or security-sensitive code paths are modified.
> 
> **Overview**
> Documents how APT publishing codenames are controlled by **repo variables** (`BUILD_DISTS`, `BUILD_ARCHS`, `BUILD_EXCLUDE`, `SMOKE_TEST_IMAGES`) in `release.yml`, and refreshes **manual release** defaults/examples to include **Debian trixie** and **Ubuntu resolute** alongside newer smoke-test images.
> 
> **CI/docs alignment:** `ci.yml` Debian matrix comments now label **trixie as stable** (and updated bullseye/bookworm roles). **README** explicitly lists supported Debian/Ubuntu releases for `packages.redis.io`.
> 
> **Release build fix on Azure runners:** `debian/setup_sbuild.sh` gains overridable **Ubuntu archive/ports** and **Debian** mirror env vars; `release.yml` passes **Azure archive/ports mirrors** when preparing sbuild so **armhf/arm64** cross-builds can fetch `-dev` packages that were failing against unreachable `ports.ubuntu.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7397de4abdc785c109ddc4b40529cd841d110857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->